### PR TITLE
feat(ivc): impl `PublicParams::serialize`

### DIFF
--- a/examples/sha256/main.rs
+++ b/examples/sha256/main.rs
@@ -16,7 +16,7 @@ use grumpkin::G1 as C2;
 
 use sirius::{
     ivc::{step_circuit, PublicParams, SimpleFloorPlanner, StepCircuit, SynthesisError, IVC},
-    poseidon::{poseidon_circuit, ROCircuitTrait},
+    poseidon::{self, ROPair},
     table::TableData,
 };
 
@@ -318,11 +318,10 @@ impl<F: PrimeField> StepCircuit<ARITY, F> for TestSha256Circuit<F> {
     }
 }
 
-type RandomOracle<const T: usize, const RATE: usize, F> =
-    poseidon_circuit::PoseidonChip<F, T, RATE>;
+type RandomOracle<const T: usize, const RATE: usize> = poseidon::PoseidonRO<T, RATE>;
 
 type RandomOracleConstant<const T: usize, const RATE: usize, F> =
-    <RandomOracle<T, RATE, F> as ROCircuitTrait<F>>::Args;
+    <RandomOracle<T, RATE> as ROPair<F>>::Args;
 
 const LIMB_WIDTH: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(32) };
 const LIMBS_COUNT_LIMIT: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(10) };
@@ -342,24 +341,24 @@ fn main() {
     let _cs1 = TableData::<<C1 as CurveExt>::Base>::new(11, vec![]);
     let _cs2 = TableData::<<C2 as CurveExt>::Base>::new(11, vec![]);
 
-    let spec1 = RandomOracleConstant::<5, 5, <C1 as CurveExt>::Base>::new(10, 10);
-    let spec2 = RandomOracleConstant::<5, 5, <C2 as CurveExt>::Base>::new(10, 10);
+    let primary_spec = RandomOracleConstant::<5, 5, <C2 as CurveExt>::Base>::new(10, 10);
+    let secondary_spec = RandomOracleConstant::<5, 5, <C1 as CurveExt>::Base>::new(10, 10);
 
-    let pp = PublicParams::<
-        ARITY,
-        ARITY,
-        C1Affine,
-        C2Affine,
-        RandomOracle<5, 5, <C1 as CurveExt>::Base>,
-        RandomOracle<5, 5, <C2 as CurveExt>::Base>,
-    >::new(LIMB_WIDTH, LIMBS_COUNT_LIMIT, &sc1, spec1, &sc2, spec2);
+    const K: usize = 20;
+    let mut pp = PublicParams::<C1Affine, C2Affine, RandomOracle<5, 5>, RandomOracle<5, 5>>::new(
+        K as u32,
+        primary_spec,
+        secondary_spec,
+        LIMB_WIDTH,
+        LIMBS_COUNT_LIMIT,
+    );
 
     let mut ivc = IVC::new(
-        &pp,
+        &mut pp,
         sc1,
-        array::from_fn(|i| C1Scalar::from_u128(i as u128)),
-        sc2,
         array::from_fn(|i| C2Scalar::from_u128(i as u128)),
+        sc2,
+        array::from_fn(|i| C1Scalar::from_u128(i as u128)),
     )
     .unwrap();
 

--- a/src/commitment.rs
+++ b/src/commitment.rs
@@ -4,11 +4,13 @@ use digest::{ExtendableOutput, Update};
 use group::Curve;
 use halo2_proofs::arithmetic::{best_multiexp, CurveAffine, CurveExt};
 use rayon::prelude::*;
+use serde::Serialize;
 use sha3::Shake256;
 
 use crate::util::parallelize;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
+#[serde(bound(serialize = "C: Serialize"))]
 pub struct CommitmentKey<C: CurveAffine> {
     ck: Vec<C>,
 }

--- a/src/ivc/mod.rs
+++ b/src/ivc/mod.rs
@@ -1,6 +1,9 @@
 pub mod step_circuit;
 
 mod floor_planner;
-mod incrementally_verifiable_computation;
-pub use incrementally_verifiable_computation::*;
 mod fold_relaxed_plonk_instance_chip;
+mod incrementally_verifiable_computation;
+mod public_params;
+
+pub use incrementally_verifiable_computation::*;
+pub use public_params::PublicParams;

--- a/src/ivc/public_params.rs
+++ b/src/ivc/public_params.rs
@@ -1,0 +1,236 @@
+use std::{fmt, num::NonZeroUsize};
+
+use ff::{FromUniformBytes, PrimeFieldBits};
+use group::prime::PrimeCurveAffine;
+use halo2curves::CurveAffine;
+use serde::Serialize;
+
+use crate::{
+    commitment::CommitmentKey,
+    digest::{self, DigestToCurve},
+    plonk::PlonkStructure,
+    poseidon::ROPair,
+    table::TableData,
+};
+
+use super::step_circuit::SynthesizeStepParams;
+
+pub(crate) struct CircuitPublicParams<C, RP>
+where
+    C: CurveAffine,
+    C::Base: PrimeFieldBits + FromUniformBytes<64>,
+    RP: ROPair<C::Base>,
+{
+    pub ck: CommitmentKey<C>,
+    pub params: SynthesizeStepParams<C, RP::OnCircuit>,
+    pub td: TableData<C::Base>,
+}
+
+impl<C: fmt::Debug, RP> fmt::Debug for CircuitPublicParams<C, RP>
+where
+    C: CurveAffine,
+    C::Base: PrimeFieldBits + FromUniformBytes<64>,
+    RP: ROPair<C::Base>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CircuitPublicParams")
+            .field("ck", &self.ck)
+            .field("params", &self.params)
+            .field("td", &self.td)
+            .finish()
+    }
+}
+
+impl<C, RP> CircuitPublicParams<C, RP>
+where
+    C: CurveAffine,
+    C::Base: PrimeFieldBits + FromUniformBytes<64>,
+    RP: ROPair<C::Base>,
+{
+    fn new(
+        k: u32,
+        is_primary_circuit: bool,
+        ro_constant: RP::Args,
+        limb_width: NonZeroUsize,
+        n_limbs: NonZeroUsize,
+    ) -> Self {
+        Self {
+            ck: CommitmentKey::setup(k as usize, b"step circuit"),
+            td: TableData::new(k, vec![]),
+            params: SynthesizeStepParams {
+                limb_width,
+                n_limbs,
+                is_primary_circuit,
+                ro_constant,
+            },
+        }
+    }
+}
+
+pub struct PublicParams<C1, C2, RP1, RP2>
+where
+    C1: CurveAffine<Base = <C2 as PrimeCurveAffine>::Scalar> + Serialize,
+    C2: CurveAffine<Base = <C1 as PrimeCurveAffine>::Scalar> + Serialize,
+
+    C1::Base: PrimeFieldBits + FromUniformBytes<64> + Serialize,
+    C1::Scalar: PrimeFieldBits + FromUniformBytes<64> + Serialize,
+
+    RP1: ROPair<C1::Base>,
+    RP2: ROPair<C2::Base>,
+{
+    pub(crate) primary: CircuitPublicParams<C2, RP2>,
+    pub(crate) secondary: CircuitPublicParams<C1, RP1>,
+}
+
+impl<C1: fmt::Debug, C2: fmt::Debug, RP1, RP2> fmt::Debug for PublicParams<C1, C2, RP1, RP2>
+where
+    C1: CurveAffine<Base = <C2 as PrimeCurveAffine>::Scalar> + Serialize,
+    C2: CurveAffine<Base = <C1 as PrimeCurveAffine>::Scalar> + Serialize,
+    C1::Base: PrimeFieldBits + FromUniformBytes<64> + Serialize,
+    C2::Base: PrimeFieldBits + FromUniformBytes<64> + Serialize,
+    RP1: ROPair<C1::Base>,
+    RP2: ROPair<C2::Base>,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PublicParams")
+            .field("primary", &self.primary)
+            .field("secondary", &self.secondary)
+            .finish()
+    }
+}
+
+impl<C1, C2, RP1, RP2> serde::Serialize for PublicParams<C1, C2, RP1, RP2>
+where
+    C1: CurveAffine<Base = <C2 as PrimeCurveAffine>::Scalar> + Serialize,
+    C2: CurveAffine<Base = <C1 as PrimeCurveAffine>::Scalar> + Serialize,
+
+    C1::Base: PrimeFieldBits + FromUniformBytes<64> + Serialize,
+    C2::Base: PrimeFieldBits + FromUniformBytes<64> + Serialize,
+
+    RP1: ROPair<C1::Base>,
+    RP2: ROPair<C2::Base>,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        #[derive(serde::Serialize)]
+        #[serde(bound(serialize = ""))]
+        struct Wrapper<'l, C1, C2, RP1, RP2>
+        where
+            C1: CurveAffine<Base = <C2 as PrimeCurveAffine>::Scalar> + Serialize,
+            C2: CurveAffine<Base = <C1 as PrimeCurveAffine>::Scalar> + Serialize,
+
+            C1::Base: PrimeFieldBits + FromUniformBytes<64> + Serialize,
+            C2::Base: PrimeFieldBits + FromUniformBytes<64> + Serialize,
+
+            RP1: ROPair<C1::Base>,
+            RP2: ROPair<C2::Base>,
+        {
+            primary_ck: &'l CommitmentKey<C2>,
+            primary_params: &'l SynthesizeStepParams<C2, RP2::OnCircuit>,
+            primary_structure: PlonkStructure<C1>,
+
+            secondary_ck: &'l CommitmentKey<C1>,
+            secondary_params: &'l SynthesizeStepParams<C1, RP1::OnCircuit>,
+            secondary_structure: PlonkStructure<C2>,
+        }
+
+        Wrapper::<'_, C1, C2, RP1, RP2> {
+            primary_params: &self.primary.params,
+            primary_ck: &self.primary.ck,
+            primary_structure: self
+                .primary
+                .td
+                .plonk_structure(&self.secondary.ck)
+                .unwrap_or_default(),
+
+            secondary_params: &self.secondary.params,
+            secondary_ck: &self.secondary.ck,
+            secondary_structure: self
+                .secondary
+                .td
+                .plonk_structure(&self.primary.ck)
+                .unwrap_or_default(),
+        }
+        .serialize(serializer)
+    }
+}
+
+impl<C1, C2, R1, R2> PublicParams<C1, C2, R1, R2>
+where
+    C1: CurveAffine<Base = <C2 as PrimeCurveAffine>::Scalar> + Serialize,
+    C2: CurveAffine<Base = <C1 as PrimeCurveAffine>::Scalar> + Serialize,
+
+    C1::Base: PrimeFieldBits + FromUniformBytes<64> + Serialize,
+    C2::Base: PrimeFieldBits + FromUniformBytes<64> + Serialize,
+
+    R1: ROPair<C1::Base>,
+    R2: ROPair<C2::Base>,
+{
+    pub fn new(
+        k: u32,
+        primary_ro_constant: R2::Args,
+        secondary_ro_constant: R1::Args,
+        limb_width: NonZeroUsize,
+        limbs_count_limit: NonZeroUsize,
+    ) -> Self {
+        Self {
+            primary: CircuitPublicParams::<C2, _>::new(
+                k,
+                true,
+                primary_ro_constant,
+                limb_width,
+                limbs_count_limit,
+            ),
+            secondary: CircuitPublicParams::<C1, _>::new(
+                k,
+                false,
+                secondary_ro_constant,
+                limb_width,
+                limbs_count_limit,
+            ),
+        }
+    }
+
+    pub fn digest<C: CurveAffine>(&self) -> Result<C, crate::ivc::Error> {
+        digest::DefaultHasher::digest_to_curve(self).map_err(crate::ivc::Error::WhileHash)
+    }
+}
+#[cfg(test)]
+mod pp_test {
+    use halo2curves::{bn256, grumpkin, CurveExt};
+
+    use bn256::G1 as C1;
+    use grumpkin::G1 as C2;
+
+    use super::*;
+
+    type C1Affine = <C1 as halo2curves::group::prime::PrimeCurve>::Affine;
+    type C2Affine = <C2 as halo2curves::group::prime::PrimeCurve>::Affine;
+
+    const LIMB_WIDTH: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(32) };
+    const LIMBS_COUNT_LIMIT: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(10) };
+
+    type RandomOracle<const T: usize, const RATE: usize> = crate::poseidon::PoseidonRO<T, RATE>;
+
+    type RandomOracleConstant<const T: usize, const RATE: usize, F> =
+        <RandomOracle<T, RATE> as ROPair<F>>::Args;
+
+    #[test]
+    fn digest() {
+        let spec1 = RandomOracleConstant::<5, 4, <C1 as CurveExt>::Base>::new(10, 10);
+        let spec2 = RandomOracleConstant::<5, 4, <C2 as CurveExt>::Base>::new(10, 10);
+
+        const K: usize = 5;
+        PublicParams::<C1Affine, C2Affine, RandomOracle<5, 4>, RandomOracle<5, 4>>::new(
+            K as u32,
+            spec2,
+            spec1,
+            LIMB_WIDTH,
+            LIMBS_COUNT_LIMIT,
+        )
+        .digest::<C1Affine>()
+        .unwrap();
+    }
+}

--- a/src/nifs/tests.rs
+++ b/src/nifs/tests.rs
@@ -41,7 +41,7 @@ where
     const R_F: usize = 4;
     const R_P: usize = 3;
 
-    let S = td1.plonk_structure(ck);
+    let S = td1.plonk_structure(ck).unwrap();
     let mut f_U =
         RelaxedPlonkInstance::new(td1.instance.len(), S.num_challenges, S.round_sizes.len());
     let mut f_W = RelaxedPlonkWitness::new(td1.k, &S.round_sizes);

--- a/src/nifs/vanilla.rs
+++ b/src/nifs/vanilla.rs
@@ -163,7 +163,7 @@ impl<C: CurveAffine, RO: ROTrait<C::Base>> VanillaFS<C, RO> {
         Error,
     > {
         // TODO: hash gate into ro (#85)
-        let S = td.plonk_structure(ck);
+        let S = td.plonk_structure(ck).unwrap();
 
         let (U2, W2) = td.run_sps_protocol(ck, ro_nark, S.num_challenges)?;
         let (cross_terms, cross_term_commits) = Self::commit_cross_terms(ck, &S, U1, W1, &U2, &W2)?;

--- a/src/plonk/lookup.rs
+++ b/src/plonk/lookup.rs
@@ -36,18 +36,20 @@
 //!
 //! Please see (#34)[https://github.com/snarkify/sirius/issues/34] for details on notations.
 //!
+use std::array;
 
-use crate::concat_vec;
-use crate::plonk::eval::Error;
 use ff::PrimeField;
 use halo2_proofs::{plonk::ConstraintSystem, poly::Rotation};
 use itertools::Itertools;
 use rayon::prelude::*;
-use std::array;
+use serde::Serialize;
 
 use crate::{
-    plonk::eval::{Eval, LookupEvalDomain},
-    plonk::util::compress_halo2_expression,
+    concat_vec,
+    plonk::{
+        eval::{Error, Eval, LookupEvalDomain},
+        util::compress_halo2_expression,
+    },
     polynomial::{Expression, Query},
     table::TableData,
 };
@@ -65,7 +67,7 @@ use crate::{
 /// into a single (i.e. non-vector) Expression:
 /// - lookup_poly = L(x_1,...,x_a) = a_1 + a_2*r + a_3*r^2 + ...
 /// - table_poly  = T(y_1,...,y_b) = t_1 + t_2*r + t_3*r^2 + ...
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct Arguments<F: PrimeField> {
     /// vector of the compressed lookup expressions
     /// L_i(x_1,...,x_{a_i})

--- a/src/polynomial/mod.rs
+++ b/src/polynomial/mod.rs
@@ -8,12 +8,13 @@ use std::{
 
 use ff::PrimeField;
 use halo2_proofs::{plonk::Expression as PE, poly::Rotation};
+use serde::Serialize;
 
 use crate::util::trim_leading_zeros;
 
 pub mod sparse;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
 pub enum ColumnIndex {
     Challenge { column_index: usize },
     Polynominal { rotation: i32, column_index: usize },
@@ -38,13 +39,21 @@ impl Ord for ColumnIndex {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize)]
 pub struct Query {
     pub index: usize,
+    #[serde(serialize_with = "serialize_rotation")]
     pub rotation: Rotation,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+fn serialize_rotation<S: serde::ser::Serializer>(
+    v: &Rotation,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    v.0.serialize(serializer)
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub enum Expression<F> {
     Constant(F),
     Polynomial(Query),
@@ -341,7 +350,7 @@ impl_expression_ops!(Mul, mul, Product, Expression<F>, std::convert::identity);
 /// index_to_poly is mapping from i to (rotation, column_index, type)
 /// poly_to_index is mapping from (rotation, column_index, type) to i \in [0,..,n-1]
 /// type has value either CHALLENGE_TYPE or POLYNOMIAL_TYPE
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct Monomial<F: PrimeField> {
     pub(crate) arity: usize,
     // poly or challenge: (rotation, column_index, type)
@@ -567,7 +576,7 @@ impl<F: PrimeField> Ord for Monomial<F> {
     }
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Serialize, Default)]
 pub struct MultiPolynomial<F: PrimeField> {
     pub(crate) arity: usize,
     pub(crate) monomials: Vec<Monomial<F>>,

--- a/src/poseidon/mod.rs
+++ b/src/poseidon/mod.rs
@@ -9,11 +9,14 @@ pub use spec::Spec;
 
 pub struct PoseidonRO<const T: usize, const RATE: usize>;
 
-impl<const T: usize, const RATE: usize, F: ff::PrimeField> ROPair<F> for PoseidonRO<T, RATE>
+impl<const T: usize, const RATE: usize, F: serde::Serialize + ff::PrimeField> ROPair<F>
+    for PoseidonRO<T, RATE>
 where
     F: ff::PrimeFieldBits + ff::FromUniformBytes<64>,
 {
     type Args = Spec<F, T, RATE>;
+    type Config = crate::main_gate::MainGateConfig<T>;
+
     type OnCircuit = poseidon_circuit::PoseidonChip<F, T, RATE>;
     type OffCircuit = poseidon_hash::PoseidonHash<F, T, RATE>;
 }

--- a/src/poseidon/random_oracle.rs
+++ b/src/poseidon/random_oracle.rs
@@ -1,4 +1,4 @@
-use std::num::NonZeroUsize;
+use std::{fmt, num::NonZeroUsize};
 
 use ff::{FromUniformBytes, PrimeField, PrimeFieldBits};
 use halo2_proofs::{arithmetic::CurveAffine, plonk::Error};
@@ -39,7 +39,7 @@ pub trait ROTrait<F: PrimeField> {
 pub trait ROCircuitTrait<F: PrimeFieldBits + FromUniformBytes<64>> {
     /// Associated type represents the arguments required to initialize the hash function in the circuit.
     /// These could include various parameters like the number of rounds, the internal state size, etc.
-    type Args: Clone;
+    type Args: fmt::Debug + Clone;
 
     /// Associated type represents the configuration settings for the hash function within the circuit.
     ///
@@ -82,8 +82,9 @@ where
     F: ff::PrimeFieldBits + ff::FromUniformBytes<64>,
 {
     /// Argument for creating on-circuit & off-circuit versions of oracles
-    type Args;
+    type Args: fmt::Debug + serde::Serialize;
+    type Config;
 
     type OffCircuit: ROTrait<F, Constants = Self::Args>;
-    type OnCircuit: ROCircuitTrait<F, Args = Self::Args>;
+    type OnCircuit: ROCircuitTrait<F, Args = Self::Args, Config = Self::Config>;
 }


### PR DESCRIPTION
**Why?**
Close #85 

**What?**
- impl `PulicParams::new`
- impl `PublicParams::serialize`
- create `pulic_params` module

**How?**
In https://github.com/snarkify/halo2/pull/6#issuecomment-1903237566 @chaosma propose instead of serialization `TableData` fold in first into `PlonkStructure`. This PR is the epitome of that idea.

One nuance of the implementation is that `plonk_structure` can be created only for `Scalar` field, so we need to have paired curves for serialization, so it is done at the highest level of `PublicParams` rather than at the `CircuitPublicParams` level

Since the code will turn out to be voluminous, it is allocated in a separate module