### PR TITLE
add digest module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,14 @@ halo2_proofs = { git = "https://github.com/snarkify/halo2", branch = "snarkify/d
 ff = "0.13"
 group = "0.13"
 # pasta_curves = "0.5"
-sha3 = "0.8.2"
+sha3 = "0.10"
+bincode = "1.3"
+serde = { version = "1.0", features = ["derive"] }
 rayon = "1.5.3"
 num-bigint = "0.4.3"
 num-traits = "0.2.16"
+once_cell = "1.18.0"
+digest = "0.10"
 
 rand_core = { version = "0.6", default-features = false }
 halo2curves = { git = 'https://github.com/privacy-scaling-explorations/halo2curves', tag = "0.4.0" }

--- a/src/commitment.rs
+++ b/src/commitment.rs
@@ -1,12 +1,10 @@
 use std::{io::Read, iter};
 
+use digest::{ExtendableOutput, Update};
 use group::Curve;
 use halo2_proofs::arithmetic::{best_multiexp, CurveAffine, CurveExt};
 use rayon::prelude::*;
-use sha3::{
-    digest::{ExtendableOutput, Input},
-    Shake256,
-};
+use sha3::Shake256;
 
 use crate::util::parallelize;
 
@@ -27,8 +25,8 @@ impl<C: CurveAffine> CommitmentKey<C> {
         let n: usize = 1 << k;
 
         let mut shake = Shake256::default();
-        shake.input(label);
-        let mut reader = shake.xof_result();
+        shake.update(label);
+        let mut reader = shake.finalize_xof();
 
         let ck_proj: Vec<_> = iter::repeat_with(|| {
             let mut uniform_bytes = [0u8; 32];

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -3,4 +3,6 @@ use std::num::NonZeroUsize;
 // SAFETY: Safe because value non zero
 pub(crate) const MAX_BITS: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(255) };
 // SAFETY: Safe because value non zero
+pub(crate) const NUM_HASH_BITS: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(250) };
+// SAFETY: Safe because value non zero
 pub(crate) const NUM_CHALLENGE_BITS: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(128) };

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -1,0 +1,155 @@
+//! Adapted from  https://github.com/microsoft/Nova/src/digest.rs
+use bincode::Options;
+use ff::PrimeField;
+use serde::Serialize;
+use sha3::{Digest, Sha3_256};
+use std::io;
+use std::marker::PhantomData;
+
+use crate::constants::NUM_HASH_BITS;
+
+/// Trait for components with potentially discrete digests to be included in their container's digest.
+pub trait Digestible {
+    /// Write the byte representation of Self in a byte buffer
+    fn write_bytes<W: Sized + io::Write>(&self, byte_sink: &mut W) -> Result<(), io::Error>;
+}
+
+/// Marker trait to be implemented for types that implement `Digestible` and `Serialize`.
+/// Their instances will be serialized to bytes then digested.
+pub trait SimpleDigestible: Serialize {}
+
+impl<T: SimpleDigestible> Digestible for T {
+    fn write_bytes<W: Sized + io::Write>(&self, byte_sink: &mut W) -> Result<(), io::Error> {
+        let config = bincode::DefaultOptions::new()
+            .with_little_endian()
+            .with_fixint_encoding();
+        // Note: bincode recursively length-prefixes every field!
+        config
+            .serialize_into(byte_sink, self)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+    }
+}
+
+pub struct DigestComputer<'a, F: PrimeField, T> {
+    inner: &'a T,
+    _phantom: PhantomData<F>,
+}
+
+impl<'a, F: PrimeField, T: Digestible> DigestComputer<'a, F, T> {
+    fn hasher() -> Sha3_256 {
+        Sha3_256::new()
+    }
+
+    fn map_to_field(digest: &[u8]) -> F {
+        let bv = (0..NUM_HASH_BITS.get()).map(|i| {
+            let (byte_pos, bit_pos) = (i / 8, i % 8);
+            let bit = (digest[byte_pos] >> bit_pos) & 1;
+            bit == 1
+        });
+
+        // turn the bit vector into a scalar
+        let mut digest = F::ZERO;
+        let mut coeff = F::ONE;
+        for bit in bv {
+            if bit {
+                digest += coeff;
+            }
+            coeff += coeff;
+        }
+        digest
+    }
+
+    /// Create a new `DigestComputer`
+    pub fn new(inner: &'a T) -> Self {
+        DigestComputer {
+            inner,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Compute the digest of a `Digestible` instance.
+    pub fn digest(&self) -> Result<F, io::Error> {
+        let mut hasher = Self::hasher();
+        self.inner
+            .write_bytes(&mut hasher)
+            .expect("Serialization error");
+        let bytes: [u8; 32] = hasher.finalize().into();
+        Ok(Self::map_to_field(&bytes))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DigestComputer, SimpleDigestible};
+    use ff::Field;
+    use halo2curves::bn256::{Fr, G1Affine};
+    use halo2curves::CurveAffine;
+    use once_cell::sync::OnceCell;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Serialize, Deserialize)]
+    struct S<C: CurveAffine> {
+        i: usize,
+        #[serde(skip, default = "OnceCell::new")]
+        digest: OnceCell<C::ScalarExt>,
+    }
+
+    impl<C: CurveAffine> SimpleDigestible for S<C> {}
+
+    impl<C: CurveAffine> S<C> {
+        fn new(i: usize) -> Self {
+            S {
+                i,
+                digest: OnceCell::new(),
+            }
+        }
+
+        fn digest(&self) -> C::ScalarExt {
+            self.digest
+                .get_or_try_init(|| DigestComputer::new(self).digest())
+                .cloned()
+                .unwrap()
+        }
+    }
+
+    #[test]
+    fn test_digest_field_not_ingested_in_computation() {
+        let s1 = S::<G1Affine>::new(42);
+
+        // let's set up a struct with a weird digest field to make sure the digest computation does not depend of it
+        let oc = OnceCell::new();
+        oc.set(Fr::ONE).unwrap();
+
+        let s2: S<G1Affine> = S { i: 42, digest: oc };
+
+        assert_eq!(
+            DigestComputer::<Fr, _>::new(&s1).digest().unwrap(),
+            DigestComputer::<Fr, _>::new(&s2).digest().unwrap()
+        );
+
+        // note: because of the semantics of `OnceCell::get_or_try_init`, the above
+        // equality will not result in `s1.digest() == s2.digest`
+        assert_ne!(
+            s2.digest(),
+            DigestComputer::<Fr, _>::new(&s2).digest().unwrap()
+        );
+    }
+
+    #[test]
+    fn test_digest_impervious_to_serialization() {
+        let good_s = S::<G1Affine>::new(42);
+
+        // let's set up a struct with a weird digest field to confuse deserializers
+        let oc = OnceCell::new();
+        oc.set(Fr::ONE).unwrap();
+
+        let bad_s: S<G1Affine> = S { i: 42, digest: oc };
+        // this justifies the adjective "bad"
+        assert_ne!(good_s.digest(), bad_s.digest());
+
+        let naughty_bytes = bincode::serialize(&bad_s).unwrap();
+
+        let retrieved_s: S<G1Affine> = bincode::deserialize(&naughty_bytes).unwrap();
+        assert_eq!(good_s.digest(), retrieved_s.digest())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod commitment;
 pub mod constants;
+pub mod digest;
 pub mod gadgets;
 pub mod ivc;
 pub mod main_gate;


### PR DESCRIPTION
This is adapted from Nova code base: https://github.com/microsoft/Nova/src/digest.rs

* Update `sha3` library version and corresponding codes in commitment key setup.
* Fix test errors

Will add related methods for `PublicParameter` and `PlonkInstance` in future PR.