### PR TITLE
feat(ivc): finalize fold chip 

### DIFF
--- a/src/gadgets/nonnative/bn/big_uint.rs
+++ b/src/gadgets/nonnative/bn/big_uint.rs
@@ -206,6 +206,10 @@ impl<F: ff::PrimeField> BigUint<F> {
             })
     }
 
+    pub fn into_f(&self) -> Option<F> {
+        F::from_str_vartime(&self.into_bigint().to_str_radix(10))
+    }
+
     pub fn limbs(&self) -> &[F] {
         self.limbs.as_slice()
     }

--- a/src/plonk/mod.rs
+++ b/src/plonk/mod.rs
@@ -80,7 +80,7 @@ pub struct PlonkStructure<C: CurveAffine> {
 
 #[derive(Clone, Debug)]
 pub struct PlonkInstance<C: CurveAffine> {
-    /// `W_commitments = round_sizes.len()`, see [`PlonkStructure.round_sizes`]
+    /// `W_commitments = round_sizes.len()`, see [`PlonkStructure::round_sizes`]
     pub(crate) W_commitments: Vec<C>,
     /// inst = [X0, X1]
     pub(crate) instance: Vec<C::ScalarExt>,


### PR DESCRIPTION
# Refactoring and Improvement of IVC Folding Chip and Test Abstractions

This PR introduces significant refinements to the IVC folding chip, enhancing its usability and maintainability. Key changes include restructuring the chip's fields and improving test fixtures for better abstraction and readability. Here's a breakdown of the specific updates:

# Refactor of Folding Chip Fields 

## Simplification of Method Arguments

The `big uint chip` has been integrated into the `self` structure, leading to a more streamlined argument structure in the fold-chip methods. This change simplifies the method interfaces by reducing the number of arguments required.

## Configuration Integration

The configuration details have also been moved into the self structure, further decluttering the method interfaces and making the chip more self-contained.

## Introduction of `AssignedRelaxedPlonkInstance`

This new structure is returned from the chip and simplifies the `AssignedWitness` structure. It represents a significant step towards more manageable and readable code.

# Enhanced Return Values from fold Function

The fold function has been updated to return assigned values. This enhancement is crucial for general use in IVC, allowing for more flexible and powerful implementations.

# Testing Improvements

## Consistency Checks with NIFS Across All Folding Functions

A new test has been implemented to ensure that the folding functionality remains consistent with the Non-Interactive Folding Scheme (NIFS) across various fields. This test is vital for verifying the integrity and reliability of the folding process in different scenarios.

# Conclusion

This PR finalizes the folding chip, which is a key component for IVC as a whole. Further work on #32 will include describing scenarios for using this chip and integrating it with custom `StepCircuit`.