### PR TITLE
refactor(sps): proposal with refactoring of rounds fn

### DIFF
--- a/src/nifs.rs
+++ b/src/nifs.rs
@@ -143,7 +143,7 @@ impl<C: CurveAffine, RO: ROTrait<C>> NIFS<C, RO> {
         let (cross_terms, cross_term_commits) = Self::commit_cross_terms(ck, &S, U1, W1, &U2, &W2);
         cross_term_commits
             .iter()
-            .for_each(|cm| ro_acc.absorb_point(*cm));
+            .for_each(|cm| ro_acc.absorb_point(cm));
         let r = ro_acc.squeeze(NUM_CHALLENGE_BITS);
         let U = U1.fold(&U2, &cross_term_commits, &r);
         let W = W1.fold(&W2, &cross_terms, &r);
@@ -182,7 +182,7 @@ impl<C: CurveAffine, RO: ROTrait<C>> NIFS<C, RO> {
         U1.absorb_into(ro_acc);
         self.cross_term_commits
             .iter()
-            .for_each(|cm| ro_acc.absorb_point(*cm));
+            .for_each(|cm| ro_acc.absorb_point(cm));
         let r = ro_acc.squeeze(NUM_CHALLENGE_BITS);
         Ok(U1.fold(&U2, &self.cross_term_commits, &r))
     }

--- a/src/nifs.rs
+++ b/src/nifs.rs
@@ -137,7 +137,7 @@ impl<C: CurveAffine, RO: ROTrait<C>> NIFS<C, RO> {
         let S = td.plonk_structure(ck);
         S.absorb_into(ro_acc);
 
-        let (U2, W2) = td.run_sps_protocol(ck, ro_nark, S.num_challenges);
+        let (U2, W2) = td.run_sps_protocol(ck, ro_nark, S.num_challenges).unwrap();
         U2.absorb_into(ro_acc);
         U1.absorb_into(ro_acc);
         let (cross_terms, cross_term_commits) = Self::commit_cross_terms(ck, &S, U1, W1, &U2, &W2);
@@ -286,7 +286,9 @@ mod tests {
         let mut f_W = RelaxedPlonkWitness::new(td1.k, &S.round_sizes);
         let mut ro_nark_prover = create_ro::<C, F2, T, RATE, R_F, R_P>();
         let mut ro_nark_verifier = create_ro::<C, F2, T, RATE, R_F, R_P>();
-        let (U1, W1) = td1.run_sps_protocol(ck, &mut ro_nark_prover, S.num_challenges);
+        let (U1, W1) = td1
+            .run_sps_protocol(ck, &mut ro_nark_prover, S.num_challenges)
+            .unwrap();
         let res = S.is_sat(ck, &U1, &W1);
         assert!(res.is_ok());
 
@@ -306,7 +308,9 @@ mod tests {
         let perm_res = S.is_sat_perm(&f_U, &f_W);
         assert!(perm_res.is_ok());
 
-        let (U1, W1) = td2.run_sps_protocol(ck, &mut ro_nark_prover, S.num_challenges);
+        let (U1, W1) = td2
+            .run_sps_protocol(ck, &mut ro_nark_prover, S.num_challenges)
+            .unwrap();
         let res = S.is_sat(ck, &U1, &W1);
         assert!(res.is_ok());
 

--- a/src/plonk/mod.rs
+++ b/src/plonk/mod.rs
@@ -141,14 +141,14 @@ pub struct PlonkTrace<C: CurveAffine> {
 impl<C: CurveAffine, RO: ROTrait<C>> AbsorbInRO<C, RO> for PlonkStructure<C> {
     // TODO: add hash of other fields including gates
     fn absorb_into(&self, ro: &mut RO) {
-        ro.absorb_point(self.fixed_commitment);
+        ro.absorb_point(&self.fixed_commitment);
     }
 }
 
 impl<C: CurveAffine, RO: ROTrait<C>> AbsorbInRO<C, RO> for PlonkInstance<C> {
     fn absorb_into(&self, ro: &mut RO) {
         for pt in self.W_commitments.iter() {
-            ro.absorb_point(*pt);
+            ro.absorb_point(pt);
         }
         for inst in self.instance.iter() {
             ro.absorb_base(fe_to_fe(inst).unwrap());
@@ -162,9 +162,9 @@ impl<C: CurveAffine, RO: ROTrait<C>> AbsorbInRO<C, RO> for PlonkInstance<C> {
 impl<C: CurveAffine, RO: ROTrait<C>> AbsorbInRO<C, RO> for RelaxedPlonkInstance<C> {
     fn absorb_into(&self, ro: &mut RO) {
         for pt in self.W_commitments.iter() {
-            ro.absorb_point(*pt);
+            ro.absorb_point(pt);
         }
-        ro.absorb_point(self.E_commitment);
+        ro.absorb_point(&self.E_commitment);
         for inst in self.instance.iter() {
             ro.absorb_base(fe_to_fe(inst).unwrap());
         }
@@ -209,7 +209,7 @@ impl<C: CurveAffine> PlonkStructure<C> {
             ro_nark.absorb_base(fe_to_fe(inst).unwrap());
         });
         for i in 0..self.num_challenges {
-            ro_nark.absorb_point(U.W_commitments[i]);
+            ro_nark.absorb_point(&U.W_commitments[i]);
             let r = ro_nark.squeeze(NUM_CHALLENGE_BITS);
             if r != U.challenges[i] {
                 return Err(format!("{}-th challenge in PlonkInstance not match", i));

--- a/src/poseidon/mod.rs
+++ b/src/poseidon/mod.rs
@@ -29,7 +29,7 @@ pub trait ROTrait<C: CurveAffine> {
     fn absorb_base(&mut self, base: C::Base);
 
     /// Adds a point to the internal state
-    fn absorb_point(&mut self, p: C);
+    fn absorb_point(&mut self, p: &C);
 
     /// Returns a challenge by hashing the internal state
     fn squeeze(&mut self, num_bits: usize) -> C::Scalar;

--- a/src/poseidon/poseidon_hash.rs
+++ b/src/poseidon/poseidon_hash.rs
@@ -118,7 +118,7 @@ where
         self.update(&[base]);
     }
 
-    fn absorb_point(&mut self, point: C) {
+    fn absorb_point(&mut self, point: &C) {
         let encoded = point.coordinates().map(|coordinates| {
             [coordinates.x(), coordinates.y()]
                 .into_iter()


### PR DESCRIPTION
- rm borrow ownership from `absorb_point` in random oracle (separate commit, for easy filter other changes)
- rm duplication of lookup arguments coefficients calc logic
- rm unnecessary `self` from some `eval` fn
- made `run_sps_protocol` internal functions simpler by rm code duplication
- fix issue with lazy `.map` without any collect at the end, in sps functions

The question that bothers me is what is the guaranteed lookup_argument inside _2-_3 functions, as there is about to be panic inside. Some of the logic may depend on that.

I suggest these changes as a discussion 