### PR TITLE
feat(bn): `check_fits_in_bits` -> `decompose_in_bits`

### DIFF
--- a/src/gadgets/nonnative/bn/big_uint_mul_mod_chip/tests.rs
+++ b/src/gadgets/nonnative/bn/big_uint_mul_mod_chip/tests.rs
@@ -421,7 +421,7 @@ mod components_tests {
                             )
                             .unwrap();
 
-                        chip.check_fits_in_bits(
+                        chip.decompose_in_bits(
                             &mut region,
                             number,
                             NonZeroUsize::new(mem::size_of::<u32>() * 8).unwrap(),


### PR DESCRIPTION
Instead of just checking that the value fits into bits, we change the return type and are able to get those bits as a cells.