### PR TITLE
feat(digest): impl `digest_to_f` ext

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,13 @@ halo2_proofs = { git = "https://github.com/snarkify/halo2", branch = "snarkify/d
 ff = "0.13"
 group = "0.13"
 # pasta_curves = "0.5"
-sha3 = "0.8.2"
+sha3 = "0.10"
+bincode = "1.3"
+serde = { version = "1.0", features = ["derive"] }
 rayon = "1.5.3"
 num-bigint = "0.4.3"
 num-traits = "0.2.16"
+digest = "0.10"
 
 rand_core = { version = "0.6", default-features = false }
 halo2curves = { git = 'https://github.com/privacy-scaling-explorations/halo2curves', tag = "0.4.0" }

--- a/src/commitment.rs
+++ b/src/commitment.rs
@@ -1,12 +1,10 @@
 use std::{io::Read, iter};
 
+use digest::{ExtendableOutput, Update};
 use group::Curve;
 use halo2_proofs::arithmetic::{best_multiexp, CurveAffine, CurveExt};
 use rayon::prelude::*;
-use sha3::{
-    digest::{ExtendableOutput, Input},
-    Shake256,
-};
+use sha3::Shake256;
 
 use crate::util::parallelize;
 
@@ -27,8 +25,8 @@ impl<C: CurveAffine> CommitmentKey<C> {
         let n: usize = 1 << k;
 
         let mut shake = Shake256::default();
-        shake.input(label);
-        let mut reader = shake.xof_result();
+        shake.update(label);
+        let mut reader = shake.finalize_xof();
 
         let ck_proj: Vec<_> = iter::repeat_with(|| {
             let mut uniform_bytes = [0u8; 32];

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -2,5 +2,11 @@ use std::num::NonZeroUsize;
 
 // SAFETY: Safe because value non zero
 pub(crate) const MAX_BITS: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(255) };
+// A hash outputs an arbitrary set of bytes, to interpret it within some field, we must
+// limit the number of bits considered so that we don't get a small number as a hash.
+//
+// Check [`crate::digest`] for more details
+// SAFETY: Safe because value non zero
+pub(crate) const NUM_HASH_BITS: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(250) };
 // SAFETY: Safe because value non zero
 pub(crate) const NUM_CHALLENGE_BITS: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(128) };

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -1,0 +1,155 @@
+use std::{io, iter, num::NonZeroUsize, ops::Deref};
+
+use bincode::Options;
+use bitter::{BitReader, LittleEndianReader};
+use digest::{typenum::U32, Digest, OutputSizeUser};
+use ff::PrimeField;
+use serde::Serialize;
+
+pub use sha3::Sha3_256 as DefaultHasher;
+
+use crate::constants::NUM_HASH_BITS;
+
+/// A trait for converting a digest to a prime field element.
+///
+/// This trait is intended for use with types implementing the [`Digest`] trait,
+/// allowing the conversion of a digest to an element of a prime field.
+pub trait DigestToF: Digest {
+    /// Serialize input & calculate digest & convert into [`PrimeField`]
+    //
+    // Allows you to use any hash function whose output is of size `[u8; 32]`
+    //
+    fn digest_to_f<F: PrimeField>(input: &impl Serialize) -> Result<F, io::Error>
+    where
+        Self: OutputSizeUser<OutputSize = U32>,
+    {
+        // Because [rust#92827](https://github.com/rust-lang/rust/issues/92827)
+        // we can't explicitly limit `F::NUM_BITS = 32` as generic params
+        if F::NUM_BITS > 32 * 8 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "Field representation too big for this hash function, {} but expected < 32 * 8",
+                    F::NUM_BITS
+                ),
+            ));
+        }
+
+        let digest = Self::digest(
+            bincode::DefaultOptions::new()
+                .with_little_endian()
+                .with_fixint_encoding()
+                .serialize(input)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
+        );
+
+        Ok(into_field_by_bits(digest.deref(), NUM_HASH_BITS))
+    }
+}
+impl DigestToF for sha3::Sha3_256 {}
+
+fn into_field_by_bits<F: PrimeField>(input: &[u8], bits_count: NonZeroUsize) -> F {
+    let mut coeff = F::ONE;
+
+    let mut reader = LittleEndianReader::new(input);
+    iter::repeat_with(|| reader.read_bit())
+        .map_while(|b| b)
+        .take(bits_count.get())
+        .fold(F::ZERO, |mut result, bit| {
+            if bit {
+                result += coeff;
+            }
+
+            coeff = coeff.double();
+
+            result
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroUsize;
+
+    use ff::PrimeField;
+    use halo2curves::bn256::Fr;
+    use serde::*;
+
+    use super::{into_field_by_bits, DigestToF};
+
+    #[test]
+    fn consistency() {
+        // MODULUS - 1
+        let input = Fr::from_str_vartime(
+            "21888242871839275222246405745257275088548364400416034343698204186575808495616",
+        )
+        .unwrap();
+
+        assert_eq!(
+            into_field_by_bits::<Fr>(
+                &input.to_repr(),
+                NonZeroUsize::new(Fr::NUM_BITS as usize).unwrap()
+            ),
+            input
+        );
+    }
+
+    /// A test structure for demonstration purposes.
+    #[derive(Serialize)]
+    struct TestStruct {
+        bytes: Vec<u8>,
+        num: u128,
+        s: String,
+    }
+
+    /// Tests successful conversion of a hash to a prime field element.
+    #[test]
+    fn test_digest_to_field_conversion() {
+        let test_data = TestStruct {
+            bytes: vec![100; 100],
+            num: u128::MAX,
+            s: "string".into(),
+        };
+
+        let _result = sha3::Sha3_256::digest_to_f::<Fr>(&test_data)
+            .expect("Failed to convert digest to field element");
+    }
+
+    /// Tests conversion with an empty input.
+    #[test]
+    fn test_empty_input_conversion() {
+        let test_data = TestStruct {
+            bytes: vec![],
+            num: 0,
+            s: "".into(),
+        };
+
+        let _result = sha3::Sha3_256::digest_to_f::<Fr>(&test_data)
+            .expect("Failed to convert digest to field element for empty input");
+    }
+
+    #[test]
+    fn skip_field() {
+        #[derive(Serialize)]
+        struct Foo {
+            num: u32,
+        }
+
+        #[derive(Serialize)]
+        struct Boo {
+            num: u32,
+            #[serde(skip)]
+            skipme: String,
+        }
+
+        let foo = sha3::Sha3_256::digest_to_f::<Fr>(&Foo { num: 32 })
+            .expect("Failed to convert digest to field element for empty input");
+
+        let boo = sha3::Sha3_256::digest_to_f::<Fr>(&Boo {
+            num: 32,
+            skipme: "data".to_string(),
+        })
+        .expect("Failed to convert digest to field element for empty input");
+
+        assert_eq!(foo, boo);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod commitment;
 pub mod constants;
+pub mod digest;
 pub mod gadgets;
 pub mod ivc;
 pub mod main_gate;


### PR DESCRIPTION
In #111 @chaosma suggested just porting the module from Nova, however, I've rethought it into a more elegant and usable form. 

Also the constant `NUM_HASH_BITS` has been changed, let me know if I misunderstood its intent and it should be 250 there

This is rethought of Nova module: https://github.com/microsoft/Nova/src/digest.rs