### PR TITLE
feat(poseidon): serialize `Spec`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ rand = "0.8"
 halo2_proofs = { git = "https://github.com/snarkify/halo2", branch = "snarkify/dev" }
 ff = "0.13"
 group = "0.13"
-# pasta_curves = "0.5"
 sha3 = "0.10"
 bincode = "1.3"
 serde = { version = "1.0", features = ["derive"] }
@@ -18,19 +17,21 @@ num-traits = "0.2.16"
 digest = "0.10"
 
 rand_core = { version = "0.6", default-features = false }
-halo2curves = { git = 'https://github.com/privacy-scaling-explorations/halo2curves', tag = "0.4.0" }
+halo2curves = { git = 'https://github.com/privacy-scaling-explorations/halo2curves', tag = "v0.6.0", features = ["derive_serde"] }
 poseidon = { git = "https://github.com/privacy-scaling-explorations/poseidon", rev = "807f8f555313f726ca03bdf941f798098f488ba4" }
 log = "0.4.20"
 itertools = "0.11.0"
 bitter = "0.6.1"
 thiserror = "1.0.48"
 result-inspect = "0.3.0"
+serde_arrays = "0.1.0"
 
 [dev-dependencies]
 env_logger = "0.10.0"
 prettytable-rs = "0.10.0"
 test-log = "0.2.12"
 halo2_gadgets = { git = "https://github.com/snarkify/halo2", branch = "snarkify/dev", features = ["unstable"] }
+bincode = "1.3"
 
 [dev-dependencies.cargo-husky]
 version = "1"

--- a/src/ivc/fold_relaxed_plonk_instance_chip.rs
+++ b/src/ivc/fold_relaxed_plonk_instance_chip.rs
@@ -1061,10 +1061,10 @@ pub struct FoldResult<C: CurveAffine> {
 
 #[cfg(test)]
 mod tests {
+    use crate::poseidon::Spec;
     use bitter::{BitReader, LittleEndianReader};
     use halo2_proofs::circuit::{floor_planner::single_pass::SingleChipLayouter, Layouter, Value};
     use halo2curves::{bn256::G1Affine as C1, CurveAffine};
-    use poseidon::Spec;
     use rand::rngs::ThreadRng;
     use rand::Rng;
 

--- a/src/poseidon/mod.rs
+++ b/src/poseidon/mod.rs
@@ -1,100 +1,15 @@
-use std::num::NonZeroUsize;
-
-use crate::main_gate::{AssignedBit, RegionCtx, WrapValue};
-use ff::{FromUniformBytes, PrimeField, PrimeFieldBits};
-use halo2_proofs::{arithmetic::CurveAffine, plonk::Error};
-
 pub mod poseidon_circuit;
 pub mod poseidon_hash;
-use poseidon::Spec;
+pub mod random_oracle;
+mod spec;
+
 pub use poseidon_hash::PoseidonHash;
-
-/// A helper trait to obsorb different objects into RO
-pub trait AbsorbInRO<F: PrimeField, RO: ROTrait<F>> {
-    /// Absorbs the value in the provided RO
-    fn absorb_into(&self, ro: &mut RO);
-}
-
-/// A helper trait that defines the constants associated with a hash function
-pub trait ROConstantsTrait {
-    /// produces constants/parameters associated with the hash function
-    fn new(r_f: usize, r_p: usize) -> Self;
-}
-
-pub trait ROTrait<F: PrimeField> {
-    /// A type representing constants/parameters associated with the hash function
-    type Constants: ROConstantsTrait;
-
-    /// Initializes the hash function
-    fn new(constants: Self::Constants) -> Self;
-
-    /// Adds a base to the internal state
-    fn absorb_field(&mut self, element: F);
-
-    /// Adds a point to the internal state
-    fn absorb_point<C: CurveAffine<Base = F>>(&mut self, p: &C);
-
-    /// Returns a challenge by hashing the internal state
-    fn squeeze<C: CurveAffine<Base = F>>(&mut self, num_bits: NonZeroUsize) -> C::Scalar;
-}
-
-/// A helper trait that defines the behavior of a hash function used as a Random Oracle (RO)
-/// within a circuit.
-pub trait ROCircuitTrait<F: PrimeFieldBits + FromUniformBytes<64>> {
-    /// Associated type represents the arguments required to initialize the hash function in the circuit.
-    /// These could include various parameters like the number of rounds, the internal state size, etc.
-    type Args: Clone;
-
-    /// Associated type represents the configuration settings for the hash function within the circuit.
-    ///
-    /// This includes defining the layout of gates, wires, and other circuit-specific parameters necessary for
-    /// the hash function's operation within the proof system.
-    type Config;
-
-    /// Constructs a new instance of the random oracle circuit
-    fn new(config: Self::Config, args: Self::Args) -> Self;
-
-    /// Adds a scalar to the internal state
-    fn absorb_base(&mut self, base: WrapValue<F>) -> &mut Self;
-
-    /// Adds a point to the internal state
-    fn absorb_point(&mut self, point: [WrapValue<F>; 2]) -> &mut Self;
-
-    /// Adds elements of iterator of [`WrapValues`] to the internal state
-    fn absorb_iter<I>(&mut self, iter: impl Iterator<Item = I>) -> &mut Self
-    where
-        I: Into<WrapValue<F>>,
-    {
-        iter.for_each(|val| {
-            self.absorb_base(val.into());
-        });
-        self
-    }
-
-    /// Returns a challenge of `num_bits` by hashing the internal state
-    fn squeeze_n_bits(
-        &mut self,
-        ctx: &mut RegionCtx<'_, F>,
-        num_bits: NonZeroUsize,
-    ) -> Result<Vec<AssignedBit<F>>, Error>;
-}
-
-/// Random Oracle is represented as a pair of on-circuit & off-circuit types,
-/// allowing the use of a single generic.
-pub trait ROPair<F: PrimeField>
-where
-    F: ff::PrimeFieldBits + ff::FromUniformBytes<64>,
-{
-    /// Argument for creating on-circuit & off-circuit versions of oracles
-    type Args;
-
-    type OffCircuit: ROTrait<F, Constants = Self::Args>;
-    type OnCircuit: ROCircuitTrait<F, Args = Self::Args>;
-}
+pub use random_oracle::*;
+pub use spec::Spec;
 
 pub struct PoseidonRO<const T: usize, const RATE: usize>;
 
-impl<const T: usize, const RATE: usize, F: PrimeField> ROPair<F> for PoseidonRO<T, RATE>
+impl<const T: usize, const RATE: usize, F: ff::PrimeField> ROPair<F> for PoseidonRO<T, RATE>
 where
     F: ff::PrimeFieldBits + ff::FromUniformBytes<64>,
 {

--- a/src/poseidon/poseidon_circuit.rs
+++ b/src/poseidon/poseidon_circuit.rs
@@ -1,16 +1,18 @@
-use crate::{
-    constants::MAX_BITS,
-    main_gate::{AssignedBit, AssignedValue, MainGate, MainGateConfig, RegionCtx, WrapValue},
-};
+use std::{convert::TryInto, num::NonZeroUsize};
+
 use ff::{FromUniformBytes, PrimeField, PrimeFieldBits};
 use halo2_proofs::{
     circuit::{AssignedCell, Chip, Value},
     plonk::Error,
 };
-use poseidon::{self, Spec};
-use std::{convert::TryInto, num::NonZeroUsize};
+use poseidon::{self};
 
-use super::ROCircuitTrait;
+use crate::{
+    constants::MAX_BITS,
+    main_gate::{AssignedBit, AssignedValue, MainGate, MainGateConfig, RegionCtx, WrapValue},
+};
+
+use super::{ROCircuitTrait, Spec};
 
 pub struct PoseidonChip<F: PrimeFieldBits, const T: usize, const RATE: usize> {
     main_gate: MainGate<F, T>,
@@ -394,14 +396,20 @@ impl<F: PrimeField + PrimeFieldBits, const T: usize, const RATE: usize> Poseidon
 
 #[cfg(test)]
 mod tests {
+    use halo2_proofs::{
+        circuit::{Layouter, SimpleFloorPlanner},
+        plonk::{Circuit, Column, ConstraintSystem, Instance},
+    };
+    use halo2curves::{
+        group::ff::FromUniformBytes,
+        pasta::{EqAffine, Fp},
+    };
+
+    use crate::{
+        create_and_verify_proof, main_gate::MainGateConfig, poseidon::Spec, run_mock_prover_test,
+    };
+
     use super::*;
-    use crate::main_gate::MainGateConfig;
-    use crate::{create_and_verify_proof, run_mock_prover_test};
-    use halo2_proofs::circuit::{Layouter, SimpleFloorPlanner};
-    use halo2_proofs::plonk::{Circuit, Column, ConstraintSystem, Instance};
-    use halo2curves::group::ff::FromUniformBytes;
-    use halo2curves::pasta::{EqAffine, Fp};
-    use poseidon::Spec;
 
     const T: usize = 3;
     const RATE: usize = 2;

--- a/src/poseidon/poseidon_hash.rs
+++ b/src/poseidon/poseidon_hash.rs
@@ -1,10 +1,14 @@
-use crate::poseidon::{ROConstantsTrait, ROTrait};
-use crate::util::{bits_to_fe_le, fe_to_bits_le};
-use halo2_proofs::arithmetic::CurveAffine;
-use halo2curves::group::ff::{FromUniformBytes, PrimeField};
-use poseidon::{self, SparseMDSMatrix, Spec};
 use std::num::NonZeroUsize;
 use std::{iter, mem};
+
+use halo2_proofs::arithmetic::CurveAffine;
+use halo2curves::group::ff::{FromUniformBytes, PrimeField};
+use poseidon::{self, SparseMDSMatrix};
+
+use crate::poseidon::{ROConstantsTrait, ROTrait};
+use crate::util::{bits_to_fe_le, fe_to_bits_le};
+
+use super::Spec;
 
 // adapted from: https://github.com/privacy-scaling-explorations/snark-verifier
 

--- a/src/poseidon/random_oracle.rs
+++ b/src/poseidon/random_oracle.rs
@@ -1,0 +1,89 @@
+use std::num::NonZeroUsize;
+
+use ff::{FromUniformBytes, PrimeField, PrimeFieldBits};
+use halo2_proofs::{arithmetic::CurveAffine, plonk::Error};
+
+use crate::main_gate::{AssignedBit, RegionCtx, WrapValue};
+
+/// A helper trait to obsorb different objects into RO
+pub trait AbsorbInRO<F: PrimeField, RO: ROTrait<F>> {
+    /// Absorbs the value in the provided RO
+    fn absorb_into(&self, ro: &mut RO);
+}
+
+/// A helper trait that defines the constants associated with a hash function
+pub trait ROConstantsTrait {
+    /// produces constants/parameters associated with the hash function
+    fn new(r_f: usize, r_p: usize) -> Self;
+}
+
+pub trait ROTrait<F: PrimeField> {
+    /// A type representing constants/parameters associated with the hash function
+    type Constants: ROConstantsTrait;
+
+    /// Initializes the hash function
+    fn new(constants: Self::Constants) -> Self;
+
+    /// Adds a base to the internal state
+    fn absorb_field(&mut self, base: F);
+
+    /// Adds a point to the internal state
+    fn absorb_point<C: CurveAffine<Base = F>>(&mut self, p: &C);
+
+    /// Returns a challenge by hashing the internal state
+    fn squeeze<C: CurveAffine<Base = F>>(&mut self, num_bits: NonZeroUsize) -> C::Scalar;
+}
+
+/// A helper trait that defines the behavior of a hash function used as a Random Oracle (RO)
+/// within a circuit.
+pub trait ROCircuitTrait<F: PrimeFieldBits + FromUniformBytes<64>> {
+    /// Associated type represents the arguments required to initialize the hash function in the circuit.
+    /// These could include various parameters like the number of rounds, the internal state size, etc.
+    type Args: Clone;
+
+    /// Associated type represents the configuration settings for the hash function within the circuit.
+    ///
+    /// This includes defining the layout of gates, wires, and other circuit-specific parameters necessary for
+    /// the hash function's operation within the proof system.
+    type Config;
+
+    /// Constructs a new instance of the random oracle circuit
+    fn new(config: Self::Config, args: Self::Args) -> Self;
+
+    /// Adds a scalar to the internal state
+    fn absorb_base(&mut self, base: WrapValue<F>) -> &mut Self;
+
+    /// Adds a point to the internal state
+    fn absorb_point(&mut self, point: [WrapValue<F>; 2]) -> &mut Self;
+
+    /// Adds elements of iterator of [`WrapValues`] to the internal state
+    fn absorb_iter<I>(&mut self, iter: impl Iterator<Item = I>) -> &mut Self
+    where
+        I: Into<WrapValue<F>>,
+    {
+        iter.for_each(|val| {
+            self.absorb_base(val.into());
+        });
+        self
+    }
+
+    /// Returns a challenge of `num_bits` by hashing the internal state
+    fn squeeze_n_bits(
+        &mut self,
+        ctx: &mut RegionCtx<'_, F>,
+        num_bits: NonZeroUsize,
+    ) -> Result<Vec<AssignedBit<F>>, Error>;
+}
+
+/// Random Oracle is represented as a pair of on-circuit & off-circuit types,
+/// allowing the use of a single generic.
+pub trait ROPair<F: PrimeField>
+where
+    F: ff::PrimeFieldBits + ff::FromUniformBytes<64>,
+{
+    /// Argument for creating on-circuit & off-circuit versions of oracles
+    type Args;
+
+    type OffCircuit: ROTrait<F, Constants = Self::Args>;
+    type OnCircuit: ROCircuitTrait<F, Args = Self::Args>;
+}

--- a/src/poseidon/spec.rs
+++ b/src/poseidon/spec.rs
@@ -1,0 +1,145 @@
+use std::ops;
+
+use ff::FromUniformBytes;
+use serde::Serialize;
+
+#[derive(Clone, Debug)]
+pub struct Spec<F: ff::PrimeField, const T: usize, const RATE: usize>(
+    pub poseidon::Spec<F, T, RATE>,
+);
+
+impl<F: ff::PrimeField, const T: usize, const RATE: usize> Spec<F, T, RATE>
+where
+    F: FromUniformBytes<64>,
+{
+    pub fn new(r_f: usize, r_p: usize) -> Self {
+        Self(poseidon::Spec::new(r_f, r_p))
+    }
+}
+
+impl<F: ff::PrimeField, const T: usize, const RATE: usize> ops::Deref for Spec<F, T, RATE> {
+    type Target = poseidon::Spec<F, T, RATE>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<F: Serialize + ff::PrimeField, const T: usize, const RATE: usize> Serialize
+    for Spec<F, T, RATE>
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        #[derive(Serialize)]
+        struct SerializableArray<F: Serialize, const T: usize>(
+            #[serde(with = "serde_arrays")] [F; T],
+        );
+
+        #[derive(Serialize)]
+        struct SerializableMDSMatrix<F: Serialize, const T: usize, const RATE: usize> {
+            #[serde(with = "serde_arrays")]
+            rows: [SerializableArray<F, T>; T],
+        }
+
+        #[derive(Serialize)]
+        struct SerializableSparseMDSMatrix<F: Serialize, const T: usize, const RATE: usize> {
+            row: SerializableArray<F, T>,
+            col_hat: SerializableArray<F, RATE>,
+        }
+
+        #[derive(Serialize)]
+        struct SerializableMDSMatrices<F: Serialize, const T: usize, const RATE: usize> {
+            mds: SerializableMDSMatrix<F, T, RATE>,
+            pre_sparse_mds: SerializableMDSMatrix<F, T, RATE>,
+            sparse_matrices: Box<[SerializableSparseMDSMatrix<F, T, RATE>]>,
+        }
+
+        #[derive(Serialize)]
+        struct SerializableOptimizedConstants<F: Serialize, const T: usize> {
+            start: Box<[SerializableArray<F, T>]>,
+            partial: Box<[F]>,
+            end: Box<[SerializableArray<F, T>]>,
+        }
+        // Create a struct to hold serializable representations of Spec fields
+        #[derive(Serialize)]
+        struct SerializableSpec<F: Serialize, const T: usize, const RATE: usize> {
+            r_f: usize,
+            mds_matrices: SerializableMDSMatrices<F, T, RATE>,
+            constants: SerializableOptimizedConstants<F, T>,
+        }
+
+        let poseidon_spec = &self.0;
+        let r_f = poseidon_spec.r_f();
+        let mds_rows = poseidon_spec.mds_matrices().mds().rows();
+
+        let mds = SerializableMDSMatrix {
+            rows: mds_rows.map(SerializableArray),
+        };
+
+        let pre_sparse_mds = SerializableMDSMatrix {
+            rows: poseidon_spec
+                .mds_matrices()
+                .pre_sparse_mds()
+                .rows()
+                .map(|m| SerializableArray(m)),
+        };
+
+        let mds_matrices = SerializableMDSMatrices {
+            mds,
+            pre_sparse_mds,
+            sparse_matrices: poseidon_spec
+                .mds_matrices()
+                .sparse_matrices()
+                .iter()
+                .map(|sparse_matrix| SerializableSparseMDSMatrix {
+                    row: SerializableArray(*sparse_matrix.row()),
+                    col_hat: SerializableArray(*sparse_matrix.col_hat()),
+                })
+                .collect::<Box<[_]>>(),
+        };
+
+        let constants = SerializableOptimizedConstants {
+            start: poseidon_spec
+                .constants()
+                .start()
+                .iter()
+                .copied()
+                .map(SerializableArray)
+                .collect(),
+            partial: poseidon_spec
+                .constants()
+                .partial()
+                .iter()
+                .copied()
+                .collect(),
+            end: poseidon_spec
+                .constants()
+                .end()
+                .iter()
+                .copied()
+                .map(SerializableArray)
+                .collect(),
+        };
+
+        SerializableSpec {
+            r_f,
+            mds_matrices,
+            constants,
+        }
+        .serialize(serializer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use halo2curves::secp256r1::Fp;
+
+    use super::*;
+
+    #[test]
+    fn just_serialize() {
+        let spec = Spec::<Fp, 10, 9>::new(10, 10);
+        bincode::serialize(&spec).unwrap();
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,14 +1,14 @@
-use crate::main_gate::AssignedValue;
-use crate::poseidon::PoseidonHash;
-use crate::poseidon::ROTrait;
+use std::{fmt, iter, num::NonZeroUsize};
+
 use ff::{BatchInvert, Field, PrimeField};
 use halo2_proofs::plonk::Assigned;
 use num_bigint::BigUint;
-use poseidon::Spec;
 pub(crate) use rayon::current_num_threads;
-use std::fmt;
-use std::iter;
-use std::num::NonZeroUsize;
+
+use crate::{
+    main_gate::AssignedValue,
+    poseidon::{PoseidonHash, ROTrait, Spec},
+};
 
 pub fn bytes_to_bits_le(bytes: Vec<u8>) -> Vec<bool> {
     let mut bits = Vec::new();


### PR DESCRIPTION
**Why?**
We need to serialize public params in order to commit pp at the IVC level. One of the most important parameters we need to serialize are constants for random oracle, which are an external type in our project. We need to wrap it in a local type and provide serialization.

There are two approaches:
- Commit `r_f` & `r_p` from which Spec is created
- Commit all constants

This is an implementation of the second approach, since the first approach makes us dependent on a particular implementation of parameter generation. But perhaps we can rely on him to avoid such redundant wrapping. Feel free to discuss the topic.

**What?**
- Allocation of all traits in the poseidon module into a separate module (like `ROTrait`, `ROCircuitTrait`, `ROPair` etc)
- Allocation of a separate 'spec' module
- Replacing in our entire project spec from external crate to our wrapper type
- Implementation of `Spec` serialization

**How?**
Using manual serialization of `Spec`, writing wrapper types for each field getter. In addition to the entity alternative (described in the **Why?**), there is an alternative implementation in the form of a fork. Technically it will be much simpler, however, it will be necessary to force another fork to support it.

Minuses of this approach
- support for the code presented in PR
- 'Spec' copying during serialization. Overhead is small, but it needs to be noted.