### PR TITLE
refactor(plonk): separate homogenous u from challenges

### DIFF
--- a/src/nifs.rs
+++ b/src/nifs.rs
@@ -138,7 +138,7 @@ impl<C: CurveAffine, RO: ROTrait<C>> NIFS<C, RO> {
         S.absorb_into(ro);
         let mut U2 = td.plonk_instance(ck);
         U2.absorb_into(ro);
-        if S.num_challenges > 1 {
+        if S.num_challenges > 0 {
             // the first challenge is used to combined multiple gates for instance U2
             U2.challenges = vec![ro.squeeze(NUM_CHALLENGE_BITS)];
         }

--- a/src/polynomial/mod.rs
+++ b/src/polynomial/mod.rs
@@ -548,10 +548,14 @@ where
                 match var_type {
                     // evaluation for challenges
                     // layout of challenges:
-                    // |num_challenges1|num_challenges2|
+                    // |num_challenges1|u1||num_challenges2|u2|
                     CHALLENGE_TYPE => match col {
                         col if col < S.num_challenges => U1.challenges[col],
-                        col if col < 2 * S.num_challenges => U2.challenges[col - S.num_challenges],
+                        col if col == S.num_challenges => U1.u,
+                        col if col < 2 * S.num_challenges + 1 => {
+                            U2.challenges[col - S.num_challenges - 1]
+                        }
+                        col if col == 2 * S.num_challenges + 1 => U2.u,
                         col => panic!("challenges index out of boundary: {col}"),
                     },
                     POLYNOMIAL_TYPE => {


### PR DESCRIPTION
We still identify `u` as of Challenge type in Expression without introduce extra type. However, in order to make the logic of folding more consistency, we separate homogeneous `u` from `challenges` in `RelaxedPlonkInstance`.  Another reason for separation is that the folding of `u` doesn't need BigNat operation which makes the code less confusion.