### PR TITLE
refactor(poseidon): rm excessive generic

### DIFF
--- a/src/nifs/tests.rs
+++ b/src/nifs/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::nifs::Error as NIFSError;
 use crate::util::create_ro;
-use ff::PrimeField;
+use ff::{PrimeField, PrimeFieldBits};
 use halo2_proofs::{
     circuit::{AssignedCell, Layouter, SimpleFloorPlanner, Value},
     plonk::{Advice, Circuit, Column, ConstraintSystem, Error, Instance, Selector},
@@ -32,7 +32,7 @@ fn fold_instances<C, F1, F2>(
 where
     C: CurveAffine<ScalarExt = F1, Base = F2>,
     F1: PrimeField,
-    F2: PrimeField + FromUniformBytes<64>,
+    F2: PrimeFieldBits + FromUniformBytes<64>,
 {
     const T: usize = 3;
     const RATE: usize = 2;
@@ -43,17 +43,17 @@ where
     let mut f_U =
         RelaxedPlonkInstance::new(td1.instance.len(), S.num_challenges, S.round_sizes.len());
     let mut f_W = RelaxedPlonkWitness::new(td1.k, &S.round_sizes);
-    let mut ro_nark_prover = create_ro::<C, F2, T, RATE, R_F, R_P>();
-    let mut ro_nark_prepare = create_ro::<C, F2, T, RATE, R_F, R_P>();
-    let mut ro_nark_verifier = create_ro::<C, F2, T, RATE, R_F, R_P>();
-    let mut ro_nark_decider = create_ro::<C, F2, T, RATE, R_F, R_P>();
+    let mut ro_nark_prover = create_ro::<C, T, RATE, R_F, R_P>();
+    let mut ro_nark_prepare = create_ro::<C, T, RATE, R_F, R_P>();
+    let mut ro_nark_verifier = create_ro::<C, T, RATE, R_F, R_P>();
+    let mut ro_nark_decider = create_ro::<C, T, RATE, R_F, R_P>();
     let (U1, W1) = td1
         .run_sps_protocol(ck, &mut ro_nark_prepare, S.num_challenges)
         .unwrap();
     assert_eq!(S.is_sat(ck, &mut ro_nark_decider, &U1, &W1).err(), None);
 
-    let mut ro_acc_prover = create_ro::<C, F2, T, RATE, R_F, R_P>();
-    let mut ro_acc_verifier = create_ro::<C, F2, T, RATE, R_F, R_P>();
+    let mut ro_acc_prover = create_ro::<C, T, RATE, R_F, R_P>();
+    let mut ro_acc_verifier = create_ro::<C, T, RATE, R_F, R_P>();
     let (nifs, (U_from_prove, W)) =
         NIFS::prove(ck, &mut ro_nark_prover, &mut ro_acc_prover, td1, &f_U, &f_W)?;
     let U_from_verify = nifs

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,7 @@
 use crate::main_gate::AssignedValue;
 use crate::poseidon::PoseidonHash;
 use crate::poseidon::ROTrait;
-use ff::{BatchInvert, Field, FromUniformBytes, PrimeField};
+use ff::{BatchInvert, Field, PrimeField};
 use halo2_proofs::plonk::Assigned;
 use halo2curves::CurveAffine;
 use num_bigint::BigUint;
@@ -193,15 +193,17 @@ pub(crate) fn concatenate_with_padding<F: PrimeField>(vs: &[Vec<F>], pad_size: u
 }
 
 pub(crate) fn create_ro<
-    C: CurveAffine<Base = F>,
-    F: PrimeField + FromUniformBytes<64>,
+    C: CurveAffine,
     const T: usize,
     const RATE: usize,
     const R_F: usize,
     const R_P: usize,
->() -> PoseidonHash<C, F, T, RATE> {
-    let spec = Spec::<F, T, RATE>::new(R_F, R_P);
-    PoseidonHash::<C, F, T, RATE>::new(spec)
+>() -> PoseidonHash<C, T, RATE>
+where
+    C::Base: ff::PrimeFieldBits + ff::FromUniformBytes<64>,
+{
+    let spec = Spec::<C::Base, T, RATE>::new(R_F, R_P);
+    PoseidonHash::<C, T, RATE>::new(spec)
 }
 
 /// Concatenate N vectors


### PR DESCRIPTION
**Why?**
While implementing IVC I needed to link two random oracle - off-circuit & on-circuit. I created a new trait that allows you to bind from and saw the redundancy in the type definition. It makes no sense to have `F` which is equal to `C::Base`, you can use `C::Base` itself

Since this affects a component outside of IVC, I've separated these changes into a separate PR

**What?**
Refactoring: remove extra generic type from `ROTrait`

**How?**

**Before**
```rust
pub struct PoseidonHash<
    C: CurveAffine<Base = F>,
    F: PrimeField + FromUniformBytes<64>,
    const T: usize,
    const RATE: usize,
>
```

**After**
```rust
pub struct PoseidonHash<C: CurveAffine, const T: usize, const RATE: usize>
where
    C::Base: ff::PrimeFieldBits + ff::FromUniformBytes<64>,
```