### PR TITLE
Use `NonZeroUsize` for constants

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,2 +1,6 @@
-pub(crate) const MAX_BITS: usize = 255;
-pub(crate) const NUM_CHALLENGE_BITS: usize = 128;
+use std::num::NonZeroUsize;
+
+// SAFETY: Safe because value non zero
+pub(crate) const MAX_BITS: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(255) };
+// SAFETY: Safe because value non zero
+pub(crate) const NUM_CHALLENGE_BITS: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(128) };

--- a/src/gadgets/ecc.rs
+++ b/src/gadgets/ecc.rs
@@ -279,6 +279,8 @@ impl<C: CurveAffine<Base = F>, F: PrimeFieldBits, const T: usize> EccChip<C, F, 
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroUsize;
+
     use super::*;
     use crate::util::fe_to_fe_safe;
     use crate::{create_and_verify_proof, run_mock_prover_test};
@@ -471,7 +473,8 @@ mod tests {
                         ecc_chip.add(ctx, &a, &b)
                     } else {
                         let lambda: C::Base = fe_to_fe_safe(&self.lambda).unwrap();
-                        let bit_len = lambda.to_le_bits().len();
+                        let bit_len =
+                            NonZeroUsize::new(lambda.to_le_bits().len()).expect("Non Zero");
                         let lambda = ctx.assign_advice(
                             || "lambda",
                             ecc_chip.main_gate.config().state[2],

--- a/src/ivc/fold_relaxed_plonk_instance_chip.rs
+++ b/src/ivc/fold_relaxed_plonk_instance_chip.rs
@@ -811,6 +811,9 @@ mod tests {
     type ScalarExt = <C1 as CurveAffine>::ScalarExt;
     const T: usize = 6;
 
+    const LIMB_WIDTH: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(64) };
+    const LIMB_LIMIT: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(255) };
+
     #[test]
     fn generate_challenge() {
         let mut rnd = rand::thread_rng();
@@ -821,8 +824,8 @@ mod tests {
                 instance: vec![ScalarExt::random(&mut rnd), ScalarExt::random(&mut rnd)],
                 challenges: vec![<C1 as CurveAffine>::ScalarExt::random(&mut rnd)],
             },
-            NonZeroUsize::new(64).unwrap(),
-            NonZeroUsize::new(4).unwrap(),
+            LIMB_WIDTH,
+            LIMB_LIMIT,
         )
         .unwrap();
 

--- a/src/main_gate.rs
+++ b/src/main_gate.rs
@@ -1,4 +1,4 @@
-use std::{array, marker::PhantomData};
+use std::{array, marker::PhantomData, num::NonZeroUsize};
 
 use ff::{PrimeField, PrimeFieldBits};
 use halo2_proofs::{
@@ -609,7 +609,7 @@ impl<F: PrimeFieldBits, const T: usize> MainGate<F, T> {
         &self,
         ctx: &mut RegionCtx<'_, F>,
         input: AssignedValue<F>,
-        bit_len: usize,
+        bit_len: NonZeroUsize,
     ) -> Result<Vec<AssignedValue<F>>, Error> {
         // TODO: ensure a is less than F.size() - 1
 

--- a/src/poseidon/mod.rs
+++ b/src/poseidon/mod.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroUsize;
+
 use crate::main_gate::{AssignedBit, RegionCtx, WrapValue};
 use ff::{FromUniformBytes, PrimeFieldBits};
 use halo2_proofs::{arithmetic::CurveAffine, plonk::Error};
@@ -32,7 +34,7 @@ pub trait ROTrait<C: CurveAffine> {
     fn absorb_point(&mut self, p: &C);
 
     /// Returns a challenge by hashing the internal state
-    fn squeeze(&mut self, num_bits: usize) -> C::Scalar;
+    fn squeeze(&mut self, num_bits: NonZeroUsize) -> C::Scalar;
 }
 
 /// A helper trait that defines the behavior of a hash function used as a Random Oracle (RO)
@@ -61,6 +63,6 @@ pub trait ROCircuitTrait<F: PrimeFieldBits + FromUniformBytes<64>> {
     fn squeeze_n_bits(
         &mut self,
         ctx: &mut RegionCtx<'_, F>,
-        num_bits: usize,
+        num_bits: NonZeroUsize,
     ) -> Result<Vec<AssignedBit<F>>, Error>;
 }

--- a/src/poseidon/poseidon_circuit.rs
+++ b/src/poseidon/poseidon_circuit.rs
@@ -8,7 +8,7 @@ use halo2_proofs::{
     plonk::Error,
 };
 use poseidon::{self, Spec};
-use std::convert::TryInto;
+use std::{convert::TryInto, num::NonZeroUsize};
 
 use super::ROCircuitTrait;
 
@@ -44,12 +44,12 @@ impl<F: PrimeFieldBits + FromUniformBytes<64>, const T: usize, const RATE: usize
     fn squeeze_n_bits(
         &mut self,
         ctx: &mut RegionCtx<'_, F>,
-        num_bits: usize,
+        num_bits: NonZeroUsize,
     ) -> Result<Vec<AssignedBit<F>>, Error> {
         let val = self.squeeze(ctx)?;
         let res = self.main_gate.le_num_to_bits(ctx, val, MAX_BITS)?;
-        if res.len() >= num_bits {
-            Ok(res[..num_bits].to_vec())
+        if res.len() >= num_bits.get() {
+            Ok(res[..num_bits.get()].to_vec())
         } else {
             Ok(res)
         }
@@ -415,11 +415,11 @@ mod tests {
 
     struct TestCircuit<F: PrimeField + PrimeFieldBits> {
         inputs: Vec<WrapValue<F>>,
-        num_bits: usize,
+        num_bits: NonZeroUsize,
     }
 
     impl<F: PrimeField + PrimeFieldBits> TestCircuit<F> {
-        fn new(inputs: Vec<F>, num_bits: usize) -> Self {
+        fn new(inputs: Vec<F>, num_bits: NonZeroUsize) -> Self {
             Self {
                 inputs: inputs
                     .into_iter()
@@ -437,7 +437,7 @@ mod tests {
         fn without_witnesses(&self) -> Self {
             Self {
                 inputs: Vec::new(),
-                num_bits: 0,
+                num_bits: NonZeroUsize::new(1).unwrap(),
             }
         }
 
@@ -473,7 +473,7 @@ mod tests {
     fn test_poseidon_circuit() {
         println!("-----running Poseidon Circuit-----");
         let mut inputs = Vec::new();
-        let num_bits = 128;
+        let num_bits = NonZeroUsize::new(128).unwrap();
         for i in 0..5 {
             inputs.push(Fp::from(i as u64));
         }
@@ -492,7 +492,7 @@ mod tests {
     fn test_mock() {
         const K: u32 = 10;
         let mut inputs = Vec::new();
-        let num_bits = 128;
+        let num_bits = NonZeroUsize::new(128).unwrap();
         for i in 0..5 {
             inputs.push(Fp::from(i as u64));
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -7,6 +7,7 @@ use num_bigint::BigUint;
 use poseidon::Spec;
 pub(crate) use rayon::current_num_threads;
 use std::iter;
+use std::num::NonZeroUsize;
 
 pub fn bytes_to_bits_le(bytes: Vec<u8>) -> Vec<bool> {
     let mut bits = Vec::new();
@@ -159,7 +160,7 @@ pub(crate) fn trim_leading_zeros(hex: String) -> String {
     format!("0x{}", trimmed)
 }
 
-pub(crate) fn normalize_trailing_zeros(bits: &mut Vec<bool>, bit_len: usize) {
+pub(crate) fn normalize_trailing_zeros(bits: &mut Vec<bool>, bit_len: NonZeroUsize) {
     let last_one_position = bits
         .iter()
         .enumerate()
@@ -173,9 +174,9 @@ pub(crate) fn normalize_trailing_zeros(bits: &mut Vec<bool>, bit_len: usize) {
     }
 
     let length = bits.len();
-    assert!(bit_len >= length, "bit length exceed maximum value");
+    assert!(bit_len.get() >= length, "bit length exceed maximum value");
 
-    for _ in 0..(bit_len - length) {
+    for _ in 0..(bit_len.get() - length) {
         bits.push(false);
     }
 }


### PR DESCRIPTION
By using `NonZero` we eliminate a class of errors where you don't get errors with zero length (e.g. traversing arrays with zero length just doesn't happen), however, no work is done and the data at the end is incorrect.

It also allows us to better reflex some places where we pass the size of some collection as a parameter and the collection turns out to be empty due to an error. Now at least we will get panic in such places