### PR TITLE
ci: turn on workflow for all PR

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Due to the squash policy, PRs will be more granular, so there will be a situation of chains of PRs going into each other. To make it easier to work with this, you can enable CI on any PR. For an open-source project this will not be expensive.