### PR TITLE
fix(plonk): allow empty PlonkStructure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ rand = "0.8"
 halo2_proofs = { git = "https://github.com/snarkify/halo2", branch = "snarkify/dev" }
 ff = "0.13"
 group = "0.13"
-# pasta_curves = "0.5"
 sha3 = "0.10"
 bincode = "1.3"
 serde = { version = "1.0", features = ["derive"] }
@@ -18,19 +17,21 @@ num-traits = "0.2.16"
 digest = "0.10"
 
 rand_core = { version = "0.6", default-features = false }
-halo2curves = { git = 'https://github.com/privacy-scaling-explorations/halo2curves', tag = "0.4.0" }
+halo2curves = { git = 'https://github.com/privacy-scaling-explorations/halo2curves', tag = "v0.6.0", features = ["derive_serde"] }
 poseidon = { git = "https://github.com/privacy-scaling-explorations/poseidon", rev = "807f8f555313f726ca03bdf941f798098f488ba4" }
 log = "0.4.20"
 itertools = "0.11.0"
 bitter = "0.6.1"
 thiserror = "1.0.48"
 result-inspect = "0.3.0"
+serde_arrays = "0.1.0"
 
 [dev-dependencies]
 env_logger = "0.10.0"
 prettytable-rs = "0.10.0"
 test-log = "0.2.12"
 halo2_gadgets = { git = "https://github.com/snarkify/halo2", branch = "snarkify/dev", features = ["unstable"] }
+bincode = "1.3"
 
 [dev-dependencies.cargo-husky]
 version = "1"

--- a/src/commitment.rs
+++ b/src/commitment.rs
@@ -4,11 +4,13 @@ use digest::{ExtendableOutput, Update};
 use group::Curve;
 use halo2_proofs::arithmetic::{best_multiexp, CurveAffine, CurveExt};
 use rayon::prelude::*;
+use serde::Serialize;
 use sha3::Shake256;
 
 use crate::util::parallelize;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
+#[serde(bound(serialize = "C: Serialize"))]
 pub struct CommitmentKey<C: CurveAffine> {
     ck: Vec<C>,
 }

--- a/src/ivc/fold_relaxed_plonk_instance_chip.rs
+++ b/src/ivc/fold_relaxed_plonk_instance_chip.rs
@@ -1061,10 +1061,10 @@ pub struct FoldResult<C: CurveAffine> {
 
 #[cfg(test)]
 mod tests {
+    use crate::poseidon::Spec;
     use bitter::{BitReader, LittleEndianReader};
     use halo2_proofs::circuit::{floor_planner::single_pass::SingleChipLayouter, Layouter, Value};
     use halo2curves::{bn256::G1Affine as C1, CurveAffine};
-    use poseidon::Spec;
     use rand::rngs::ThreadRng;
     use rand::Rng;
 

--- a/src/ivc/incrementally_verifiable_computation.rs
+++ b/src/ivc/incrementally_verifiable_computation.rs
@@ -31,12 +31,12 @@ where
     params: SynthesizeStepParams<C, ROC>,
 }
 
-impl<AnyCurve, CC, RO, ROC> AbsorbInRO<AnyCurve, RO> for CircuitPublicParams<CC, ROC>
+impl<F, CC, RO, ROC> AbsorbInRO<F, RO> for CircuitPublicParams<CC, ROC>
 where
-    AnyCurve: CurveAffine,
+    F: PrimeField,
     CC: CurveAffine,
     CC::Base: PrimeFieldBits + FromUniformBytes<64>,
-    RO: ROTrait<AnyCurve>,
+    RO: ROTrait<F>,
     ROC: ROCircuitTrait<CC::Base>,
 {
     fn absorb_into(&self, _ro: &mut RO) {
@@ -86,7 +86,7 @@ where
         todo!("Impl creation of pub params")
     }
 
-    pub fn digest<ROT: ROTrait<C1>>(&self, constant: ROT::Constants) -> C1::ScalarExt {
+    pub fn digest<ROT: ROTrait<C1::Base>>(&self, constant: ROT::Constants) -> C1::ScalarExt {
         let mut ro = ROT::new(constant);
 
         let Self {
@@ -98,7 +98,7 @@ where
         secondary.absorb_into(&mut ro);
 
         let bytes_count = C1::Base::ZERO.to_repr().as_ref().len();
-        ro.squeeze(NonZeroUsize::new(bytes_count * 8).unwrap())
+        ro.squeeze::<C1>(NonZeroUsize::new(bytes_count * 8).unwrap())
     }
 }
 

--- a/src/ivc/mod.rs
+++ b/src/ivc/mod.rs
@@ -1,6 +1,9 @@
 pub mod step_circuit;
 
 mod floor_planner;
-mod incrementally_verifiable_computation;
-pub use incrementally_verifiable_computation::*;
 mod fold_relaxed_plonk_instance_chip;
+mod incrementally_verifiable_computation;
+mod public_params;
+
+pub use incrementally_verifiable_computation::*;
+pub use public_params::PublicParams;

--- a/src/ivc/public_params.rs
+++ b/src/ivc/public_params.rs
@@ -1,0 +1,226 @@
+use std::{fmt, num::NonZeroUsize};
+
+use ff::{FromUniformBytes, PrimeFieldBits};
+use group::prime::PrimeCurveAffine;
+use halo2curves::CurveAffine;
+use serde::Serialize;
+
+use crate::{
+    commitment::CommitmentKey,
+    digest::{self, DigestToCurve},
+    plonk::PlonkStructure,
+    poseidon::ROPair,
+    table::TableData,
+};
+
+use super::step_circuit::SynthesizeStepParams;
+
+pub(crate) struct CircuitPublicParams<C, RP>
+where
+    C: CurveAffine,
+    C::Base: PrimeFieldBits + FromUniformBytes<64>,
+    RP: ROPair<C::Base>,
+{
+    pub ck: CommitmentKey<C>,
+    pub params: SynthesizeStepParams<C, RP::OnCircuit>,
+    pub td: TableData<C::Base>,
+}
+
+impl<C: fmt::Debug, RP> fmt::Debug for CircuitPublicParams<C, RP>
+where
+    C: CurveAffine,
+    C::Base: PrimeFieldBits + FromUniformBytes<64>,
+    RP: ROPair<C::Base>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CircuitPublicParams")
+            .field("ck", &self.ck)
+            .field("params", &self.params)
+            .field("td", &self.td)
+            .finish()
+    }
+}
+
+impl<C, RP> CircuitPublicParams<C, RP>
+where
+    C: CurveAffine,
+    C::Base: PrimeFieldBits + FromUniformBytes<64>,
+    RP: ROPair<C::Base>,
+{
+    fn new(
+        k: u32,
+        is_primary_circuit: bool,
+        ro_constant: RP::Args,
+        limb_width: NonZeroUsize,
+        n_limbs: NonZeroUsize,
+    ) -> Self {
+        Self {
+            ck: CommitmentKey::setup(k as usize, b"step circuit"),
+            td: TableData::new(k, vec![]),
+            params: SynthesizeStepParams {
+                limb_width,
+                n_limbs,
+                is_primary_circuit,
+                ro_constant,
+            },
+        }
+    }
+}
+
+pub struct PublicParams<C1, C2, RP1, RP2>
+where
+    C1: CurveAffine<Base = <C2 as PrimeCurveAffine>::Scalar> + Serialize,
+    C2: CurveAffine<Base = <C1 as PrimeCurveAffine>::Scalar> + Serialize,
+    C1::Base: PrimeFieldBits + FromUniformBytes<64> + Serialize,
+    C2::Base: PrimeFieldBits + FromUniformBytes<64> + Serialize,
+    RP1: ROPair<C1::Base>,
+    RP2: ROPair<C2::Base>,
+{
+    pub(crate) primary: CircuitPublicParams<C1, RP1>,
+    pub(crate) secondary: CircuitPublicParams<C2, RP2>,
+}
+
+impl<C1: fmt::Debug, C2: fmt::Debug, RP1, RP2> fmt::Debug for PublicParams<C1, C2, RP1, RP2>
+where
+    C1: CurveAffine<Base = <C2 as PrimeCurveAffine>::Scalar> + Serialize,
+    C2: CurveAffine<Base = <C1 as PrimeCurveAffine>::Scalar> + Serialize,
+    C1::Base: PrimeFieldBits + FromUniformBytes<64> + Serialize,
+    C2::Base: PrimeFieldBits + FromUniformBytes<64> + Serialize,
+    RP1: ROPair<C1::Base>,
+    RP2: ROPair<C2::Base>,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PublicParams")
+            .field("primary", &self.primary)
+            .field("secondary", &self.secondary)
+            .finish()
+    }
+}
+
+impl<C1, C2, RP1, RP2> serde::Serialize for PublicParams<C1, C2, RP1, RP2>
+where
+    C1: CurveAffine<Base = <C2 as PrimeCurveAffine>::Scalar> + Serialize,
+    C2: CurveAffine<Base = <C1 as PrimeCurveAffine>::Scalar> + Serialize,
+
+    C1::Base: PrimeFieldBits + FromUniformBytes<64> + Serialize,
+    C2::Base: PrimeFieldBits + FromUniformBytes<64> + Serialize,
+
+    RP1: ROPair<C1::Base>,
+    RP2: ROPair<C2::Base>,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        #[derive(serde::Serialize)]
+        #[serde(bound(serialize = ""))]
+        struct Wrapper<'l, C1, C2, RP1, RP2>
+        where
+            C1: CurveAffine<Base = <C2 as PrimeCurveAffine>::Scalar> + Serialize,
+            C2: CurveAffine<Base = <C1 as PrimeCurveAffine>::Scalar> + Serialize,
+
+            C1::Base: PrimeFieldBits + FromUniformBytes<64> + Serialize,
+            C2::Base: PrimeFieldBits + FromUniformBytes<64> + Serialize,
+
+            RP1: ROPair<C1::Base>,
+            RP2: ROPair<C2::Base>,
+        {
+            primary_ck: &'l CommitmentKey<C1>,
+            primary_params: &'l SynthesizeStepParams<C1, RP1::OnCircuit>,
+            primary_structure: PlonkStructure<C2>,
+
+            secondary_ck: &'l CommitmentKey<C2>,
+            secondary_params: &'l SynthesizeStepParams<C2, RP2::OnCircuit>,
+            secondary_structure: PlonkStructure<C1>,
+        }
+
+        Wrapper::<'_, C1, C2, RP1, RP2> {
+            primary_params: &self.primary.params,
+            primary_ck: &self.primary.ck,
+            primary_structure: self.primary.td.plonk_structure(&self.secondary.ck),
+
+            secondary_params: &self.secondary.params,
+            secondary_ck: &self.secondary.ck,
+            secondary_structure: self.secondary.td.plonk_structure(&self.primary.ck),
+        }
+        .serialize(serializer)
+    }
+}
+
+impl<C1, C2, R1, R2> PublicParams<C1, C2, R1, R2>
+where
+    C1: CurveAffine<Base = <C2 as PrimeCurveAffine>::Scalar> + Serialize,
+    C2: CurveAffine<Base = <C1 as PrimeCurveAffine>::Scalar> + Serialize,
+
+    C1::Base: PrimeFieldBits + FromUniformBytes<64> + Serialize,
+    C2::Base: PrimeFieldBits + FromUniformBytes<64> + Serialize,
+
+    R1: ROPair<C1::Base>,
+    R2: ROPair<C2::Base>,
+{
+    pub fn new(
+        k: u32,
+        primary_ro_constant: R1::Args,
+        secondary_ro_constant: R2::Args,
+        limb_width: NonZeroUsize,
+        limbs_count_limit: NonZeroUsize,
+    ) -> Self {
+        Self {
+            primary: CircuitPublicParams::<C1, _>::new(
+                k,
+                true,
+                primary_ro_constant,
+                limb_width,
+                limbs_count_limit,
+            ),
+            secondary: CircuitPublicParams::<C2, _>::new(
+                k,
+                false,
+                secondary_ro_constant,
+                limb_width,
+                limbs_count_limit,
+            ),
+        }
+    }
+
+    pub fn digest<C: CurveAffine>(&self) -> Result<C, crate::ivc::Error> {
+        digest::DefaultHasher::digest_to_curve(self).map_err(crate::ivc::Error::WhileHash)
+    }
+}
+#[cfg(test)]
+mod pp_test {
+    use halo2curves::{bn256, grumpkin, CurveExt};
+
+    use bn256::G1 as C1;
+    use grumpkin::G1 as C2;
+
+    use super::*;
+
+    type C1Affine = <C1 as halo2curves::group::prime::PrimeCurve>::Affine;
+    type C2Affine = <C2 as halo2curves::group::prime::PrimeCurve>::Affine;
+
+    const LIMB_WIDTH: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(32) };
+    const LIMBS_COUNT_LIMIT: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(10) };
+
+    type RandomOracle<const T: usize, const RATE: usize> = crate::poseidon::PoseidonRO<T, RATE>;
+
+    type RandomOracleConstant<const T: usize, const RATE: usize, F> =
+        <RandomOracle<T, RATE> as ROPair<F>>::Args;
+
+    #[test]
+    fn digest() {
+        let spec1 = RandomOracleConstant::<5, 4, <C1 as CurveExt>::Base>::new(10, 10);
+        let spec2 = RandomOracleConstant::<5, 4, <C2 as CurveExt>::Base>::new(10, 10);
+
+        const K: usize = 5;
+        let pp = PublicParams::<C1Affine, C2Affine, RandomOracle<5, 4>, RandomOracle<5, 4>>::new(
+            K as u32,
+            spec1,
+            spec2,
+            LIMB_WIDTH,
+            LIMBS_COUNT_LIMIT,
+        );
+        dbg!(&pp);
+        pp.digest::<C1Affine>().unwrap();
+    }
+}

--- a/src/nifs/mod.rs
+++ b/src/nifs/mod.rs
@@ -53,12 +53,12 @@ pub type CrossTermCommits<C> = Vec<C>;
 /// Please refer to: [notes](https://hackmd.io/@chaosma/BJvWmnw_h#31-NIFS)
 // TODO Replace links to either the documentation right here, or the official Snarkify resource
 #[derive(Clone, Debug)]
-pub struct NIFS<C: CurveAffine, RO: ROTrait<C>> {
+pub struct NIFS<C: CurveAffine, RO: ROTrait<C::Base>> {
     pub(crate) cross_term_commits: CrossTermCommits<C>,
     _marker: PhantomData<RO>,
 }
 
-impl<C: CurveAffine, RO: ROTrait<C>> NIFS<C, RO> {
+impl<C: CurveAffine, RO: ROTrait<C::Base>> NIFS<C, RO> {
     /// Commits to the cross terms between two Plonk instance-witness pairs.
     ///
     /// This method calculates the cross terms and their commitments, which
@@ -142,7 +142,7 @@ impl<C: CurveAffine, RO: ROTrait<C>> NIFS<C, RO> {
             .iter()
             .for_each(|cm| ro_acc.absorb_point(cm));
 
-        Ok(ro_acc.squeeze(NUM_CHALLENGE_BITS))
+        Ok(ro_acc.squeeze::<C>(NUM_CHALLENGE_BITS))
     }
 
     /// Generates a proof of correct folding using the NIFS protocol.

--- a/src/nifs/tests.rs
+++ b/src/nifs/tests.rs
@@ -44,17 +44,17 @@ where
     let mut f_U =
         RelaxedPlonkInstance::new(td1.instance.len(), S.num_challenges, S.round_sizes.len());
     let mut f_W = RelaxedPlonkWitness::new(td1.k, &S.round_sizes);
-    let mut ro_nark_prover = create_ro::<C, T, RATE, R_F, R_P>();
-    let mut ro_nark_prepare = create_ro::<C, T, RATE, R_F, R_P>();
-    let mut ro_nark_verifier = create_ro::<C, T, RATE, R_F, R_P>();
-    let mut ro_nark_decider = create_ro::<C, T, RATE, R_F, R_P>();
+    let mut ro_nark_prover = create_ro::<C::Base, T, RATE, R_F, R_P>();
+    let mut ro_nark_prepare = create_ro::<C::Base, T, RATE, R_F, R_P>();
+    let mut ro_nark_verifier = create_ro::<C::Base, T, RATE, R_F, R_P>();
+    let mut ro_nark_decider = create_ro::<C::Base, T, RATE, R_F, R_P>();
     let (U1, W1) = td1
         .run_sps_protocol(ck, &mut ro_nark_prepare, S.num_challenges)
         .unwrap();
     assert_eq!(S.is_sat(ck, &mut ro_nark_decider, &U1, &W1).err(), None);
 
-    let mut ro_acc_prover = create_ro::<C, T, RATE, R_F, R_P>();
-    let mut ro_acc_verifier = create_ro::<C, T, RATE, R_F, R_P>();
+    let mut ro_acc_prover = create_ro::<C::Base, T, RATE, R_F, R_P>();
+    let mut ro_acc_verifier = create_ro::<C::Base, T, RATE, R_F, R_P>();
     let (nifs, (U_from_prove, W)) = NIFS::prove(
         ck,
         pp_digest,
@@ -64,6 +64,7 @@ where
         &f_U,
         &f_W,
     )?;
+
     let U_from_verify = nifs
         .verify(
             pp_digest,

--- a/src/plonk/lookup.rs
+++ b/src/plonk/lookup.rs
@@ -36,18 +36,20 @@
 //!
 //! Please see (#34)[https://github.com/snarkify/sirius/issues/34] for details on notations.
 //!
+use std::array;
 
-use crate::concat_vec;
-use crate::plonk::eval::Error;
 use ff::PrimeField;
 use halo2_proofs::{plonk::ConstraintSystem, poly::Rotation};
 use itertools::Itertools;
 use rayon::prelude::*;
-use std::array;
+use serde::Serialize;
 
 use crate::{
-    plonk::eval::{Eval, LookupEvalDomain},
-    plonk::util::compress_halo2_expression,
+    concat_vec,
+    plonk::{
+        eval::{Error, Eval, LookupEvalDomain},
+        util::compress_halo2_expression,
+    },
     polynomial::{Expression, Query},
     table::TableData,
 };
@@ -65,7 +67,7 @@ use crate::{
 /// into a single (i.e. non-vector) Expression:
 /// - lookup_poly = L(x_1,...,x_a) = a_1 + a_2*r + a_3*r^2 + ...
 /// - table_poly  = T(y_1,...,y_b) = t_1 + t_2*r + t_3*r^2 + ...
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct Arguments<F: PrimeField> {
     /// vector of the compressed lookup expressions
     /// L_i(x_1,...,x_{a_i})

--- a/src/plonk/mod.rs
+++ b/src/plonk/mod.rs
@@ -146,14 +146,14 @@ pub struct PlonkTrace<C: CurveAffine> {
     w: PlonkWitness<C::Scalar>,
 }
 
-impl<C: CurveAffine, RO: ROTrait<C>> AbsorbInRO<C, RO> for PlonkStructure<C> {
+impl<C: CurveAffine, RO: ROTrait<C::Base>> AbsorbInRO<C::Base, RO> for PlonkStructure<C> {
     // TODO: add hash of other fields including gates
     fn absorb_into(&self, ro: &mut RO) {
         ro.absorb_point(&self.fixed_commitment);
     }
 }
 
-impl<C: CurveAffine, RO: ROTrait<C>> AbsorbInRO<C, RO> for PlonkInstance<C> {
+impl<C: CurveAffine, RO: ROTrait<C::Base>> AbsorbInRO<C::Base, RO> for PlonkInstance<C> {
     fn absorb_into(&self, ro: &mut RO) {
         for pt in self.W_commitments.iter() {
             ro.absorb_point(pt);
@@ -167,7 +167,7 @@ impl<C: CurveAffine, RO: ROTrait<C>> AbsorbInRO<C, RO> for PlonkInstance<C> {
     }
 }
 
-impl<C: CurveAffine, RO: ROTrait<C>> AbsorbInRO<C, RO> for RelaxedPlonkInstance<C> {
+impl<C: CurveAffine, RO: ROTrait<C::Base>> AbsorbInRO<C::Base, RO> for RelaxedPlonkInstance<C> {
     fn absorb_into(&self, ro: &mut RO) {
         for pt in self.W_commitments.iter() {
             ro.absorb_point(pt);
@@ -212,7 +212,7 @@ impl<C: CurveAffine> PlonkStructure<C> {
     }
 
     /// run special soundness protocol for verifier
-    pub fn run_sps_verifier<RO: ROTrait<C>>(
+    pub fn run_sps_verifier<RO: ROTrait<C::Base>>(
         &self,
         U: &PlonkInstance<C>,
         ro_nark: &mut RO,
@@ -226,7 +226,7 @@ impl<C: CurveAffine> PlonkStructure<C> {
         });
         for i in 0..self.num_challenges {
             ro_nark.absorb_point(&U.W_commitments[i]);
-            let r = ro_nark.squeeze(NUM_CHALLENGE_BITS);
+            let r = ro_nark.squeeze::<C>(NUM_CHALLENGE_BITS);
             if r != U.challenges[i] {
                 return Err(SpsError::ChallengeNotMatch { challenge_index: i });
             }
@@ -234,7 +234,7 @@ impl<C: CurveAffine> PlonkStructure<C> {
         Ok(())
     }
 
-    pub fn is_sat<F, RO: ROTrait<C>>(
+    pub fn is_sat<F, RO: ROTrait<C::Base>>(
         &self,
         ck: &CommitmentKey<C>,
         ro_nark: &mut RO,

--- a/src/plonk/mod.rs
+++ b/src/plonk/mod.rs
@@ -61,7 +61,7 @@ pub enum DeciderError {
     },
 }
 
-#[derive(Clone, PartialEq, Serialize)]
+#[derive(Clone, PartialEq, Serialize, Default)]
 #[serde(bound(serialize = "
     C: Serialize,
     C::ScalarExt: Serialize

--- a/src/plonk/mod.rs
+++ b/src/plonk/mod.rs
@@ -16,6 +16,13 @@
 //! a given Plonk instance and witness satisfy the circuit constraints.
 use std::iter;
 
+use ff::{Field, PrimeField};
+use halo2_proofs::arithmetic::{best_multiexp, CurveAffine};
+use itertools::Itertools;
+use log::*;
+use rayon::prelude::*;
+use serde::Serialize;
+
 use crate::{
     commitment::CommitmentKey,
     concat_vec,
@@ -29,11 +36,6 @@ use crate::{
     table::SpsError,
     util::fe_to_fe,
 };
-use ff::{Field, PrimeField};
-use halo2_proofs::arithmetic::{best_multiexp, CurveAffine};
-use itertools::Itertools;
-use log::*;
-use rayon::prelude::*;
 
 pub mod eval;
 pub mod lookup;
@@ -59,7 +61,11 @@ pub enum DeciderError {
     },
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Serialize)]
+#[serde(bound(serialize = "
+    C: Serialize,
+    C::ScalarExt: Serialize
+"))]
 pub struct PlonkStructure<C: CurveAffine> {
     /// k is a parameter such that 2^k is the total number of rows
     pub(crate) k: usize,
@@ -136,14 +142,14 @@ pub struct RelaxedPlonkWitness<F: PrimeField> {
 
 // TODO #31 docs
 pub struct RelaxedPlonkTrace<C: CurveAffine> {
-    U: RelaxedPlonkInstance<C>,
-    W: RelaxedPlonkWitness<C::Scalar>,
+    pub U: RelaxedPlonkInstance<C>,
+    pub W: RelaxedPlonkWitness<C::Scalar>,
 }
 
 // TODO #31 docs
 pub struct PlonkTrace<C: CurveAffine> {
-    u: PlonkInstance<C>,
-    w: PlonkWitness<C::Scalar>,
+    pub u: PlonkInstance<C>,
+    pub w: PlonkWitness<C::Scalar>,
 }
 
 impl<C: CurveAffine, RO: ROTrait<C::Base>> AbsorbInRO<C::Base, RO> for PlonkStructure<C> {

--- a/src/polynomial/mod.rs
+++ b/src/polynomial/mod.rs
@@ -576,7 +576,7 @@ impl<F: PrimeField> Ord for Monomial<F> {
     }
 }
 
-#[derive(Clone, PartialEq, Serialize)]
+#[derive(Clone, PartialEq, Serialize, Default)]
 pub struct MultiPolynomial<F: PrimeField> {
     pub(crate) arity: usize,
     pub(crate) monomials: Vec<Monomial<F>>,

--- a/src/poseidon/mod.rs
+++ b/src/poseidon/mod.rs
@@ -1,100 +1,15 @@
-use std::num::NonZeroUsize;
-
-use crate::main_gate::{AssignedBit, RegionCtx, WrapValue};
-use ff::{FromUniformBytes, PrimeField, PrimeFieldBits};
-use halo2_proofs::{arithmetic::CurveAffine, plonk::Error};
-
 pub mod poseidon_circuit;
 pub mod poseidon_hash;
-use poseidon::Spec;
+pub mod random_oracle;
+mod spec;
+
 pub use poseidon_hash::PoseidonHash;
-
-/// A helper trait to obsorb different objects into RO
-pub trait AbsorbInRO<F: PrimeField, RO: ROTrait<F>> {
-    /// Absorbs the value in the provided RO
-    fn absorb_into(&self, ro: &mut RO);
-}
-
-/// A helper trait that defines the constants associated with a hash function
-pub trait ROConstantsTrait {
-    /// produces constants/parameters associated with the hash function
-    fn new(r_f: usize, r_p: usize) -> Self;
-}
-
-pub trait ROTrait<F: PrimeField> {
-    /// A type representing constants/parameters associated with the hash function
-    type Constants: ROConstantsTrait;
-
-    /// Initializes the hash function
-    fn new(constants: Self::Constants) -> Self;
-
-    /// Adds a base to the internal state
-    fn absorb_base(&mut self, base: F);
-
-    /// Adds a point to the internal state
-    fn absorb_point<C: CurveAffine<Base = F>>(&mut self, p: &C);
-
-    /// Returns a challenge by hashing the internal state
-    fn squeeze<C: CurveAffine<Base = F>>(&mut self, num_bits: NonZeroUsize) -> C::Scalar;
-}
-
-/// A helper trait that defines the behavior of a hash function used as a Random Oracle (RO)
-/// within a circuit.
-pub trait ROCircuitTrait<F: PrimeFieldBits + FromUniformBytes<64>> {
-    /// Associated type represents the arguments required to initialize the hash function in the circuit.
-    /// These could include various parameters like the number of rounds, the internal state size, etc.
-    type Args: Clone;
-
-    /// Associated type represents the configuration settings for the hash function within the circuit.
-    ///
-    /// This includes defining the layout of gates, wires, and other circuit-specific parameters necessary for
-    /// the hash function's operation within the proof system.
-    type Config;
-
-    /// Constructs a new instance of the random oracle circuit
-    fn new(config: Self::Config, args: Self::Args) -> Self;
-
-    /// Adds a scalar to the internal state
-    fn absorb_base(&mut self, base: WrapValue<F>) -> &mut Self;
-
-    /// Adds a point to the internal state
-    fn absorb_point(&mut self, point: [WrapValue<F>; 2]) -> &mut Self;
-
-    /// Adds elements of iterator of [`WrapValues`] to the internal state
-    fn absorb_iter<I>(&mut self, iter: impl Iterator<Item = I>) -> &mut Self
-    where
-        I: Into<WrapValue<F>>,
-    {
-        iter.for_each(|val| {
-            self.absorb_base(val.into());
-        });
-        self
-    }
-
-    /// Returns a challenge of `num_bits` by hashing the internal state
-    fn squeeze_n_bits(
-        &mut self,
-        ctx: &mut RegionCtx<'_, F>,
-        num_bits: NonZeroUsize,
-    ) -> Result<Vec<AssignedBit<F>>, Error>;
-}
-
-/// Random Oracle is represented as a pair of on-circuit & off-circuit types,
-/// allowing the use of a single generic.
-pub trait ROPair<F: PrimeField>
-where
-    F: ff::PrimeFieldBits + ff::FromUniformBytes<64>,
-{
-    /// Argument for creating on-circuit & off-circuit versions of oracles
-    type Args;
-
-    type OffCircuit: ROTrait<F, Constants = Self::Args>;
-    type OnCircuit: ROCircuitTrait<F, Args = Self::Args>;
-}
+pub use random_oracle::*;
+pub use spec::Spec;
 
 pub struct PoseidonRO<const T: usize, const RATE: usize>;
 
-impl<const T: usize, const RATE: usize, F: PrimeField> ROPair<F> for PoseidonRO<T, RATE>
+impl<const T: usize, const RATE: usize, F: ff::PrimeField> ROPair<F> for PoseidonRO<T, RATE>
 where
     F: ff::PrimeFieldBits + ff::FromUniformBytes<64>,
 {

--- a/src/poseidon/mod.rs
+++ b/src/poseidon/mod.rs
@@ -1,7 +1,7 @@
 use std::num::NonZeroUsize;
 
 use crate::main_gate::{AssignedBit, RegionCtx, WrapValue};
-use ff::{FromUniformBytes, PrimeFieldBits};
+use ff::{FromUniformBytes, PrimeField, PrimeFieldBits};
 use halo2_proofs::{arithmetic::CurveAffine, plonk::Error};
 
 pub mod poseidon_circuit;
@@ -10,7 +10,7 @@ use poseidon::Spec;
 pub use poseidon_hash::PoseidonHash;
 
 /// A helper trait to obsorb different objects into RO
-pub trait AbsorbInRO<C: CurveAffine, RO: ROTrait<C>> {
+pub trait AbsorbInRO<F: PrimeField, RO: ROTrait<F>> {
     /// Absorbs the value in the provided RO
     fn absorb_into(&self, ro: &mut RO);
 }
@@ -21,7 +21,7 @@ pub trait ROConstantsTrait {
     fn new(r_f: usize, r_p: usize) -> Self;
 }
 
-pub trait ROTrait<C: CurveAffine> {
+pub trait ROTrait<F: PrimeField> {
     /// A type representing constants/parameters associated with the hash function
     type Constants: ROConstantsTrait;
 
@@ -29,13 +29,13 @@ pub trait ROTrait<C: CurveAffine> {
     fn new(constants: Self::Constants) -> Self;
 
     /// Adds a base to the internal state
-    fn absorb_base(&mut self, base: C::Base);
+    fn absorb_base(&mut self, base: F);
 
     /// Adds a point to the internal state
-    fn absorb_point(&mut self, p: &C);
+    fn absorb_point<C: CurveAffine<Base = F>>(&mut self, p: &C);
 
     /// Returns a challenge by hashing the internal state
-    fn squeeze(&mut self, num_bits: NonZeroUsize) -> C::Scalar;
+    fn squeeze<C: CurveAffine<Base = F>>(&mut self, num_bits: NonZeroUsize) -> C::Scalar;
 }
 
 /// A helper trait that defines the behavior of a hash function used as a Random Oracle (RO)
@@ -81,24 +81,24 @@ pub trait ROCircuitTrait<F: PrimeFieldBits + FromUniformBytes<64>> {
 
 /// Random Oracle is represented as a pair of on-circuit & off-circuit types,
 /// allowing the use of a single generic.
-pub trait ROPair<C: CurveAffine>
+pub trait ROPair<F: PrimeField>
 where
-    C::Base: ff::PrimeFieldBits + ff::FromUniformBytes<64>,
+    F: ff::PrimeFieldBits + ff::FromUniformBytes<64>,
 {
     /// Argument for creating on-circuit & off-circuit versions of oracles
     type Args;
 
-    type OffCircuit: ROTrait<C, Constants = Self::Args>;
-    type OnCircuit: ROCircuitTrait<C::Base, Args = Self::Args>;
+    type OffCircuit: ROTrait<F, Constants = Self::Args>;
+    type OnCircuit: ROCircuitTrait<F, Args = Self::Args>;
 }
 
 pub struct PoseidonRO<const T: usize, const RATE: usize>;
 
-impl<const T: usize, const RATE: usize, C: CurveAffine> ROPair<C> for PoseidonRO<T, RATE>
+impl<const T: usize, const RATE: usize, F: PrimeField> ROPair<F> for PoseidonRO<T, RATE>
 where
-    C::Base: ff::PrimeFieldBits + ff::FromUniformBytes<64>,
+    F: ff::PrimeFieldBits + ff::FromUniformBytes<64>,
 {
-    type Args = Spec<C::Base, T, RATE>;
-    type OnCircuit = poseidon_circuit::PoseidonChip<C::Base, T, RATE>;
-    type OffCircuit = poseidon_hash::PoseidonHash<C, T, RATE>;
+    type Args = Spec<F, T, RATE>;
+    type OnCircuit = poseidon_circuit::PoseidonChip<F, T, RATE>;
+    type OffCircuit = poseidon_hash::PoseidonHash<F, T, RATE>;
 }

--- a/src/poseidon/mod.rs
+++ b/src/poseidon/mod.rs
@@ -9,11 +9,14 @@ pub use spec::Spec;
 
 pub struct PoseidonRO<const T: usize, const RATE: usize>;
 
-impl<const T: usize, const RATE: usize, F: ff::PrimeField> ROPair<F> for PoseidonRO<T, RATE>
+impl<const T: usize, const RATE: usize, F: serde::Serialize + ff::PrimeField> ROPair<F>
+    for PoseidonRO<T, RATE>
 where
     F: ff::PrimeFieldBits + ff::FromUniformBytes<64>,
 {
     type Args = Spec<F, T, RATE>;
+    type Config = crate::main_gate::MainGateConfig<T>;
+
     type OnCircuit = poseidon_circuit::PoseidonChip<F, T, RATE>;
     type OffCircuit = poseidon_hash::PoseidonHash<F, T, RATE>;
 }

--- a/src/poseidon/poseidon_circuit.rs
+++ b/src/poseidon/poseidon_circuit.rs
@@ -1,16 +1,18 @@
-use crate::{
-    constants::MAX_BITS,
-    main_gate::{AssignedBit, AssignedValue, MainGate, MainGateConfig, RegionCtx, WrapValue},
-};
+use std::{convert::TryInto, num::NonZeroUsize};
+
 use ff::{FromUniformBytes, PrimeField, PrimeFieldBits};
 use halo2_proofs::{
     circuit::{AssignedCell, Chip, Value},
     plonk::Error,
 };
-use poseidon::{self, Spec};
-use std::{convert::TryInto, num::NonZeroUsize};
+use poseidon::{self};
 
-use super::ROCircuitTrait;
+use crate::{
+    constants::MAX_BITS,
+    main_gate::{AssignedBit, AssignedValue, MainGate, MainGateConfig, RegionCtx, WrapValue},
+};
+
+use super::{ROCircuitTrait, Spec};
 
 pub struct PoseidonChip<F: PrimeFieldBits, const T: usize, const RATE: usize> {
     main_gate: MainGate<F, T>,
@@ -394,14 +396,20 @@ impl<F: PrimeField + PrimeFieldBits, const T: usize, const RATE: usize> Poseidon
 
 #[cfg(test)]
 mod tests {
+    use halo2_proofs::{
+        circuit::{Layouter, SimpleFloorPlanner},
+        plonk::{Circuit, Column, ConstraintSystem, Instance},
+    };
+    use halo2curves::{
+        group::ff::FromUniformBytes,
+        pasta::{EqAffine, Fp},
+    };
+
+    use crate::{
+        create_and_verify_proof, main_gate::MainGateConfig, poseidon::Spec, run_mock_prover_test,
+    };
+
     use super::*;
-    use crate::main_gate::MainGateConfig;
-    use crate::{create_and_verify_proof, run_mock_prover_test};
-    use halo2_proofs::circuit::{Layouter, SimpleFloorPlanner};
-    use halo2_proofs::plonk::{Circuit, Column, ConstraintSystem, Instance};
-    use halo2curves::group::ff::FromUniformBytes;
-    use halo2curves::pasta::{EqAffine, Fp};
-    use poseidon::Spec;
 
     const T: usize = 3;
     const RATE: usize = 2;

--- a/src/poseidon/poseidon_hash.rs
+++ b/src/poseidon/poseidon_hash.rs
@@ -1,10 +1,14 @@
-use crate::poseidon::{ROConstantsTrait, ROTrait};
-use crate::util::{bits_to_fe_le, fe_to_bits_le};
-use halo2_proofs::arithmetic::CurveAffine;
-use halo2curves::group::ff::{FromUniformBytes, PrimeField};
-use poseidon::{self, SparseMDSMatrix, Spec};
 use std::num::NonZeroUsize;
 use std::{iter, mem};
+
+use halo2_proofs::arithmetic::CurveAffine;
+use halo2curves::group::ff::{FromUniformBytes, PrimeField};
+use poseidon::{self, SparseMDSMatrix};
+
+use crate::poseidon::{ROConstantsTrait, ROTrait};
+use crate::util::{bits_to_fe_le, fe_to_bits_le};
+
+use super::Spec;
 
 // adapted from: https://github.com/privacy-scaling-explorations/snark-verifier
 

--- a/src/poseidon/random_oracle.rs
+++ b/src/poseidon/random_oracle.rs
@@ -1,0 +1,89 @@
+use std::num::NonZeroUsize;
+
+use ff::{FromUniformBytes, PrimeField, PrimeFieldBits};
+use halo2_proofs::{arithmetic::CurveAffine, plonk::Error};
+
+use crate::main_gate::{AssignedBit, RegionCtx, WrapValue};
+
+/// A helper trait to obsorb different objects into RO
+pub trait AbsorbInRO<F: PrimeField, RO: ROTrait<F>> {
+    /// Absorbs the value in the provided RO
+    fn absorb_into(&self, ro: &mut RO);
+}
+
+/// A helper trait that defines the constants associated with a hash function
+pub trait ROConstantsTrait {
+    /// produces constants/parameters associated with the hash function
+    fn new(r_f: usize, r_p: usize) -> Self;
+}
+
+pub trait ROTrait<F: PrimeField> {
+    /// A type representing constants/parameters associated with the hash function
+    type Constants: ROConstantsTrait;
+
+    /// Initializes the hash function
+    fn new(constants: Self::Constants) -> Self;
+
+    /// Adds a base to the internal state
+    fn absorb_base(&mut self, base: F);
+
+    /// Adds a point to the internal state
+    fn absorb_point<C: CurveAffine<Base = F>>(&mut self, p: &C);
+
+    /// Returns a challenge by hashing the internal state
+    fn squeeze<C: CurveAffine<Base = F>>(&mut self, num_bits: NonZeroUsize) -> C::Scalar;
+}
+
+/// A helper trait that defines the behavior of a hash function used as a Random Oracle (RO)
+/// within a circuit.
+pub trait ROCircuitTrait<F: PrimeFieldBits + FromUniformBytes<64>> {
+    /// Associated type represents the arguments required to initialize the hash function in the circuit.
+    /// These could include various parameters like the number of rounds, the internal state size, etc.
+    type Args: Clone;
+
+    /// Associated type represents the configuration settings for the hash function within the circuit.
+    ///
+    /// This includes defining the layout of gates, wires, and other circuit-specific parameters necessary for
+    /// the hash function's operation within the proof system.
+    type Config;
+
+    /// Constructs a new instance of the random oracle circuit
+    fn new(config: Self::Config, args: Self::Args) -> Self;
+
+    /// Adds a scalar to the internal state
+    fn absorb_base(&mut self, base: WrapValue<F>) -> &mut Self;
+
+    /// Adds a point to the internal state
+    fn absorb_point(&mut self, point: [WrapValue<F>; 2]) -> &mut Self;
+
+    /// Adds elements of iterator of [`WrapValues`] to the internal state
+    fn absorb_iter<I>(&mut self, iter: impl Iterator<Item = I>) -> &mut Self
+    where
+        I: Into<WrapValue<F>>,
+    {
+        iter.for_each(|val| {
+            self.absorb_base(val.into());
+        });
+        self
+    }
+
+    /// Returns a challenge of `num_bits` by hashing the internal state
+    fn squeeze_n_bits(
+        &mut self,
+        ctx: &mut RegionCtx<'_, F>,
+        num_bits: NonZeroUsize,
+    ) -> Result<Vec<AssignedBit<F>>, Error>;
+}
+
+/// Random Oracle is represented as a pair of on-circuit & off-circuit types,
+/// allowing the use of a single generic.
+pub trait ROPair<F: PrimeField>
+where
+    F: ff::PrimeFieldBits + ff::FromUniformBytes<64>,
+{
+    /// Argument for creating on-circuit & off-circuit versions of oracles
+    type Args;
+
+    type OffCircuit: ROTrait<F, Constants = Self::Args>;
+    type OnCircuit: ROCircuitTrait<F, Args = Self::Args>;
+}

--- a/src/poseidon/random_oracle.rs
+++ b/src/poseidon/random_oracle.rs
@@ -1,4 +1,4 @@
-use std::num::NonZeroUsize;
+use std::{fmt, num::NonZeroUsize};
 
 use ff::{FromUniformBytes, PrimeField, PrimeFieldBits};
 use halo2_proofs::{arithmetic::CurveAffine, plonk::Error};
@@ -39,7 +39,7 @@ pub trait ROTrait<F: PrimeField> {
 pub trait ROCircuitTrait<F: PrimeFieldBits + FromUniformBytes<64>> {
     /// Associated type represents the arguments required to initialize the hash function in the circuit.
     /// These could include various parameters like the number of rounds, the internal state size, etc.
-    type Args: Clone;
+    type Args: fmt::Debug + Clone;
 
     /// Associated type represents the configuration settings for the hash function within the circuit.
     ///
@@ -82,8 +82,9 @@ where
     F: ff::PrimeFieldBits + ff::FromUniformBytes<64>,
 {
     /// Argument for creating on-circuit & off-circuit versions of oracles
-    type Args;
+    type Args: fmt::Debug + serde::Serialize;
+    type Config;
 
     type OffCircuit: ROTrait<F, Constants = Self::Args>;
-    type OnCircuit: ROCircuitTrait<F, Args = Self::Args>;
+    type OnCircuit: ROCircuitTrait<F, Args = Self::Args, Config = Self::Config>;
 }

--- a/src/poseidon/spec.rs
+++ b/src/poseidon/spec.rs
@@ -1,0 +1,140 @@
+use std::ops;
+
+use ff::FromUniformBytes;
+use serde::Serialize;
+
+#[derive(Clone, Debug)]
+pub struct Spec<F: ff::PrimeField, const T: usize, const RATE: usize>(
+    pub poseidon::Spec<F, T, RATE>,
+);
+
+impl<F: ff::PrimeField, const T: usize, const RATE: usize> Spec<F, T, RATE>
+where
+    F: FromUniformBytes<64>,
+{
+    pub fn new(r_f: usize, r_p: usize) -> Self {
+        Self(poseidon::Spec::new(r_f, r_p))
+    }
+}
+
+impl<F: ff::PrimeField, const T: usize, const RATE: usize> ops::Deref for Spec<F, T, RATE> {
+    type Target = poseidon::Spec<F, T, RATE>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<F: Serialize + ff::PrimeField, const T: usize, const RATE: usize> Serialize
+    for Spec<F, T, RATE>
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        #[derive(Serialize)]
+        struct SerializableArray<F: Serialize, const T: usize>(
+            #[serde(with = "serde_arrays")] [F; T],
+        );
+
+        #[derive(Serialize)]
+        struct SerializableMDSMatrix<F: Serialize, const T: usize, const RATE: usize> {
+            #[serde(with = "serde_arrays")]
+            rows: [SerializableArray<F, T>; T],
+        }
+
+        #[derive(Serialize)]
+        struct SerializableSparseMDSMatrix<F: Serialize, const T: usize, const RATE: usize> {
+            row: SerializableArray<F, T>,
+            col_hat: SerializableArray<F, RATE>,
+        }
+
+        #[derive(Serialize)]
+        struct SerializableMDSMatrices<F: Serialize, const T: usize, const RATE: usize> {
+            mds: SerializableMDSMatrix<F, T, RATE>,
+            pre_sparse_mds: SerializableMDSMatrix<F, T, RATE>,
+            sparse_matrices: Vec<SerializableSparseMDSMatrix<F, T, RATE>>,
+        }
+
+        #[derive(Serialize)]
+        struct SerializableOptimizedConstants<F: Serialize, const T: usize> {
+            start: Vec<SerializableArray<F, T>>,
+            partial: Vec<F>,
+            end: Vec<SerializableArray<F, T>>,
+        }
+        // Create a struct to hold serializable representations of Spec fields
+        #[derive(Serialize)]
+        struct SerializableSpec<F: Serialize, const T: usize, const RATE: usize> {
+            r_f: usize,
+            mds_matrices: SerializableMDSMatrices<F, T, RATE>,
+            constants: SerializableOptimizedConstants<F, T>,
+        }
+
+        let poseidon_spec = &self.0;
+        let r_f = poseidon_spec.r_f();
+        let mds_rows = poseidon_spec.mds_matrices().mds().rows();
+
+        let mds = SerializableMDSMatrix {
+            rows: mds_rows.map(SerializableArray),
+        };
+
+        let pre_sparse_mds = SerializableMDSMatrix {
+            rows: poseidon_spec
+                .mds_matrices()
+                .pre_sparse_mds()
+                .rows()
+                .map(|m| SerializableArray(m)),
+        };
+
+        let mds_matrices = SerializableMDSMatrices {
+            mds,
+            pre_sparse_mds,
+            sparse_matrices: poseidon_spec
+                .mds_matrices()
+                .sparse_matrices()
+                .iter()
+                .map(|sparse_matrix| SerializableSparseMDSMatrix {
+                    row: SerializableArray(*sparse_matrix.row()),
+                    col_hat: SerializableArray(*sparse_matrix.col_hat()),
+                })
+                .collect::<Vec<_>>(),
+        };
+
+        let constants = SerializableOptimizedConstants {
+            start: poseidon_spec
+                .constants()
+                .start()
+                .iter()
+                .copied()
+                .map(SerializableArray)
+                .collect(),
+            partial: poseidon_spec.constants().partial().to_vec(),
+            end: poseidon_spec
+                .constants()
+                .end()
+                .iter()
+                .copied()
+                .map(SerializableArray)
+                .collect(),
+        };
+
+        SerializableSpec {
+            r_f,
+            mds_matrices,
+            constants,
+        }
+        .serialize(serializer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use halo2curves::secp256r1::Fp;
+
+    use super::*;
+
+    #[test]
+    fn just_serialize() {
+        let spec = Spec::<Fp, 10, 9>::new(10, 10);
+        bincode::serialize(&spec).unwrap();
+    }
+}

--- a/src/table.rs
+++ b/src/table.rs
@@ -184,10 +184,10 @@ impl<F: PrimeField> TableData<F> {
         &self,
         ck: &CommitmentKey<C>,
     ) -> PlonkStructure<C> {
-        assert!(
-            !self.advice.is_empty(),
-            "should call TableData.assembly() first"
-        );
+        if self.advice.is_empty() {
+            return PlonkStructure::default();
+        }
+
         let selectors = self.selector.clone();
         let selector_columns =
             self.selector

--- a/src/table.rs
+++ b/src/table.rs
@@ -310,7 +310,7 @@ impl<F: PrimeField> TableData<F> {
     /// sequence of generating challenges:
     /// [pi.instance] -> [C] -> ]r1[
     /// w.r.t multiple gates + no lookup
-    fn run_sps_protocol_1<C: CurveAffine<ScalarExt = F>, RO: ROTrait<C>>(
+    fn run_sps_protocol_1<C: CurveAffine<ScalarExt = F>, RO: ROTrait<C::Base>>(
         &self,
         ck: &CommitmentKey<C>,
         ro_nark: &mut RO,
@@ -326,7 +326,7 @@ impl<F: PrimeField> TableData<F> {
 
         plonk_instance
             .challenges
-            .push(ro_nark.squeeze(NUM_CHALLENGE_BITS));
+            .push(ro_nark.squeeze::<C>(NUM_CHALLENGE_BITS));
 
         Ok((plonk_instance, plonk_witness))
     }
@@ -336,7 +336,7 @@ impl<F: PrimeField> TableData<F> {
     /// sequence of generating challenges:
     /// [pi.instance] -> [C1] -> ]r1[ -> [C2] -> ]r2[
     /// w.r.t has lookup but no vector lookup
-    fn run_sps_protocol_2<C: CurveAffine<ScalarExt = F>, RO: ROTrait<C>>(
+    fn run_sps_protocol_2<C: CurveAffine<ScalarExt = F>, RO: ROTrait<C::Base>>(
         &self,
         ck: &CommitmentKey<C>,
         ro_nark: &mut RO,
@@ -370,7 +370,7 @@ impl<F: PrimeField> TableData<F> {
             ro_nark.absorb_base(fe_to_fe(inst).unwrap());
         });
         ro_nark.absorb_point(&C1);
-        let r1 = ro_nark.squeeze(NUM_CHALLENGE_BITS);
+        let r1 = ro_nark.squeeze::<C>(NUM_CHALLENGE_BITS);
 
         // round 2
         let lookup_coeff = lookup_coeff.evaluate_coefficient_2(r1);
@@ -382,7 +382,7 @@ impl<F: PrimeField> TableData<F> {
 
         let C2 = ck.commit(&W2);
         ro_nark.absorb_point(&C2);
-        let r2 = ro_nark.squeeze(NUM_CHALLENGE_BITS);
+        let r2 = ro_nark.squeeze::<C>(NUM_CHALLENGE_BITS);
 
         Ok((
             PlonkInstance {
@@ -398,7 +398,7 @@ impl<F: PrimeField> TableData<F> {
     /// notations: "[C]" absorb C; "]r[" squeeze r;
     /// sequence of generating challenges:
     /// [pi.instance] -> [C1] -> ]r1[ -> [C2] -> ]r2[ -> [C3] -> ]r3[
-    fn run_sps_protocol_3<C: CurveAffine<ScalarExt = F>, RO: ROTrait<C>>(
+    fn run_sps_protocol_3<C: CurveAffine<ScalarExt = F>, RO: ROTrait<C::Base>>(
         &self,
         ck: &CommitmentKey<C>,
         ro_nark: &mut RO,
@@ -417,7 +417,7 @@ impl<F: PrimeField> TableData<F> {
         let W1 = concatenate_with_padding(&self.advice_columns, k_power_of_2);
         let C1 = ck.commit(&W1);
         ro_nark.absorb_point(&C1);
-        let r1 = ro_nark.squeeze(NUM_CHALLENGE_BITS);
+        let r1 = ro_nark.squeeze::<C>(NUM_CHALLENGE_BITS);
 
         // round 2
         let lookup_coeff = self
@@ -433,7 +433,7 @@ impl<F: PrimeField> TableData<F> {
         );
         let C2 = ck.commit(&W2);
         ro_nark.absorb_point(&C2);
-        let r2 = ro_nark.squeeze(NUM_CHALLENGE_BITS);
+        let r2 = ro_nark.squeeze::<C>(NUM_CHALLENGE_BITS);
 
         // round 3
         let lookup_coeff = lookup_coeff.evaluate_coefficient_2(r2);
@@ -445,7 +445,7 @@ impl<F: PrimeField> TableData<F> {
 
         let C3 = ck.commit(&W3);
         ro_nark.absorb_point(&C3);
-        let r3 = ro_nark.squeeze(NUM_CHALLENGE_BITS);
+        let r3 = ro_nark.squeeze::<C>(NUM_CHALLENGE_BITS);
 
         Ok((
             PlonkInstance {
@@ -462,7 +462,7 @@ impl<F: PrimeField> TableData<F> {
     /// run special soundness protocol to generate witnesses and challenges
     /// depending on whether we have multiple gates, lookup arguments and whether
     /// we have vector lookup, we will call different sub-sps protocol
-    pub fn run_sps_protocol<C: CurveAffine<ScalarExt = F>, RO: ROTrait<C>>(
+    pub fn run_sps_protocol<C: CurveAffine<ScalarExt = F>, RO: ROTrait<C::Base>>(
         &self,
         ck: &CommitmentKey<C>,
         ro_nark: &mut RO,

--- a/src/table.rs
+++ b/src/table.rs
@@ -43,7 +43,7 @@ use halo2_proofs::{
 use log::*;
 use std::collections::HashMap;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct TableData<F: PrimeField> {
     // TODO: without usable_rows still safe?
     pub(crate) k: u32,

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,14 +1,14 @@
-use crate::main_gate::AssignedValue;
-use crate::poseidon::PoseidonHash;
-use crate::poseidon::ROTrait;
+use std::{fmt, iter, num::NonZeroUsize};
+
 use ff::{BatchInvert, Field, PrimeField};
 use halo2_proofs::plonk::Assigned;
 use num_bigint::BigUint;
-use poseidon::Spec;
 pub(crate) use rayon::current_num_threads;
-use std::fmt;
-use std::iter;
-use std::num::NonZeroUsize;
+
+use crate::{
+    main_gate::AssignedValue,
+    poseidon::{PoseidonHash, ROTrait, Spec},
+};
 
 pub fn bytes_to_bits_le(bytes: Vec<u8>) -> Vec<bool> {
     let mut bits = Vec::new();

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,7 +3,6 @@ use crate::poseidon::PoseidonHash;
 use crate::poseidon::ROTrait;
 use ff::{BatchInvert, Field, PrimeField};
 use halo2_proofs::plonk::Assigned;
-use halo2curves::CurveAffine;
 use num_bigint::BigUint;
 use poseidon::Spec;
 pub(crate) use rayon::current_num_threads;
@@ -193,17 +192,17 @@ pub(crate) fn concatenate_with_padding<F: PrimeField>(vs: &[Vec<F>], pad_size: u
 }
 
 pub(crate) fn create_ro<
-    C: CurveAffine,
+    F: PrimeField,
     const T: usize,
     const RATE: usize,
     const R_F: usize,
     const R_P: usize,
->() -> PoseidonHash<C, T, RATE>
+>() -> PoseidonHash<F, T, RATE>
 where
-    C::Base: ff::PrimeFieldBits + ff::FromUniformBytes<64>,
+    F: ff::PrimeFieldBits + ff::FromUniformBytes<64>,
 {
-    let spec = Spec::<C::Base, T, RATE>::new(R_F, R_P);
-    PoseidonHash::<C, T, RATE>::new(spec)
+    let spec = Spec::<F, T, RATE>::new(R_F, R_P);
+    PoseidonHash::<F, T, RATE>::new(spec)
 }
 
 /// Concatenate N vectors


### PR DESCRIPTION
Fix the test failure in #118 . It allows initialization of PlonkStructure for default/empty TableData.
It will be the dev's responsibility to assembly TableData before calling `fn plonk_structure`


