### PR TITLE
feat(ivc): finalize `StepCircuitExt::synthesize`

### DIFF
--- a/src/poseidon/mod.rs
+++ b/src/poseidon/mod.rs
@@ -54,10 +54,21 @@ pub trait ROCircuitTrait<F: PrimeFieldBits + FromUniformBytes<64>> {
     fn new(config: Self::Config, args: Self::Args) -> Self;
 
     /// Adds a scalar to the internal state
-    fn absorb_base(&mut self, base: WrapValue<F>);
+    fn absorb_base(&mut self, base: WrapValue<F>) -> &mut Self;
 
     /// Adds a point to the internal state
-    fn absorb_point(&mut self, x: WrapValue<F>, y: WrapValue<F>);
+    fn absorb_point(&mut self, point: [WrapValue<F>; 2]) -> &mut Self;
+
+    /// Adds elements of iterator of [`WrapValues`] to the internal state
+    fn absorb_iter<I>(&mut self, iter: impl Iterator<Item = I>) -> &mut Self
+    where
+        I: Into<WrapValue<F>>,
+    {
+        iter.for_each(|val| {
+            self.absorb_base(val.into());
+        });
+        self
+    }
 
     /// Returns a challenge of `num_bits` by hashing the internal state
     fn squeeze_n_bits(

--- a/src/poseidon/poseidon_circuit.rs
+++ b/src/poseidon/poseidon_circuit.rs
@@ -33,12 +33,12 @@ impl<F: PrimeFieldBits + FromUniformBytes<64>, const T: usize, const RATE: usize
         }
     }
 
-    fn absorb_base(&mut self, base: WrapValue<F>) {
+    fn absorb_base(&mut self, base: WrapValue<F>) -> &mut Self {
         self.update(&[base])
     }
 
-    fn absorb_point(&mut self, x: WrapValue<F>, y: WrapValue<F>) {
-        self.update(&[x, y])
+    fn absorb_point(&mut self, point: [WrapValue<F>; 2]) -> &mut Self {
+        self.update(&point)
     }
 
     fn squeeze_n_bits(
@@ -356,8 +356,9 @@ impl<F: PrimeField + PrimeFieldBits, const T: usize, const RATE: usize> Poseidon
         Ok(res)
     }
 
-    pub fn update(&mut self, inputs: &[WrapValue<F>]) {
-        self.buf.extend_from_slice(inputs)
+    pub fn update(&mut self, inputs: &[WrapValue<F>]) -> &mut Self {
+        self.buf.extend_from_slice(inputs);
+        self
     }
 
     pub fn squeeze(&mut self, ctx: &mut RegionCtx<'_, F>) -> Result<AssignedValue<F>, Error> {


### PR DESCRIPTION
- feat(ivc): finalize `StepCircuitExt::synthesize`
- feat(mg): impl `WrapValue::from_assigned_point`
- feat(ivc): `AssignedRelaxedPlonkInstance::absorb_into`
- feat(ivc): add assigned input witness into folding result

Finalized 'StepCircuitExt', the result now includes all the context needed for subsequent IVC work.

Part of #32 