### PR TITLE
feat(nifs): pass `pp_digest` as parameter

### DIFF
--- a/src/ivc/fold_relaxed_plonk_instance_chip.rs
+++ b/src/ivc/fold_relaxed_plonk_instance_chip.rs
@@ -1813,9 +1813,6 @@ mod tests {
         let mut td = TableData::<ScalarExt>::new(K as u32, vec![]);
         let _config = td.prepare_assembly(MainGate::<ScalarExt, T>::configure);
 
-        let mut structure = td.plonk_structure(&CommitmentKey::<C1>::setup(K, b"mock"));
-
-        structure.fixed_commitment = pp_hash;
-        NIFS::generate_challenge(&mut ro, &structure, relaxed, input, cross_term_commits).unwrap()
+        NIFS::generate_challenge(pp_hash, &mut ro, relaxed, input, cross_term_commits).unwrap()
     }
 }

--- a/src/nifs/tests.rs
+++ b/src/nifs/tests.rs
@@ -26,6 +26,7 @@ use std::marker::PhantomData;
 /// copy constrains relation
 fn fold_instances<C, F1, F2>(
     ck: &CommitmentKey<C>,
+    pp_digest: &C,
     td1: &TableData<F1>,
     td2: &TableData<F1>,
 ) -> Result<(), NIFSError>
@@ -54,10 +55,24 @@ where
 
     let mut ro_acc_prover = create_ro::<C, T, RATE, R_F, R_P>();
     let mut ro_acc_verifier = create_ro::<C, T, RATE, R_F, R_P>();
-    let (nifs, (U_from_prove, W)) =
-        NIFS::prove(ck, &mut ro_nark_prover, &mut ro_acc_prover, td1, &f_U, &f_W)?;
+    let (nifs, (U_from_prove, W)) = NIFS::prove(
+        ck,
+        pp_digest,
+        &mut ro_nark_prover,
+        &mut ro_acc_prover,
+        td1,
+        &f_U,
+        &f_W,
+    )?;
     let U_from_verify = nifs
-        .verify(&mut ro_nark_verifier, &mut ro_acc_verifier, &S, f_U, U1)
+        .verify(
+            pp_digest,
+            &mut ro_nark_verifier,
+            &mut ro_acc_verifier,
+            &S,
+            f_U,
+            U1,
+        )
         .unwrap();
     assert_eq!(U_from_prove, U_from_verify);
 
@@ -71,10 +86,24 @@ where
         .unwrap();
     assert_eq!(S.is_sat(ck, &mut ro_nark_decider, &U1, &W1).err(), None);
 
-    let (nifs, (U_from_prove, _W)) =
-        NIFS::prove(ck, &mut ro_nark_prover, &mut ro_acc_prover, td2, &f_U, &f_W)?;
+    let (nifs, (U_from_prove, _W)) = NIFS::prove(
+        ck,
+        pp_digest,
+        &mut ro_nark_prover,
+        &mut ro_acc_prover,
+        td2,
+        &f_U,
+        &f_W,
+    )?;
     let U_from_verify = nifs
-        .verify(&mut ro_nark_verifier, &mut ro_acc_verifier, &S, f_U, U1)
+        .verify(
+            pp_digest,
+            &mut ro_nark_verifier,
+            &mut ro_acc_verifier,
+            &S,
+            f_U,
+            U1,
+        )
         .unwrap();
     assert_eq!(U_from_prove, U_from_verify);
 
@@ -176,7 +205,7 @@ mod zero_round_test {
         let p2 = smallest_power(td1.cs.num_selectors() + td1.cs.num_fixed_columns(), K);
         let ck = CommitmentKey::<G1Affine>::setup(p1.max(p2), b"zero_round_test");
 
-        fold_instances(&ck, &td1, &td2)
+        fold_instances(&ck, &G1Affine::default(), &td1, &td2)
     }
 }
 
@@ -364,7 +393,7 @@ mod one_round_test {
         let p2 = smallest_power(td1.cs.num_selectors() + td1.cs.num_fixed_columns(), K);
         let ck = CommitmentKey::<G1Affine>::setup(p1.max(p2), b"one_round_test");
 
-        fold_instances(&ck, &td1, &td2)
+        fold_instances(&ck, &G1Affine::default(), &td1, &td2)
     }
 }
 
@@ -673,6 +702,6 @@ mod three_rounds_test {
         let p2 = smallest_power(td1.cs.num_selectors() + td1.cs.num_fixed_columns(), K);
         let ck = CommitmentKey::<G1Affine>::setup(p1.max(p2), b"three_rounds_test");
 
-        fold_instances(&ck, &td1, &td2)
+        fold_instances(&ck, &G1Affine::default(), &td1, &td2)
     }
 }


### PR DESCRIPTION
In previous implementation, we use fixed_commitment to represent circuit information which is not enough. We have to include custom gates and other necessary metadata. See issue #85.

To do so, we implemented digest method to calculate the hash of public parameters, see #112 
We can pass the digest hash as parameter to the `NIFS::prove` and `NIFS::verify`. However, there is one minor difficulty is that we have to represent the hash we generate as BigInt limbs. It turned out we can easily solve this by commit the hash (as scalar) to a point in ECC curve.   

There are still work left to be done in future PR/PRs: 
(1) change `digest_to_f` to `digest_to_curve`, which can be simply achieved by one ecc scalar mul: `digest=hash_digest*commitment_key[0]`.
(2) remove the unnecessary fixed_commitment calculation.
(3) make a better digest method that avoid modify halo2 library

