### PR TITLE
fix `is_sat_perm`

### DIFF
--- a/src/nifs/tests.rs
+++ b/src/nifs/tests.rs
@@ -63,11 +63,8 @@ where
 
     f_U = U_from_verify;
     f_W = W;
-    let res = S.is_sat_relaxed(ck, &f_U, &f_W);
-    assert!(res.is_ok());
-    // TODO: fix #91
-    //    let perm_res = S.is_sat_perm(&f_U, &f_W);
-    //    assert!(perm_res.is_ok());
+    assert_eq!(S.is_sat_relaxed(ck, &f_U, &f_W).err(), None);
+    assert_eq!(S.is_sat_perm(&f_U, &f_W).err(), None);
 
     let (U1, W1) = td2
         .run_sps_protocol(ck, &mut ro_nark_prepare, S.num_challenges)
@@ -84,9 +81,7 @@ where
     f_U = U_from_verify;
     f_W = _W;
     assert_eq!(S.is_sat_relaxed(ck, &f_U, &f_W).err(), None);
-    // TODO: fix #91
-    //    let perm_res = S.is_sat_perm(&f_U, &f_W);
-    //    assert!(perm_res.is_ok());
+    assert_eq!(S.is_sat_perm(&f_U, &f_W).err(), None);
     Ok(())
 }
 

--- a/src/polynomial/sparse.rs
+++ b/src/polynomial/sparse.rs
@@ -1,7 +1,7 @@
 use ff::PrimeField;
 
 // represent a sparse matrix M = {(i, j, v)}, i.e. M[i,j] = v
-// the size of matrix is N*N with N = num_fixed_columns + num_instance_columns + num_advice_columns
+// the size of matrix is N*N with N = num_io + num_advice_columns * num_rows
 pub(crate) type SparseMatrix<Scalar> = Vec<(usize, usize, Scalar)>;
 
 pub(crate) fn matrix_multiply<F: PrimeField>(P: &SparseMatrix<F>, Z: &[F]) -> Vec<F> {


### PR DESCRIPTION
This PR fixed issues in `is_sat_perm`

*  correct calculation of instance column index: previously it assumes the index is always 0, but the actual index depends on the developer input
*  the columns in permutation need exclude instance column when instance column is none
* When the special soundness protocol has round equals one, the `W.W[0]` is no longer witness columns, we can slice with correct length to uniform different round numbers.

Close #91 