### PR TITLE
docs: add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+<!-- The most simplified version of Conventional Commits for PR titles. -->
+<!-- allowed prefixes: `feat`, `fix`, `chore`, `ci`, `docs`, `test` -->
+<!-- module names: the full name of the top-level module whose modifications were the reason for creating the PR or an accepted abbreviation, which should be specified in the rustdoc of the corresponding module -->
+
+**Why?**
+<!-- It makes more sense to add a link to the issue here, adding context as to whether this PR is the final or partial insertion of it. If there is no issue, there should be a short description of why the change is needed here -->
+
+**What?**
+<!-- A short description of what this PR brings to the project. For example "split module A into two parts" or "added implementation of B". -->
+
+**How?**
+<!-- An explanation of how it was done. This paragraph should be the context for reading already diff, so that the reviewer keeps in mind that these changes were made in this way for such purposes. -->
+
+<!-- BREAKING_CHANGE: after stabilization -->
+<!-- **Tested?** section after stabilization -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,4 @@
+<!-- Please read https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr for general guidance-->
 <!-- The most simplified version of Conventional Commits for PR titles. -->
 <!-- allowed prefixes: `feat`, `fix`, `chore`, `ci`, `docs`, `test` -->
 <!-- module names: the full name of the top-level module whose modifications were the reason for creating the PR or an accepted abbreviation, which should be specified in the rustdoc of the corresponding module -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-<!-- Please read https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr for general guidance-->
+<!-- Please read https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr for general guidance -->
 <!-- The most simplified version of Conventional Commits for PR titles. -->
 <!-- allowed prefixes: `feat`, `fix`, `chore`, `ci`, `docs`, `test` -->
 <!-- module names: the full name of the top-level module whose modifications were the reason for creating the PR or an accepted abbreviation, which should be specified in the rustdoc of the corresponding module -->
@@ -7,11 +7,11 @@
 <!-- Link to the related issue(s). If there's no issue, briefly explain the need for this change. -->
 
 **Changes Overview**
-<!-- Concisely describe the changes and their impact on the project, point out anything you want reviewers to scrutinize-->
+<!-- Concisely describe the changes and their impact on the project, point out anything you want reviewers to scrutinize -->
 
 <!-- Optional Sections -->
-<!--**Implementation Details**-->
-<!-- For non-trivial changes, provide context on the approach taken, focusing on the rationale behind key decisions.-->
+<!-- **Implementation Details** -->
+<!-- For non-trivial changes, provide context on the approach taken, focusing on the rationale behind key decisions. -->
 
-<!--**Testing plan**-->
-<!-- Detail the testing performed to ensure reliability and performance.-->
+<!-- **Testing plan** -->
+<!-- Detail the testing performed to ensure reliability and performance. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,14 +2,15 @@
 <!-- allowed prefixes: `feat`, `fix`, `chore`, `ci`, `docs`, `test` -->
 <!-- module names: the full name of the top-level module whose modifications were the reason for creating the PR or an accepted abbreviation, which should be specified in the rustdoc of the corresponding module -->
 
-**Why?**
-<!-- It makes more sense to add a link to the issue here, adding context as to whether this PR is the final or partial insertion of it. If there is no issue, there should be a short description of why the change is needed here -->
+**Issue Link / Motivation**
+<!-- Link to the related issue(s). If there's no issue, briefly explain the need for this change. -->
 
-**What?**
-<!-- A short description of what this PR brings to the project. For example "split module A into two parts" or "added implementation of B". -->
+**Changes Overview**
+<!-- Concisely describe the changes and their impact on the project, point out anything you want reviewers to scrutinize-->
 
-**How?**
-<!-- An explanation of how it was done. This paragraph should be the context for reading already diff, so that the reviewer keeps in mind that these changes were made in this way for such purposes. -->
+<!-- Optional Sections -->
+<!--**Implementation Details**-->
+<!-- For non-trivial changes, provide context on the approach taken, focusing on the rationale behind key decisions.-->
 
-<!-- BREAKING_CHANGE: after stabilization -->
-<!-- **Tested?** section after stabilization -->
+<!--**Testing plan**-->
+<!-- Detail the testing performed to ensure reliability and performance.-->


### PR DESCRIPTION
**Why?**
As the company is now unifying engineering practices, we are developing a common template that will allow us to simply and quickly describe PR in a consistent way.

**What?**
A markdown template for new PRs 

**How?**
- The template itself is as simple as possible and doesn't require any big descriptions. It simply allows to unify questions that may arise among contributors to the repository, as well as among observers.
- The github-template mechanism described in the [documentation](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository) is used