### PR TITLE
feat(ivc): impl ext::synthesize_step_non_base_case

### DIFF
--- a/src/gadgets/ecc.rs
+++ b/src/gadgets/ecc.rs
@@ -356,6 +356,23 @@ impl<C: CurveAffine<Base = F>, F: PrimeFieldBits, const T: usize> EccChip<C, F, 
         let yr = self.main_gate.sub(ctx, &tmp3, &p.y)?;
         Ok(AssignedPoint { x: xr, y: yr })
     }
+
+    pub fn conditional_select(
+        &self,
+        ctx: &mut RegionCtx<'_, C::Base>,
+        lhs: &AssignedPoint<C>,
+        rhs: &AssignedPoint<C>,
+        condition: &AssignedValue<C::Base>,
+    ) -> Result<AssignedPoint<C>, Error> {
+        Ok(AssignedPoint {
+            x: self
+                .main_gate
+                .conditional_select(ctx, &lhs.x, &rhs.x, condition)?,
+            y: self
+                .main_gate
+                .conditional_select(ctx, &lhs.y, &rhs.y, condition)?,
+        })
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Enhancements to IVC and ECC in Incrementally Verifiable Computation

This PR introduces significant improvements to the IVC algorithm, focusing on the implementation of conditional selection between base and non-base cases, and refining the ECC component. 

Here's a breakdown of the changes:

## What has been done?
### Implementation of Selection Between Base and Non-Base Cases (IVC):

A new feature is introduced to handle the selection between base and non-base cases in the IVC process. At step zero our task is simply to generate a relaxed plonk instance, and at any other step to commit folding. But we are running on-circuit, so we perform both of these actions each time, and then choose one of the options depending on the step.

### Implement `synthesize_step_base_case` for step circuit module

Implemented a method to synthesize steps specifically for the base case of IVC. That is, make a call to the key folding-chip inside the `StepCircutiExt` abstraction. This is a preparation for synthesizing the step circuit itself

### New Method for On-Circuit Conditional Selection (IVC and ECC)

- Developed a new method, `AssignedRelaxed::conditional_select`, for on-circuit conditional selection between the base and non-base cases. This method plays a key role in choosing the correct assigned relaxed Plonk instance based on the step in IVC

- Enhanced the ECC component with the implementation of `conditional_select`. This auxiliary function is simplify on-circuit conditional selection of curve point.

Part of #32