### PR TITLE
feat(bn): `num_bigint::BigInt` -> `::BigUint`

### DIFF
--- a/src/gadgets/nonnative/bn/big_uint.rs
+++ b/src/gadgets/nonnative/bn/big_uint.rs
@@ -5,7 +5,7 @@ use halo2_proofs::{
     circuit::{AssignedCell, Value},
     plonk::{Advice, Column},
 };
-use num_bigint::{BigInt, Sign};
+use num_bigint::BigUint as BigUintRaw;
 use num_traits::{identities::One, Zero};
 
 use crate::{error::Halo2PlonkError, main_gate::RegionCtx};
@@ -13,7 +13,7 @@ use crate::{error::Halo2PlonkError, main_gate::RegionCtx};
 // A big natural number with limbs in field `F`
 //
 // Stores inside limbs of a certain length,
-// created from [`num_bigint::BigInt`] and
+// created from [`num_bigint::BigUintRaw`] and
 // allows access to certain limbs
 //
 // IMPORTANT: It is not an independent
@@ -79,7 +79,7 @@ impl<F: ff::PrimeField> BigUint<F> {
         limbs_count_limit: NonZeroUsize,
     ) -> Result<Self, Error> {
         // FIXME Simplify
-        Self::from_bigint(&BigInt::from(input), limb_width, limbs_count_limit)
+        Self::from_biguint(&BigUintRaw::from(input), limb_width, limbs_count_limit)
     }
 
     pub fn from_u128(
@@ -88,7 +88,7 @@ impl<F: ff::PrimeField> BigUint<F> {
         limbs_count_limit: NonZeroUsize,
     ) -> Result<Self, Error> {
         // FIXME Simplify
-        Self::from_bigint(&BigInt::from(input), limb_width, limbs_count_limit)
+        Self::from_biguint(&BigUintRaw::from(input), limb_width, limbs_count_limit)
     }
 
     // If the values in Cell are unknown, they will be filled in
@@ -125,8 +125,18 @@ impl<F: ff::PrimeField> BigUint<F> {
             .transpose()
     }
 
-    pub fn from_bigint(
-        input: &BigInt,
+    pub fn from_f(
+        input: &F,
+        limb_width: NonZeroUsize,
+        limbs_count_limit: NonZeroUsize,
+    ) -> Result<Self, Error> {
+        let bu = BigUintRaw::from_bytes_le(input.to_repr().as_ref());
+
+        Self::from_biguint(&bu, limb_width, limbs_count_limit)
+    }
+
+    pub fn from_biguint(
+        input: &BigUintRaw,
         limb_width: NonZeroUsize,
         limbs_count_limit: NonZeroUsize,
     ) -> Result<Self, Error> {
@@ -160,11 +170,11 @@ impl<F: ff::PrimeField> BigUint<F> {
         todo!("Implement and test the conversion of an element from another field")
     }
 
-    pub fn into_bigint(&self) -> BigInt {
+    pub fn into_bigint(&self) -> num_bigint::BigUint {
         self.limbs
             .iter()
             .rev()
-            .fold(BigInt::zero(), |mut result, limb| {
+            .fold(BigUintRaw::zero(), |mut result, limb| {
                 result <<= self.limb_width().get();
                 result + f_to_nat(limb)
             })
@@ -217,7 +227,7 @@ impl<F: ff::PrimeField> BigUint<F> {
     }
 }
 
-pub fn nat_to_f<Scalar: ff::PrimeField>(n: &BigInt) -> Option<Scalar> {
+pub fn nat_to_f<Scalar: ff::PrimeField>(n: &num_bigint::BigUint) -> Option<Scalar> {
     Scalar::from_str_vartime(&format!("{n}"))
 }
 
@@ -229,17 +239,17 @@ fn write_be<F: PrimeField, W: io::Write>(f: &F, mut writer: W) -> io::Result<()>
         .try_for_each(|digit| writer.write_all(&[*digit]))
 }
 
-pub fn f_to_nat<Scalar: PrimeField>(f: &Scalar) -> BigInt {
+pub fn f_to_nat<Scalar: PrimeField>(f: &Scalar) -> num_bigint::BigUint {
     let mut s = Vec::new();
     write_be(f, &mut s).unwrap(); // f.to_repr().write_be(&mut s).unwrap();
-    BigInt::from_bytes_le(Sign::Plus, f.to_repr().as_ref())
+    BigUintRaw::from_bytes_le(f.to_repr().as_ref())
 }
 
 // Calculate `2 ^ n - 1`
-pub fn get_big_int_with_n_ones(n: usize) -> BigInt {
+pub fn get_big_int_with_n_ones(n: usize) -> num_bigint::BigUint {
     match n {
-        0 => BigInt::zero(),
-        n => (BigInt::one() << n) - 1,
+        0 => BigUintRaw::zero(),
+        n => (BigUintRaw::one() << n) - 1u8,
     }
 }
 
@@ -266,7 +276,7 @@ mod tests {
             .unwrap();
             assert_eq!(bn.limbs_count().get(), 1, "Limbs > 1 at {input}");
             assert_eq!(bn.limbs(), &[Fp::from_u128(input.into())]);
-            assert_eq!(bn.into_bigint(), BigInt::from(input));
+            assert_eq!(bn.into_bigint(), BigUintRaw::from(input));
         }
     }
 
@@ -281,14 +291,14 @@ mod tests {
             .unwrap();
             assert_eq!(bn.limbs_count().get(), 1, "Limbs > 1 at {input}");
             assert_eq!(bn.limbs(), &[Fp::from_u128(input)]);
-            assert_eq!(bn.into_bigint(), BigInt::from(input));
+            assert_eq!(bn.into_bigint(), BigUintRaw::from(input));
         }
     }
 
     #[test]
     fn from_two_limbs() {
-        let input = BigInt::from(u128::MAX) * BigInt::from(u128::MAX);
-        let bn = BigUint::<Fp>::from_bigint(
+        let input = BigUintRaw::from(u128::MAX) * BigUintRaw::from(u128::MAX);
+        let bn = BigUint::<Fp>::from_biguint(
             &input,
             NonZeroUsize::new(mem::size_of::<u128>() * 8).unwrap(),
             NonZeroUsize::new(4).unwrap(),
@@ -308,8 +318,8 @@ mod tests {
 
     #[test]
     fn limbs_count_err() {
-        let input = BigInt::from(u128::MAX) * BigInt::from(u128::MAX);
-        let result_with_bn = BigUint::<Fp>::from_bigint(
+        let input = BigUintRaw::from(u128::MAX) * BigUintRaw::from(u128::MAX);
+        let result_with_bn = BigUint::<Fp>::from_biguint(
             &input,
             NonZeroUsize::new(mem::size_of::<u64>() * 8).unwrap(),
             NonZeroUsize::new(1).unwrap(),

--- a/src/gadgets/nonnative/bn/big_uint_mul_mod_chip/mod.rs
+++ b/src/gadgets/nonnative/bn/big_uint_mul_mod_chip/mod.rs
@@ -10,7 +10,7 @@ use ff::PrimeField;
 use halo2_proofs::circuit::{AssignedCell, Chip, Value};
 use itertools::{EitherOrBoth, Itertools};
 use log::*;
-use num_bigint::BigInt;
+use num_bigint::BigUint as BigUintRaw;
 use num_traits::{One, ToPrimitive, Zero};
 
 use crate::main_gate::{AssignAdviceFrom, MainGate, MainGateConfig, RegionCtx};
@@ -52,8 +52,8 @@ impl<F: ff::PrimeField> BigUintMulModChip<F> {
         }
     }
 
-    pub fn to_bignat(&self, input: &BigInt) -> Result<BigUint<F>, Error> {
-        Ok(BigUint::<F>::from_bigint(
+    pub fn to_bignat(&self, input: &BigUintRaw) -> Result<BigUint<F>, Error> {
+        Ok(BigUint::<F>::from_biguint(
             input,
             self.limb_width,
             self.limbs_count_limit,
@@ -441,10 +441,11 @@ impl<F: ff::PrimeField> BigUintMulModChip<F> {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        let grouped_max_word: BigInt = (0..limbs_per_group).fold(BigInt::zero(), |mut acc, i| {
-            acc.set_bit((i * limb_width) as u64, true);
-            acc
-        });
+        let grouped_max_word: BigUintRaw =
+            (0..limbs_per_group).fold(BigUintRaw::zero(), |mut acc, i| {
+                acc.set_bit((i * limb_width) as u64, true);
+                acc
+            });
 
         Ok(GroupedBigUint {
             cells: grouped,
@@ -514,7 +515,7 @@ impl<F: ff::PrimeField> BigUintMulModChip<F> {
     ) -> Result<(), Error> {
         let limb_width = self.limb_width.get();
 
-        let max_word_bn: BigInt = cmp::max(
+        let max_word_bn: BigUintRaw = cmp::max(
             big_uint::f_to_nat(&lhs.max_word),
             big_uint::f_to_nat(&rhs.max_word),
         );
@@ -522,10 +523,10 @@ impl<F: ff::PrimeField> BigUintMulModChip<F> {
 
         debug!("max word: {max_word_bn}");
 
-        let target_base_bn = BigInt::one() << limb_width;
+        let target_base_bn = BigUintRaw::one() << limb_width;
         let target_base: F = big_uint::nat_to_f(&target_base_bn).expect("TODO");
 
-        let mut accumulated_extra = BigInt::zero();
+        let mut accumulated_extra = BigUintRaw::zero();
         let carry_bits = calc_carry_bits(&max_word_bn, limb_width)?;
         debug!("carry_bits {carry_bits}");
 
@@ -1065,11 +1066,11 @@ impl<F: ff::PrimeField> Chip<F> for BigUintMulModChip<F> {
     }
 }
 
-fn calc_carry_bits(max_word: &BigInt, limb_width: usize) -> Result<NonZeroUsize, Error> {
+fn calc_carry_bits(max_word: &BigUintRaw, limb_width: usize) -> Result<NonZeroUsize, Error> {
     // FIXME: Is `f64` really needed here
-    // We can calculate `log2` for BigInt without f64
+    // We can calculate `log2` for BigUintRaw without f64
     let carry_bits = max_word
-        .mul(BigInt::one() + BigInt::one())
+        .mul(BigUintRaw::one() + BigUintRaw::one())
         .to_f64()
         .ok_or(Error::CarryBitsCalculate)?
         .log2()

--- a/src/gadgets/nonnative/bn/big_uint_mul_mod_chip/tests.rs
+++ b/src/gadgets/nonnative/bn/big_uint_mul_mod_chip/tests.rs
@@ -197,21 +197,21 @@ mod mult_mod_tests {
         ];
 
         for Context { lhs, rhs, modulus } in cases {
-            let lhs = BigInt::from_u128(lhs).unwrap();
-            let rhs = BigInt::from_u128(rhs).unwrap();
-            let modulus = BigInt::from_u128(modulus).unwrap();
+            let lhs = BigUintRaw::from_u128(lhs).unwrap();
+            let rhs = BigUintRaw::from_u128(rhs).unwrap();
+            let modulus = BigUintRaw::from_u128(modulus).unwrap();
 
             let quotient = (&lhs * &rhs) / &modulus;
             let remainer = (&lhs * &rhs) % &modulus;
 
             println!("{lhs} * {rhs} = {quotient} * {modulus} + {remainer}");
 
-            let lhs = BigUint::from_bigint(&lhs, LIMB_WIDTH, LIMBS_COUNT_LIMIT).unwrap();
-            let rhs = BigUint::from_bigint(&rhs, LIMB_WIDTH, LIMBS_COUNT_LIMIT).unwrap();
-            let modulus = BigUint::from_bigint(&modulus, LIMB_WIDTH, LIMBS_COUNT_LIMIT).unwrap();
+            let lhs = BigUint::from_biguint(&lhs, LIMB_WIDTH, LIMBS_COUNT_LIMIT).unwrap();
+            let rhs = BigUint::from_biguint(&rhs, LIMB_WIDTH, LIMBS_COUNT_LIMIT).unwrap();
+            let modulus = BigUint::from_biguint(&modulus, LIMB_WIDTH, LIMBS_COUNT_LIMIT).unwrap();
 
-            let quotient = BigUint::from_bigint(&quotient, LIMB_WIDTH, LIMBS_COUNT_LIMIT).unwrap();
-            let remainer = BigUint::from_bigint(&remainer, LIMB_WIDTH, LIMBS_COUNT_LIMIT).unwrap();
+            let quotient = BigUint::from_biguint(&quotient, LIMB_WIDTH, LIMBS_COUNT_LIMIT).unwrap();
+            let remainer = BigUint::from_biguint(&remainer, LIMB_WIDTH, LIMBS_COUNT_LIMIT).unwrap();
 
             let prover = match MockProver::run(
                 K,
@@ -509,7 +509,7 @@ mod components_tests {
         .unwrap()
     }
 
-    fn group_limbs<F: PrimeField>(inp: &BigUint<F>, max_word: BigInt) -> BigUint<F> {
+    fn group_limbs<F: PrimeField>(inp: &BigUint<F>, max_word: BigUintRaw) -> BigUint<F> {
         let limb_width = LIMB_WIDTH.get();
         let limbs_per_group =
             calc_limbs_per_group::<F>(calc_carry_bits(&max_word, limb_width).unwrap(), limb_width)
@@ -537,11 +537,11 @@ mod components_tests {
 
     #[test_log::test]
     fn test_bn() {
-        let lhs = BigInt::from_u64(u64::MAX).unwrap() * BigInt::from_u64(100).unwrap();
-        let rhs = BigInt::from_u64(u64::MAX).unwrap() * BigInt::from_u64(u64::MAX).unwrap();
+        let lhs = BigUintRaw::from_u64(u64::MAX).unwrap() * BigUintRaw::from_u64(100).unwrap();
+        let rhs = BigUintRaw::from_u64(u64::MAX).unwrap() * BigUintRaw::from_u64(u64::MAX).unwrap();
 
-        let lhs = BigUint::from_bigint(&lhs, LIMB_WIDTH, LIMBS_COUNT_LIMIT).unwrap();
-        let rhs = BigUint::from_bigint(&rhs, LIMB_WIDTH, LIMBS_COUNT_LIMIT).unwrap();
+        let lhs = BigUint::from_biguint(&lhs, LIMB_WIDTH, LIMBS_COUNT_LIMIT).unwrap();
+        let rhs = BigUint::from_biguint(&rhs, LIMB_WIDTH, LIMBS_COUNT_LIMIT).unwrap();
         let prod = mult_with_overflow(&lhs, &rhs);
         log::info!("prod {prod:?}");
         let sum = sum_with_overflow(&lhs, &rhs);
@@ -572,11 +572,11 @@ mod components_tests {
 
     #[test_log::test]
     fn test_zero() {
-        let lhs = BigInt::from_u64(u64::MAX).unwrap() * BigInt::from_u64(100).unwrap();
-        let rhs = BigInt::from_u64(0).unwrap();
+        let lhs = BigUintRaw::from_u64(u64::MAX).unwrap() * BigUintRaw::from_u64(100).unwrap();
+        let rhs = BigUintRaw::from_u64(0).unwrap();
 
-        let lhs = BigUint::from_bigint(&lhs, LIMB_WIDTH, LIMBS_COUNT_LIMIT).unwrap();
-        let rhs = BigUint::from_bigint(&rhs, LIMB_WIDTH, LIMBS_COUNT_LIMIT).unwrap();
+        let lhs = BigUint::from_biguint(&lhs, LIMB_WIDTH, LIMBS_COUNT_LIMIT).unwrap();
+        let rhs = BigUint::from_biguint(&rhs, LIMB_WIDTH, LIMBS_COUNT_LIMIT).unwrap();
         let prod = mult_with_overflow(&lhs, &rhs);
         log::info!("prod {prod:?}");
         let sum = sum_with_overflow(&lhs, &rhs);


### PR DESCRIPTION
Internally, the `BigUint` type started to be used instead of `BigInt`, so as not to have additional sign problems, and since negative numbers were not really supported.

Close #43