### PR TITLE
refactor(poly): tuple -> struct for col index

### DIFF
--- a/src/main_gate.rs
+++ b/src/main_gate.rs
@@ -641,7 +641,7 @@ impl<F: PrimeFieldBits, const T: usize> MainGate<F, T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::polynomial::{Expression, CHALLENGE_TYPE};
+    use crate::polynomial::{ColumnIndex, Expression};
     use halo2curves::pasta::Fp;
 
     #[test]
@@ -703,8 +703,18 @@ mod tests {
         let num_vars = meta.1 + meta.2;
         let res = multipoly.fold_transform(num_fixed, num_vars);
         let r_index = res.num_challenges() - 1;
-        let e1 = res.coeff_of((0, r_index, CHALLENGE_TYPE), 0);
-        let e2 = res.coeff_of((0, r_index, CHALLENGE_TYPE), 5);
+        let e1 = res.coeff_of(
+            ColumnIndex::Challenge {
+                column_index: r_index,
+            },
+            0,
+        );
+        let e2 = res.coeff_of(
+            ColumnIndex::Challenge {
+                column_index: r_index,
+            },
+            5,
+        );
         // E1: "(u1^5)(rc) + (q1_0)(u1^4)(s1_0) + (q5_0)(s1_0^5) + (u1^4)(q1_1)(s1_1) + (u1^3)(qm)(s1_0)(s1_1) + (q5_1)(s1_1^5) + (u1^4)(qi)(in1) + (u1^4)(qo)(out1)"
         assert_eq!(
             e1.to_string(),

--- a/src/nifs/mod.rs
+++ b/src/nifs/mod.rs
@@ -16,7 +16,7 @@ use crate::plonk::{
     PlonkInstance, PlonkStructure, PlonkWitness, RelaxedPlonkInstance, RelaxedPlonkWitness,
     SpsError, TableData,
 };
-use crate::polynomial::CHALLENGE_TYPE;
+use crate::polynomial::ColumnIndex;
 use crate::poseidon::{AbsorbInRO, ROTrait};
 use halo2_proofs::arithmetic::CurveAffine;
 use rayon::prelude::*;
@@ -108,7 +108,14 @@ impl<C: CurveAffine, RO: ROTrait<C>> NIFS<C, RO> {
         let r_index = normalized.num_challenges() - 1;
         let degree = S.poly.degree_for_folding(offset);
         let cross_terms: Vec<Vec<C::ScalarExt>> = (1..degree)
-            .map(|k| normalized.coeff_of((0, r_index, CHALLENGE_TYPE), k))
+            .map(|k| {
+                normalized.coeff_of(
+                    ColumnIndex::Challenge {
+                        column_index: r_index,
+                    },
+                    k,
+                )
+            })
             .map(|multipoly| {
                 (0..num_row)
                     .into_par_iter()


### PR DESCRIPTION
Previously, a tuple of three interrelated elements such as rotation & index column & type of var was used. Such a tuple is much simpler to express with enum

As refactoring for #80 