### PR TITLE
refactor(util): rm unnecessary borrow of ownership

### DIFF
--- a/src/gadgets/ecc.rs
+++ b/src/gadgets/ecc.rs
@@ -454,7 +454,7 @@ mod tests {
                         ctx.next();
                         ecc_chip.add(ctx, &a, &b)
                     } else {
-                        let lambda: C::Base = fe_to_fe_safe(self.lambda);
+                        let lambda: C::Base = fe_to_fe_safe(&self.lambda).unwrap();
                         let bit_len = lambda.to_le_bits().len();
                         let lambda = ctx.assign_advice(
                             || "lambda",

--- a/src/plonk/mod.rs
+++ b/src/plonk/mod.rs
@@ -116,7 +116,7 @@ impl<C: CurveAffine, RO: ROTrait<C>> AbsorbInRO<C, RO> for PlonkInstance<C> {
     fn absorb_into(&self, ro: &mut RO) {
         ro.absorb_point(self.W_commitment);
         for inst in self.instance.iter().take(2) {
-            ro.absorb_base(fe_to_fe(*inst));
+            ro.absorb_base(fe_to_fe(inst).unwrap());
         }
     }
 }
@@ -125,9 +125,9 @@ impl<C: CurveAffine, RO: ROTrait<C>> AbsorbInRO<C, RO> for RelaxedPlonkInstance<
     fn absorb_into(&self, ro: &mut RO) {
         ro.absorb_point(self.W_commitment);
         for inst in self.instance.iter().take(2) {
-            ro.absorb_base(fe_to_fe(*inst));
+            ro.absorb_base(fe_to_fe(inst).unwrap());
         }
-        ro.absorb_base(fe_to_fe(self.u));
+        ro.absorb_base(fe_to_fe(&self.u).unwrap());
         ro.absorb_point(self.E_commitment);
     }
 }

--- a/src/poseidon/poseidon_hash.rs
+++ b/src/poseidon/poseidon_hash.rs
@@ -173,7 +173,7 @@ impl<
         }
 
         let output = self.state.inner[1];
-        let bits = fe_to_bits_le(output)[..num_bits].to_vec();
+        let bits = fe_to_bits_le(&output)[..num_bits].to_vec();
         bits_to_fe_le(bits)
     }
 


### PR DESCRIPTION
refactor(util): return `Option` instead of panic
feat(util): Handle potential errors in field conversions

Part of #41