### PR TITLE
add bit_len as parameter to remove ecc scalar_mul MAX_BITS requirement

### DIFF
--- a/src/main_gate.rs
+++ b/src/main_gate.rs
@@ -545,6 +545,7 @@ impl<F: PrimeFieldBits, const T: usize> MainGate<F, T> {
         &self,
         ctx: &mut RegionCtx<'_, F>,
         a: AssignedValue<F>,
+        bit_len: usize,
     ) -> Result<Vec<AssignedValue<F>>, Error> {
         // TODO: ensure a is less than F.size() - 1
         let mut length = 0;
@@ -560,7 +561,7 @@ impl<F: PrimeFieldBits, const T: usize> MainGate<F, T> {
             .iter()
             .map(|bit| bit.unwrap().unwrap())
             .collect::<Vec<_>>();
-        normalize_trailing_zeros(&mut bits);
+        normalize_trailing_zeros(&mut bits, bit_len);
         let bits = self.assign_bits(ctx, &bits)?;
         let num = self.le_bits_to_num(ctx, &bits)?;
         assert_eq!(num.value().unwrap(), a.value().unwrap());

--- a/src/poseidon/poseidon_circuit.rs
+++ b/src/poseidon/poseidon_circuit.rs
@@ -1,5 +1,6 @@
-use crate::main_gate::{
-    AssignedBit, AssignedValue, MainGate, MainGateConfig, RegionCtx, WrapValue,
+use crate::{
+    constants::MAX_BITS,
+    main_gate::{AssignedBit, AssignedValue, MainGate, MainGateConfig, RegionCtx, WrapValue},
 };
 use ff::{FromUniformBytes, PrimeField, PrimeFieldBits};
 use halo2_proofs::{
@@ -34,7 +35,7 @@ impl<F: PrimeFieldBits + FromUniformBytes<64>, const T: usize, const RATE: usize
         num_bits: usize,
     ) -> Result<Vec<AssignedBit<F>>, Error> {
         let val = self.squeeze(ctx)?;
-        let res = self.main_gate.le_num_to_bits(ctx, val)?;
+        let res = self.main_gate.le_num_to_bits(ctx, val, MAX_BITS)?;
         if res.len() >= num_bits {
             Ok(res[..num_bits].to_vec())
         } else {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,3 @@
-use crate::constants::MAX_BITS;
 use ff::{BatchInvert, Field, PrimeField};
 use halo2_proofs::plonk::Assigned;
 use num_bigint::BigUint;
@@ -146,7 +145,7 @@ pub(crate) fn trim_leading_zeros(hex: String) -> String {
     format!("0x{}", trimmed)
 }
 
-pub(crate) fn normalize_trailing_zeros(bits: &mut Vec<bool>) {
+pub(crate) fn normalize_trailing_zeros(bits: &mut Vec<bool>, bit_len: usize) {
     let last_one_position = bits
         .iter()
         .enumerate()
@@ -160,9 +159,9 @@ pub(crate) fn normalize_trailing_zeros(bits: &mut Vec<bool>) {
     }
 
     let length = bits.len();
-    assert!(MAX_BITS >= length);
+    assert!(bit_len >= length, "bit length exceed maximum value");
 
-    for _ in 0..(MAX_BITS - length) {
+    for _ in 0..(bit_len - length) {
         bits.push(false);
     }
 }


### PR DESCRIPTION
In previous version of `scalar_mul` in ecc gadget. We fixed the bit length of scalar to the `MAX_BITS`. This is unnecessary. I removed this hardcode requirement.