### PR TITLE
refactor: integrate `inspect_err`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ log = "0.4.20"
 itertools = "0.11.0"
 bitter = "0.6.1"
 thiserror = "1.0.48"
+result-inspect = "0.3.0"
 
 [dev-dependencies]
 env_logger = "0.10.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::type_complexity)]
+#![allow(unstable_name_collisions)]
 #![allow(dead_code)] // TODO: remove it later
 #![allow(non_snake_case)] // UPPER_CASE is used for ease of compatibility with Nova documentation
 


### PR DESCRIPTION
chore: add dep `result_inspect`

There are three common approaches to check errors trace:
- Errors include full & detailed annotations of the situation (e.g. on which variable the error occurred by str).
- Included execution traces (something like `backtrace` for panic, only for errors, can be added automaticly by 'thiserror' crate).
- Logs with context

The first one is the best, but requires a lot of dev-work, the second one is simpler, but is redundant for debugging, because every error will bring with it a callstack. The third is the most temporary, however, the fastest to add and, most importantly, to migrate to any of the above two methods.

Therefore, for the speed of work at this stage, I suggest just logging the error trace, and then migrate to one of the designs above.