### PR TITLE
test(ivc): improve fold tests fixtures

### DIFF
--- a/src/ivc/fold_relaxed_plonk_instance_chip.rs
+++ b/src/ivc/fold_relaxed_plonk_instance_chip.rs
@@ -829,7 +829,7 @@ mod tests {
         )
         .unwrap();
 
-        let mut td = TableData::new(10, vec![]);
+        let mut td = TableData::new(19, vec![]);
         let mut shape: Box<dyn RegionLayouter<_>> =
             Box::new(RegionShape::new(RegionIndex::from(0)));
         let shape_mut: &mut dyn RegionLayouter<_> = shape.as_mut();


### PR DESCRIPTION
In anticipation of the rest of the tests, the current state has been refactored and the number of fold rounds for testing has been expanded. The last change is significant for example for `fold_E`, which passed for one round of folding (because `r` was `u128` and `r ^ 2` in both fields was the same), but for two rounds already gave an error. 