### PR TITLE
feat(ivc): impl `IVC::new`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@
 *.sh
 *.txt
 .vscode
+.cache
 .idea
+tags

--- a/examples/sha256/main.rs
+++ b/examples/sha256/main.rs
@@ -401,5 +401,5 @@ fn main() {
     )
     .unwrap();
 
-    debug!("base case ready: {ivc:?}");
+    debug!("base case ready");
 }

--- a/examples/sha256/main.rs
+++ b/examples/sha256/main.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use std::{array, iter, marker::PhantomData, num::NonZeroUsize};
+use std::{array, fs, io, iter, marker::PhantomData, num::NonZeroUsize, path::Path};
 
 use ff::PrimeField;
 use halo2_gadgets::sha256::BLOCK_SIZE;
@@ -9,15 +9,16 @@ use halo2_proofs::{
     plonk::ConstraintSystem,
 };
 
-use halo2curves::{bn256, grumpkin, CurveExt};
+use halo2curves::{bn256, grumpkin, CurveAffine, CurveExt};
 
 use bn256::G1 as C1;
 use grumpkin::G1 as C2;
 
+use log::*;
 use sirius::{
+    commitment::CommitmentKey,
     ivc::{step_circuit, PublicParams, SimpleFloorPlanner, StepCircuit, SynthesisError, IVC},
     poseidon::{self, ROPair},
-    table::TableData,
 };
 
 mod table16;
@@ -265,6 +266,9 @@ struct TestSha256Circuit<F: PrimeField> {
 // TODO
 const ARITY: usize = BLOCK_SIZE / 2;
 
+const CIRCUIT_TABLE_SIZE: usize = 22;
+const COMMITMENT_KEY_SIZE: usize = 27;
+
 impl<F: PrimeField> StepCircuit<ARITY, F> for TestSha256Circuit<F> {
     type Config = Table16Config;
     type FloorPlanner = SimpleFloorPlanner;
@@ -318,10 +322,12 @@ impl<F: PrimeField> StepCircuit<ARITY, F> for TestSha256Circuit<F> {
     }
 }
 
-type RandomOracle<const T: usize, const RATE: usize> = poseidon::PoseidonRO<T, RATE>;
+const T: usize = 5;
+const RATE: usize = 4;
 
-type RandomOracleConstant<const T: usize, const RATE: usize, F> =
-    <RandomOracle<T, RATE> as ROPair<F>>::Args;
+type RandomOracle = poseidon::PoseidonRO<T, RATE>;
+
+type RandomOracleConstant<F> = <RandomOracle as ROPair<F>>::Args;
 
 const LIMB_WIDTH: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(32) };
 const LIMBS_COUNT_LIMIT: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(10) };
@@ -332,53 +338,68 @@ type C2Affine = <C2 as halo2curves::group::prime::PrimeCurve>::Affine;
 type C1Scalar = <C1 as halo2curves::group::Group>::Scalar;
 type C2Scalar = <C2 as halo2curves::group::Group>::Scalar;
 
+fn get_or_create_commitment_key<C>(k: usize, label: &'static str) -> io::Result<CommitmentKey<C>>
+where
+    C: CurveAffine + serde::Serialize + serde::de::DeserializeOwned,
+    C::Repr: serde::Serialize + serde::de::DeserializeOwned,
+{
+    const FOLDER: &str = ".cache/examples/sha256";
+
+    let file_name = format!("{}/commitment_{}_{}.bin", FOLDER, label, k);
+    let file_path = Path::new(&file_name);
+
+    if file_path.exists() {
+        debug!("{file_path:?} exists, load key");
+        unsafe { CommitmentKey::load_from_file(file_path, 2_usize.pow(k as u32)) }
+    } else {
+        debug!("{file_path:?} not exists, start generate");
+        let key = CommitmentKey::setup(k, label.as_bytes());
+        fs::create_dir_all(file_path.parent().unwrap())?;
+        unsafe {
+            key.save_to_file(file_path)?;
+        }
+        Ok(key)
+    }
+}
+
 fn main() {
+    env_logger::init();
+    log::info!("Start");
     // C1
     let sc1 = TestSha256Circuit::default();
     // C2
     let sc2 = step_circuit::trivial::Circuit::<ARITY, _>::default();
 
-    let _cs1 = TableData::<<C1 as CurveExt>::Base>::new(11, vec![]);
-    let _cs2 = TableData::<<C2 as CurveExt>::Base>::new(11, vec![]);
+    let primary_spec = RandomOracleConstant::<<C2 as CurveExt>::Base>::new(10, 10);
+    let secondary_spec = RandomOracleConstant::<<C1 as CurveExt>::Base>::new(10, 10);
 
-    let primary_spec = RandomOracleConstant::<5, 5, <C2 as CurveExt>::Base>::new(10, 10);
-    let secondary_spec = RandomOracleConstant::<5, 5, <C1 as CurveExt>::Base>::new(10, 10);
+    info!("Start generate");
+    let primary_commitment_key = get_or_create_commitment_key(COMMITMENT_KEY_SIZE, "primary")
+        .expect("Failed to get primary key");
+    info!("Primary generated");
+    let secondary_commitment_key = get_or_create_commitment_key(COMMITMENT_KEY_SIZE, "secondary")
+        .expect("Failed to get secondary key");
+    info!("Secondary generated");
 
-    const K: usize = 20;
-    let mut pp = PublicParams::<C1Affine, C2Affine, RandomOracle<5, 5>, RandomOracle<5, 5>>::new(
-        K as u32,
+    let pp = PublicParams::<C1Affine, C2Affine, RandomOracle, RandomOracle>::new(
+        CIRCUIT_TABLE_SIZE as u32,
+        &primary_commitment_key,
+        &secondary_commitment_key,
         primary_spec,
         secondary_spec,
         LIMB_WIDTH,
         LIMBS_COUNT_LIMIT,
     );
+    info!("Public Params: {pp:?}");
 
-    let mut ivc = IVC::new(
-        &mut pp,
+    let ivc = IVC::new(
+        &pp,
         sc1,
-        array::from_fn(|i| C2Scalar::from_u128(i as u128)),
+        array::from_fn(|i| C1Scalar::from_u128(i as u128)),
         sc2,
-        array::from_fn(|i| C1Scalar::from_u128(i as u128)),
-    )
-    .unwrap();
-
-    ivc.prove_step(
-        &pp,
-        array::from_fn(|i| C1Scalar::from_u128(i as u128)),
         array::from_fn(|i| C2Scalar::from_u128(i as u128)),
     )
     .unwrap();
 
-    ivc.verify(
-        &pp,
-        2,
-        array::from_fn(|i| C1Scalar::from_u128(i as u128)),
-        array::from_fn(|i| C2Scalar::from_u128(i as u128)),
-    )
-    .unwrap();
-
-    todo!(
-        "#33 Waiting for IVC Circuit for test {:?}",
-        TestSha256Circuit::<<C1 as CurveExt>::Base>::default()
-    );
+    debug!("base case ready: {ivc:?}");
 }

--- a/examples/trivial/main.rs
+++ b/examples/trivial/main.rs
@@ -1,0 +1,105 @@
+#![allow(dead_code)]
+
+use std::{array, fs, io, num::NonZeroUsize, path::Path};
+
+use ff::PrimeField;
+use halo2_gadgets::sha256::BLOCK_SIZE;
+
+use halo2curves::{bn256, grumpkin, CurveAffine, CurveExt};
+
+use bn256::G1 as C1;
+use grumpkin::G1 as C2;
+
+use log::*;
+use sirius::{
+    commitment::CommitmentKey,
+    ivc::{step_circuit, PublicParams, IVC},
+    poseidon::{self, ROPair},
+};
+
+const ARITY: usize = BLOCK_SIZE / 2;
+
+const CIRCUIT_TABLE_SIZE: usize = 20;
+const COMMITMENT_KEY_SIZE: usize = 25;
+const T: usize = 5;
+const RATE: usize = 4;
+
+type RandomOracle = poseidon::PoseidonRO<T, RATE>;
+
+type RandomOracleConstant<F> = <RandomOracle as ROPair<F>>::Args;
+
+const LIMB_WIDTH: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(32) };
+const LIMBS_COUNT_LIMIT: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(10) };
+
+type C1Affine = <C1 as halo2curves::group::prime::PrimeCurve>::Affine;
+type C2Affine = <C2 as halo2curves::group::prime::PrimeCurve>::Affine;
+
+type C1Scalar = <C1 as halo2curves::group::Group>::Scalar;
+type C2Scalar = <C2 as halo2curves::group::Group>::Scalar;
+
+fn get_or_create_commitment_key<C>(k: usize, label: &'static str) -> io::Result<CommitmentKey<C>>
+where
+    C: CurveAffine + serde::Serialize + serde::de::DeserializeOwned,
+    C::Repr: serde::Serialize + serde::de::DeserializeOwned,
+{
+    const FOLDER: &str = ".cache/examples/sha256";
+
+    let file_name = format!("{}/commitment_{}_{}.bin", FOLDER, label, k);
+    let file_path = Path::new(&file_name);
+
+    if file_path.exists() {
+        debug!("{file_path:?} exists, load key");
+        unsafe { CommitmentKey::load_from_file(file_path, 2_usize.pow(k as u32)) }
+    } else {
+        debug!("{file_path:?} not exists, start generate");
+        let key = CommitmentKey::setup(k, label.as_bytes());
+        fs::create_dir_all(file_path.parent().unwrap())?;
+        unsafe {
+            key.save_to_file(file_path)?;
+        }
+        Ok(key)
+    }
+}
+
+fn main() {
+    env_logger::init();
+    log::info!("Start");
+    // C1
+    let sc1 = step_circuit::trivial::Circuit::<ARITY, _>::default();
+    // C2
+    let sc2 = step_circuit::trivial::Circuit::<ARITY, _>::default();
+
+    let primary_spec = RandomOracleConstant::<<C2 as CurveExt>::Base>::new(10, 10);
+    let secondary_spec = RandomOracleConstant::<<C1 as CurveExt>::Base>::new(10, 10);
+
+    info!("Start generate");
+    let primary_commitment_key = get_or_create_commitment_key(COMMITMENT_KEY_SIZE, "primary")
+        .expect("Failed to get primary key");
+    info!("Primary generated");
+    let secondary_commitment_key = get_or_create_commitment_key(COMMITMENT_KEY_SIZE, "secondary")
+        .expect("Failed to get secondary key");
+    info!("Secondary generated");
+
+    let pp = PublicParams::<C1Affine, C2Affine, RandomOracle, RandomOracle>::new(
+        CIRCUIT_TABLE_SIZE as u32,
+        &primary_commitment_key,
+        &secondary_commitment_key,
+        primary_spec,
+        secondary_spec,
+        LIMB_WIDTH,
+        LIMBS_COUNT_LIMIT,
+    );
+    info!("public params: {pp:?}");
+
+    debug!("start ivc");
+    let _ivc = IVC::new(
+        &pp,
+        sc1,
+        array::from_fn(|i| C1Scalar::from_u128(i as u128)),
+        sc2,
+        array::from_fn(|i| C2Scalar::from_u128(i as u128)),
+    )
+    .unwrap();
+
+    debug!("base case ready");
+}

--- a/src/commitment.rs
+++ b/src/commitment.rs
@@ -1,23 +1,45 @@
-use std::{io::Read, iter};
+use std::{iter, ops};
 
 use digest::{ExtendableOutput, Update};
 use group::Curve;
 use halo2_proofs::arithmetic::{best_multiexp, CurveAffine, CurveExt};
+use log::*;
 use rayon::prelude::*;
-use serde::Serialize;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use sha3::Shake256;
 
 use crate::util::parallelize;
 
-#[derive(Clone, Debug, Serialize)]
-#[serde(bound(serialize = "C: Serialize"))]
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Can't commit too long input: input len: {input_len}, but limit is {limit}")]
+    TooLongInput { input_len: usize, limit: usize },
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CommitmentKey<C: CurveAffine> {
-    ck: Vec<C>,
+    ck: Box<[C]>,
+}
+
+impl<C: CurveAffine> ops::Deref for CommitmentKey<C> {
+    type Target = [C];
+
+    fn deref(&self) -> &Self::Target {
+        &self.ck
+    }
 }
 
 impl<C: CurveAffine> CommitmentKey<C> {
     pub fn default_value() -> C {
         C::identity()
+    }
+
+    pub fn len(&self) -> usize {
+        self.ck.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.ck.is_empty()
     }
 
     pub fn setup(k: usize, label: &'static [u8]) -> Self {
@@ -26,21 +48,19 @@ impl<C: CurveAffine> CommitmentKey<C> {
         assert!(k < 32);
         let n: usize = 1 << k;
 
-        let mut shake = Shake256::default();
-        shake.update(label);
-        let mut reader = shake.finalize_xof();
+        let mut reader = Shake256::default().chain(label).finalize_xof();
 
-        let ck_proj: Vec<_> = iter::repeat_with(|| {
-            let mut uniform_bytes = [0u8; 32];
-            reader.read_exact(&mut uniform_bytes).unwrap();
-            uniform_bytes
+        let ck_proj: Box<[_]> = iter::repeat_with(|| {
+            let mut buffer = [0u8; 32];
+            reader.read_exact(&mut buffer).unwrap();
+            buffer
         })
         .take(n)
         .par_bridge()
         .map(|uniform_byte| (C::CurveExt::hash_to_curve("from_uniform_bytes"))(&uniform_byte))
         .collect();
 
-        let mut ck: Vec<C> = vec![C::identity(); n];
+        let mut ck: Box<[C]> = iter::repeat(C::identity()).take(n).collect();
         parallelize(&mut ck, |(ck, start)| {
             C::Curve::batch_normalize(&ck_proj[start..start + ck.len()], ck);
         });
@@ -48,11 +68,52 @@ impl<C: CurveAffine> CommitmentKey<C> {
         CommitmentKey { ck }
     }
 
-    pub fn commit(&self, v: &[C::Scalar]) -> C {
-        assert!(
-            self.ck.len() >= v.len(),
-            "CommitmentKey size must be greater than or equal to scalar vector size"
-        );
-        best_multiexp(v, &self.ck[..v.len()]).to_affine()
+    pub fn commit(&self, v: &[C::Scalar]) -> Result<C, Error> {
+        if self.ck.len() >= v.len() {
+            Ok(best_multiexp(v, &self.ck[..v.len()]).to_affine())
+        } else {
+            Err(Error::TooLongInput {
+                input_len: v.len(),
+                limit: self.ck.len(),
+            })
+        }
+    }
+}
+
+use std::{
+    fs::File,
+    io::{self, Read, Write},
+    path::Path,
+    slice,
+};
+
+impl<C: CurveAffine> CommitmentKey<C>
+where
+    C::Repr: Serialize + DeserializeOwned,
+{
+    /// # Safety
+    /// TODO
+    pub unsafe fn save_to_file(&self, file_path: &Path) -> io::Result<()> {
+        let ptr = self.ck.as_ptr();
+        let len = self.ck.len();
+        let byte_slice = slice::from_raw_parts(ptr as *const u8, len * std::mem::size_of::<C>());
+        File::create(file_path)?.write_all(byte_slice)
+    }
+
+    /// # Safety
+    /// TODO
+    pub unsafe fn load_from_file(file_path: &Path, vec_len: usize) -> io::Result<Self> {
+        let mut vec = Vec::with_capacity(vec_len);
+        let mut file = File::open(file_path)?;
+        let ptr = vec.as_mut_ptr();
+        let byte_slice =
+            slice::from_raw_parts_mut(ptr as *mut u8, vec_len * std::mem::size_of::<C>());
+
+        file.read_exact(byte_slice)?;
+        vec.set_len(vec_len);
+
+        Ok(Self {
+            ck: vec.into_boxed_slice(),
+        })
     }
 }

--- a/src/gadgets/nonnative/bn/big_uint_mul_mod_chip/tests.rs
+++ b/src/gadgets/nonnative/bn/big_uint_mul_mod_chip/tests.rs
@@ -459,7 +459,12 @@ mod components_tests {
             }
         }
 
-        BigUint::from_limbs(production_cells.into_iter().flatten(), LIMB_WIDTH).unwrap()
+        BigUint::from_limbs(
+            production_cells.into_iter().flatten(),
+            LIMB_WIDTH,
+            LIMBS_COUNT_LIMIT,
+        )
+        .unwrap()
     }
 
     fn sum_with_overflow<F: PrimeField>(lhs: &BigUint<F>, rhs: &BigUint<F>) -> BigUint<F> {
@@ -490,6 +495,7 @@ mod components_tests {
                     limb
                 }),
             LIMB_WIDTH,
+            LIMBS_COUNT_LIMIT,
         )
         .unwrap()
     }
@@ -516,6 +522,7 @@ mod components_tests {
                         .sum()
                 }),
             LIMB_WIDTH,
+            LIMBS_COUNT_LIMIT,
         )
         .unwrap()
     }

--- a/src/ivc/incrementally_verifiable_computation.rs
+++ b/src/ivc/incrementally_verifiable_computation.rs
@@ -1,15 +1,22 @@
 use std::io;
 
-use ff::{FromUniformBytes, PrimeFieldBits};
+use ff::{Field, FromUniformBytes, PrimeFieldBits};
 use group::prime::PrimeCurveAffine;
+use halo2_proofs::circuit::{floor_planner::single_pass::SingleChipLayouter, Layouter};
 use halo2curves::CurveAffine;
+use log::*;
 use serde::Serialize;
 
 use crate::{
-    ivc::public_params::PublicParams,
-    main_gate::{AssignedValue, MainGateConfig},
-    plonk::{PlonkTrace, RelaxedPlonkTrace},
-    poseidon::ROPair,
+    ivc::{
+        public_params::PublicParams,
+        step_circuit::{StepCircuitExt, StepInputs, StepSynthesisResult},
+    },
+    main_gate::{AdviceCyclicAssignor, AssignedValue, MainGateConfig, RegionCtx},
+    plonk::{PlonkInstance, PlonkTrace, RelaxedPlonkTrace},
+    poseidon::{ROPair, ROTrait},
+    sps,
+    table::TableData,
 };
 
 pub use super::{
@@ -17,7 +24,7 @@ pub use super::{
     step_circuit::{self, StepCircuit, SynthesisError},
 };
 
-// TODO #31 docs
+#[derive(Debug)]
 struct StepCircuitContext<const ARITY: usize, C, SC>
 where
     C: CurveAffine,
@@ -40,6 +47,8 @@ pub enum Error {
     Step(#[from] step_circuit::SynthesisError),
     #[error("TODO")]
     WhileHash(io::Error),
+    #[error(transparent)]
+    Sps(#[from] sps::Error),
 }
 
 // TODO #31 docs
@@ -55,38 +64,288 @@ where
     primary: StepCircuitContext<A1, C1, SC1>,
     secondary: StepCircuitContext<A2, C2, SC2>,
 
-    primary_trace: PlonkTrace<C2>,
+    secondary_trace: PlonkTrace<C2>,
 
     step: usize,
+}
+
+impl<
+        const A1: usize,
+        const A2: usize,
+        C1: std::fmt::Debug,
+        C2: std::fmt::Debug,
+        SC1: std::fmt::Debug,
+        SC2: std::fmt::Debug,
+    > std::fmt::Debug for IVC<A1, A2, C1, C2, SC1, SC2>
+where
+    C1: CurveAffine<Base = <C2 as PrimeCurveAffine>::Scalar>,
+    C2: CurveAffine<Base = <C1 as PrimeCurveAffine>::Scalar>,
+    SC1: StepCircuit<A1, C1::Scalar>,
+    SC2: StepCircuit<A2, C2::Scalar>,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IVC")
+            .field("primary", &self.primary)
+            .field("secondary", &self.secondary)
+            .field("secondary_trace", &self.secondary_trace)
+            .field("step", &self.step)
+            .finish()
+    }
 }
 
 impl<const A1: usize, const A2: usize, C1, C2, SC1, SC2> IVC<A1, A2, C1, C2, SC1, SC2>
 where
     C1: CurveAffine<Base = <C2 as PrimeCurveAffine>::Scalar> + Serialize,
     C2: CurveAffine<Base = <C1 as PrimeCurveAffine>::Scalar> + Serialize,
-    C1::ScalarExt: Serialize,
-    C2::ScalarExt: Serialize,
+    C1::Base: PrimeFieldBits + FromUniformBytes<64> + Serialize,
+    C2::Base: PrimeFieldBits + FromUniformBytes<64> + Serialize,
     SC1: StepCircuit<A1, C1::Scalar>,
     SC2: StepCircuit<A2, C2::Scalar>,
-    C1::Base: PrimeFieldBits + FromUniformBytes<64>,
-    C2::Base: PrimeFieldBits + FromUniformBytes<64>,
 {
+    /// Initializes a new instance of an Incrementally Verifiable Computation (IVC) system.
+    ///
+    /// This method establishes the zero round (base case) of the IVC within the context.
+    /// It sets up the primary and secondary step circuits, along with their initial states (z0),
+    /// and configures the necessary parameters and traces for both circuits.
+    ///
+    /// # Type Parameters
+    /// * `T` - A constant size parameter for the [`crate::main_gate::MainGateConfig`].
+    /// * `RP1`, `RP2` - Types representing the random oracle pair (on-circuit & off-circuit) for
+    /// the primary and secondary curves, respectively.
+    ///
+    /// # Algorithmic Summary
+    ///
+    /// 1. **Table Data Preparation**: For both primary and secondary circuits, it initializes
+    ///    [`TableData`] structures with the provided Plonk configuration parameters. These
+    ///    structures are essential for building the circuit layout and assembling the proof
+    ///    system.
+    ///
+    /// 2. **Circuit Configuration**: It configures the step circuits for both primary and
+    ///    secondary contexts. This involves defining the layout and constraints of the circuits
+    ///    based on the `StepCircuit` trait implementations for `SC1` and `SC2`.
+    ///
+    /// 3. **Initial State Assignment**: The initial states (`z0_primary` and `z0_secondary`) are
+    ///    assigned to the constraint system. This forms the base case for the IVC scheme, representing
+    ///    the starting point of the computation.
+    ///
+    /// 4. **Synthesizing the Primary Step Circuit**: Constructs the primary step circuit by
+    ///    applying constraints and recording output states (`z_i`), encoding the computation for
+    ///    the zero round. After run The Sumcheck Protocol over Polynomial Systems (SPS Protocol) for
+    ///    receive generates [`PlonkInstance`] (`u`) & [`crate::plonk::PlonkWitness`]
+    ///
+    /// 5. **Synthesizing the Secondary Step Circuit**: Similarly, constructs the secondary step
+    ///    circuit. Notably, it passes the [`PlonkInstance`] from the primary circuit synthesis as
+    ///    [`StepInputs::u`].After run The Sumcheck Protocol over Polynomial Systems (SPS Protocol) for
+    ///    receive generates [`PlonkInstance`] (`u`) & [`crate::plonk::PlonkWitness`]
+    ///
+    /// 6. **Creating StepCircuitContext**: For both primary and secondary circuits, a
+    ///    [`StepCircuitContext`] is created, encapsulating the step circuit, its relaxed trace, and
+    ///    the initial and final states.
+    ///
+    /// 7. **Finalizing IVC Instance**: The function concludes by constructing and returning the
+    ///    `IVC` instance, which holds the contexts for both circuits.
     pub fn new<const T: usize, RP1, RP2>(
-        _pp: &mut PublicParams<C1, C2, RP1, RP2>,
-        _primary: SC1,
-        _z0_primary: [C1::Base; A1],
-        _secondary: SC2,
-        _z0_secondary: [C2::Base; A2],
+        pp: &PublicParams<C1, C2, RP2, RP1>,
+        primary: SC1,
+        z0_primary: [C1::Scalar; A1],
+        secondary: SC2,
+        z0_secondary: [C2::Scalar; A2],
     ) -> Result<Self, Error>
     where
-        RP1: ROPair<C1::Base, Config = MainGateConfig<T>>,
-        RP2: ROPair<C2::Base, Config = MainGateConfig<T>>,
+        RP1: ROPair<C1::Scalar, Config = MainGateConfig<T>>,
+        RP2: ROPair<C2::Scalar, Config = MainGateConfig<T>>,
     {
-        // TODO #31
-        todo!("Logic at `RecursiveSNARK::new`")
+        info!("start ivc base case");
+
+        let primary_public_params_hash = pp.digest()?;
+        let secondary_public_params_hash = pp.digest()?;
+
+        let mut primary_td = TableData::new(
+            pp.primary.k_table_size,
+            // Not used in zero step, only in verify-step, when folding is over
+            vec![C1::Scalar::ZERO, C1::Scalar::ZERO],
+        );
+        let primary_config = primary_td.prepare_assembly(|cs| {
+            // Not used in zero step, only in verify-step, when folding is over
+            let _X0 = cs.instance_column();
+            <SC1 as StepCircuitExt<'_, A1, C2>>::configure(cs)
+        })?;
+        debug!("primary step circuit configured");
+
+        let mut secondary_td = TableData::new(
+            pp.secondary.k_table_size,
+            // Not used in zero step, only in verify-step, when folding is over
+            vec![C2::Scalar::ZERO, C2::Scalar::ZERO],
+        );
+        let secondary_config = secondary_td.prepare_assembly(|cs| {
+            // Not used in zero step, only in verify-step, when folding is over
+            let _X0 = cs.instance_column();
+            <SC2 as StepCircuitExt<'_, A2, C1>>::configure(cs)
+        })?;
+        debug!("secondary step circuit configured");
+
+        let primary_cross_term_commits_len = secondary_td
+            .plonk_structure()
+            .unwrap()
+            .get_degree_for_folding();
+
+        let secondary_cross_term_commits_len = primary_td
+            .plonk_structure()
+            .unwrap()
+            .get_degree_for_folding();
+
+        debug!("cross term commits len: primary={primary_cross_term_commits_len}, secondary={secondary_cross_term_commits_len}");
+
+        let (primary_ctx, primary_plonk_instance) = {
+            let mut layouter =
+                SingleChipLayouter::<'_, C1::Scalar, _>::new(&mut primary_td, vec![])?;
+
+            let primary_assigned_z0: [_; A1] = layouter.assign_region(
+                || "assigned_z0_primary",
+                |region| {
+                    primary_config
+                        .main_gate_config
+                        .advice_cycle_assigner()
+                        .assign_all_advice(
+                            &mut RegionCtx::new(region, 0),
+                            || "z0_primary",
+                            z0_primary.iter().copied(),
+                        )
+                        .map(|inp| inp.try_into().unwrap())
+                },
+            )?;
+            debug!("primary z0 assigned");
+            debug!("start primary synthesize");
+
+            let StepSynthesisResult {
+                z_output: primary_assigned_z_output,
+                // Not used in zero step, only in verify-step, when folding is over
+                output_hash: _primary_output_hash,
+                // Not used in zero step, only in verify-step, when folding is over
+                X1: _primary_X1,
+            } = primary.synthesize(
+                primary_config,
+                &mut layouter,
+                StepInputs {
+                    step_public_params: &pp.primary.params,
+                    public_params_hash: primary_public_params_hash,
+                    step: C1::Scalar::ZERO,
+                    z_0: primary_assigned_z0.clone(),
+                    z_i: primary_assigned_z0.clone(),
+                    // Can be any
+                    U: PlonkInstance::default().to_relax(),
+                    // Can be any
+                    u: PlonkInstance::default(),
+                    cross_term_commits: vec![C2::identity(); primary_cross_term_commits_len],
+                },
+            )?;
+
+            debug!("start primary td postpone");
+            primary_td.postpone_assembly();
+            debug!("primary synthesized, start sps");
+
+            let (primary_plonk_instance, primary_plonk_witness) = primary_td.run_sps_protocol(
+                pp.secondary.ck,
+                &mut RP2::OffCircuit::new(pp.secondary.params.ro_constant.clone()),
+                primary_td.plonk_structure().unwrap().num_challenges,
+            )?;
+
+            (
+                StepCircuitContext::<A1, C1, SC1> {
+                    step_circuit: primary,
+                    relaxed_trace: RelaxedPlonkTrace {
+                        U: primary_plonk_instance.to_relax(),
+                        W: primary_plonk_witness.to_relax(pp.primary.k_table_size as usize),
+                    },
+                    z_0: primary_assigned_z0,
+                    z_i: primary_assigned_z_output,
+                },
+                primary_plonk_instance,
+            )
+        };
+        debug!("primary ctx ready");
+
+        let (secondary_ctx, secondary_trace) = {
+            let mut layouter =
+                SingleChipLayouter::<'_, C2::Scalar, _>::new(&mut secondary_td, vec![])?;
+
+            let secondary_assigned_z0: [_; A2] = layouter.assign_region(
+                || "assigned_z0_secondary",
+                |region| {
+                    secondary_config
+                        .main_gate_config
+                        .advice_cycle_assigner()
+                        .assign_all_advice(
+                            &mut RegionCtx::new(region, 0),
+                            || "z0_secondary",
+                            z0_secondary.iter().copied(),
+                        )
+                        .map(|inp| inp.try_into().unwrap())
+                },
+            )?;
+            debug!("secondary z0 assigned");
+            debug!("start secondary synthesize");
+
+            let StepSynthesisResult {
+                z_output: secondary_assigned_z_output,
+                // Not used in zero step, only in verify-step, when folding is over
+                output_hash: _secondary_output_hash,
+                // Not used in zero step, only in verify-step, when folding is over
+                X1: _secondary_X1,
+            } = secondary.synthesize(
+                secondary_config,
+                &mut layouter,
+                StepInputs {
+                    step_public_params: &pp.secondary.params,
+                    public_params_hash: secondary_public_params_hash,
+                    step: C2::Scalar::ZERO,
+                    z_0: secondary_assigned_z0.clone(),
+                    z_i: secondary_assigned_z0.clone(),
+                    // Can be any
+                    U: primary_plonk_instance.to_relax(),
+                    u: primary_plonk_instance.clone(),
+                    cross_term_commits: vec![C1::identity(); secondary_cross_term_commits_len],
+                },
+            )?;
+
+            debug!("start secondary td postpone");
+            secondary_td.postpone_assembly();
+            debug!("secondary synthesized");
+
+            let (secondary_plonk_instance, secondary_plonk_witness) = secondary_td
+                .run_sps_protocol(
+                    pp.primary.ck,
+                    &mut RP1::OffCircuit::new(pp.primary.params.ro_constant.clone()),
+                    secondary_td.plonk_structure().unwrap().num_challenges,
+                )?;
+
+            (
+                StepCircuitContext::<A2, C2, SC2> {
+                    step_circuit: secondary,
+                    relaxed_trace: RelaxedPlonkTrace {
+                        U: secondary_plonk_instance.to_relax(),
+                        W: secondary_plonk_witness.to_relax(pp.secondary.k_table_size as usize),
+                    },
+                    z_0: secondary_assigned_z0,
+                    z_i: secondary_assigned_z_output,
+                },
+                PlonkTrace {
+                    u: secondary_plonk_instance,
+                    w: secondary_plonk_witness,
+                },
+            )
+        };
+        debug!("secondary ctx ready");
+
+        Ok(Self {
+            step: 1,
+            secondary_trace,
+            primary: primary_ctx,
+            secondary: secondary_ctx,
+        })
     }
 
-    pub fn prove_step<RO1, RO2>(
+    pub fn fold_step<RO1, RO2>(
         &mut self,
         _pp: &PublicParams<C1, C2, RO1, RO2>,
         _z0_primary: [C1::Scalar; A1],

--- a/src/nifs/vanilla.rs
+++ b/src/nifs/vanilla.rs
@@ -111,7 +111,8 @@ impl<C: CurveAffine, RO: ROTrait<C::Base>> VanillaFS<C, RO> {
                     .collect::<Result<Vec<C::ScalarExt>, EvalError>>()
             })
             .collect::<Result<Vec<Vec<C::ScalarExt>>, EvalError>>()?;
-        let cross_term_commits: Vec<C> = cross_terms.iter().map(|v| ck.commit(v)).collect();
+        let cross_term_commits: Vec<C> =
+            cross_terms.iter().map(|v| ck.commit(v).unwrap()).collect();
         Ok((cross_terms, cross_term_commits))
     }
 

--- a/src/plonk/lookup.rs
+++ b/src/plonk/lookup.rs
@@ -36,11 +36,15 @@
 //!
 //! Please see (#34)[https://github.com/snarkify/sirius/issues/34] for details on notations.
 //!
-use std::array;
+use std::{
+    array,
+    collections::{HashMap, HashSet},
+};
 
 use ff::PrimeField;
 use halo2_proofs::{plonk::ConstraintSystem, poly::Rotation};
 use itertools::Itertools;
+use log::*;
 use rayon::prelude::*;
 use serde::Serialize;
 
@@ -204,9 +208,11 @@ impl<F: PrimeField> Arguments<F> {
             fixed: &table.fixed_columns,
             advice: &table.advice_columns,
         };
+
         let nrow = 2usize.pow(table.k);
+        debug!("lookup_polys len: {} ", self.lookup_polys.len());
         self.lookup_polys
-            .iter()
+            .par_iter()
             .map(|expr| expr.expand())
             .map(|poly| {
                 (0..nrow)
@@ -229,7 +235,7 @@ impl<F: PrimeField> Arguments<F> {
         };
         let nrow = 2usize.pow(table.k);
         self.table_polys
-            .iter()
+            .par_iter()
             .map(|expr| expr.expand())
             .map(|poly| {
                 (0..nrow)
@@ -242,15 +248,31 @@ impl<F: PrimeField> Arguments<F> {
     /// calculate the coefficients {m_i} in the log derivative formula
     /// m_i = sum_j \xi(w_j=t_i) assuming {t_i} have no duplicates
     fn evaluate_m(&self, l: &[F], t: &[F]) -> Vec<F> {
-        let mut processed_t = Vec::new();
+        debug!("evaluate_m: {} & {}", l.len(), t.len());
+        let mut processed_t = HashSet::with_capacity(l.len().max(t.len()));
+
+        let l_elements = l
+            .iter()
+            .fold(HashMap::with_capacity(l.len()), |mut acc, l_i| {
+                *acc.entry(l_i.to_repr().as_ref().to_vec()).or_insert(0) += 1;
+                acc
+            });
+
+        debug!("builded l_elements {}", l_elements.len());
 
         t.iter()
             .map(|t_i| {
-                if processed_t.contains(&t_i) {
+                if processed_t.contains(t_i.to_repr().as_ref()) {
                     F::ZERO
                 } else {
-                    processed_t.push(t_i);
-                    F::from_u128(l.iter().filter(|l_j| l_j.eq(&t_i)).count() as u128)
+                    processed_t.insert(t_i.to_repr().as_ref().to_vec());
+
+                    F::from_u128(
+                        l_elements
+                            .get(t_i.to_repr().as_ref())
+                            .copied()
+                            .unwrap_or_default() as u128,
+                    )
                 }
             })
             .collect()
@@ -274,14 +296,18 @@ impl<F: PrimeField> Arguments<F> {
         table: &TableData<F>,
         r: F,
     ) -> Result<ArgumentCoefficient1<F>, Error> {
+        debug!("start evaluate_coefficient_1");
         let ls = self.evaluate_ls(table, r)?;
+        debug!("ls calculated: {}", ls.len());
         let ts = self.evaluate_ts(table, r)?;
+        debug!("ts calculated: {}", ts.len());
 
-        let ms = ls
-            .iter()
-            .zip_eq(ts.iter())
+        let mut ms = Vec::with_capacity(ls.len());
+        ls.par_iter()
+            .zip_eq(ts.par_iter())
             .map(|(l, t)| self.evaluate_m(l, t))
-            .collect::<Vec<_>>();
+            .collect_into_vec(&mut ms);
+        debug!("ms calculated");
 
         Ok(ArgumentCoefficient1 { ls, ts, ms })
     }

--- a/src/plonk/mod.rs
+++ b/src/plonk/mod.rs
@@ -137,12 +137,14 @@ pub struct RelaxedPlonkWitness<F: PrimeField> {
 }
 
 // TODO #31 docs
+#[derive(Debug)]
 pub struct RelaxedPlonkTrace<C: CurveAffine> {
     pub U: RelaxedPlonkInstance<C>,
     pub W: RelaxedPlonkWitness<C::Scalar>,
 }
 
 // TODO #31 docs
+#[derive(Debug)]
 pub struct PlonkTrace<C: CurveAffine> {
     pub u: PlonkInstance<C>,
     pub w: PlonkWitness<C::Scalar>,
@@ -184,6 +186,11 @@ impl<F: PrimeField> PlonkStructure<F> {
         self.fixed_columns.len() + self.selectors.len()
     }
 
+    pub fn get_degree_for_folding(&self) -> usize {
+        let offset = self.num_non_fold_vars();
+        self.poly.degree_for_folding(offset)
+    }
+
     /// return the number of variables to be folded
     /// each lookup argument will add 5 variables (l,t,m,h,g)
     pub fn num_fold_vars(&self) -> usize {
@@ -221,7 +228,7 @@ impl<F: PrimeField> PlonkStructure<F> {
             .W_commitments
             .iter()
             .zip(W.W.iter())
-            .filter_map(|(Ci, Wi)| ck.commit(Wi).ne(Ci).then_some(()))
+            .filter_map(|(Ci, Wi)| ck.commit(Wi).unwrap().ne(Ci).then_some(()))
             .count();
 
         let data = PlonkEvalDomain {
@@ -266,7 +273,7 @@ impl<F: PrimeField> PlonkStructure<F> {
             .W_commitments
             .iter()
             .zip(W.W.iter())
-            .filter_map(|(Ci, Wi)| ck.commit(Wi).ne(Ci).then_some(()))
+            .filter_map(|(Ci, Wi)| ck.commit(Wi).unwrap().ne(Ci).then_some(()))
             .count();
 
         let nrow = 2usize.pow(self.k as u32);
@@ -290,7 +297,7 @@ impl<F: PrimeField> PlonkStructure<F> {
                     .filter(|(i, v)| W.E[*i].ne(v))
                     .count()
             })?;
-        let is_E_equal = ck.commit(&W.E).eq(&U.E_commitment);
+        let is_E_equal = ck.commit(&W.E).unwrap().eq(&U.E_commitment);
         let is_h_equal_g = self.is_sat_log_derivative(&W.W);
 
         match (res == 0, check_W_commitments == 0, is_E_equal, is_h_equal_g) {

--- a/src/polynomial/mod.rs
+++ b/src/polynomial/mod.rs
@@ -1,6 +1,6 @@
 use std::{
     cmp::{Eq, Ord, Ordering, PartialEq, PartialOrd},
-    collections::{HashMap, HashSet, BTreeSet},
+    collections::{BTreeSet, HashMap, HashSet},
     fmt,
     fmt::{Debug, Display},
     ops::{Add, Mul, Neg, Sub},

--- a/src/poseidon/random_oracle.rs
+++ b/src/poseidon/random_oracle.rs
@@ -19,7 +19,7 @@ pub trait ROConstantsTrait {
 
 pub trait ROTrait<F: PrimeField> {
     /// A type representing constants/parameters associated with the hash function
-    type Constants: ROConstantsTrait;
+    type Constants: ROConstantsTrait + Clone;
 
     /// Initializes the hash function
     fn new(constants: Self::Constants) -> Self;
@@ -82,7 +82,7 @@ where
     F: ff::PrimeFieldBits + ff::FromUniformBytes<64>,
 {
     /// Argument for creating on-circuit & off-circuit versions of oracles
-    type Args: fmt::Debug + serde::Serialize;
+    type Args: fmt::Debug + serde::Serialize + Clone;
     type Config;
 
     type OffCircuit: ROTrait<F, Constants = Self::Args>;

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,6 +4,7 @@ use ff::{BatchInvert, Field, PrimeField};
 use halo2_proofs::plonk::Assigned;
 use num_bigint::BigUint;
 pub(crate) use rayon::current_num_threads;
+use rayon::prelude::*;
 
 use crate::{
     main_gate::AssignedValue,
@@ -100,9 +101,9 @@ fn invert<F: Field>(
 
 pub(crate) fn batch_invert_assigned<F: Field>(assigned: &[Vec<Assigned<F>>]) -> Vec<Vec<F>> {
     let mut assigned_denominators: Vec<_> = assigned
-        .iter()
+        .par_iter()
         .map(|f| {
-            f.iter()
+            f.par_iter()
                 .map(|value| value.denominator())
                 .collect::<Vec<_>>()
         })
@@ -182,13 +183,87 @@ pub(crate) fn normalize_trailing_zeros(bits: &mut Vec<bool>, bit_len: NonZeroUsi
     }
 }
 
+/// Concatenates a slice of vectors, each containing elements of type `F`, into a single vector,
+/// with padding to ensure uniform segment sizes.
 pub(crate) fn concatenate_with_padding<F: PrimeField>(vs: &[Vec<F>], pad_size: usize) -> Vec<F> {
-    vs.iter()
-        .fold(Vec::with_capacity(vs.len() * pad_size), |mut result, v| {
-            result.extend_from_slice(v);
-            result.extend(iter::repeat(F::ZERO).take(pad_size.saturating_sub(v.len())));
-            result
+    vs.par_iter()
+        .flat_map_iter(|v| {
+            v.iter()
+                .copied()
+                .chain(iter::repeat(F::ZERO).take(pad_size.saturating_sub(v.len())))
         })
+        .collect()
+}
+
+#[allow(clippy::items_after_test_module)]
+#[cfg(test)]
+mod tests {
+    use halo2curves::pasta::Fp;
+
+    use super::*;
+
+    // Helper to easily create an Fp element
+    fn fp(num: u64) -> Fp {
+        Fp::from(num)
+    }
+
+    // Test empty input
+    #[test]
+    fn concatenate_empty() {
+        let input: Vec<Vec<Fp>> = vec![];
+        let result = concatenate_with_padding(&input, 4);
+        assert!(result.is_empty());
+    }
+
+    // Test padding with single vector
+    #[test]
+    fn single_vector_with_padding() {
+        let input = vec![vec![fp(1), fp(2)]];
+        let result = concatenate_with_padding(&input, 4);
+        assert_eq!(result, vec![fp(1), fp(2), Fp::zero(), Fp::zero()]);
+    }
+
+    // Test no padding needed (perfect fit)
+    #[test]
+    fn single_vector_no_padding() {
+        let input = vec![vec![fp(1), fp(2), fp(3), fp(4)]];
+        let result = concatenate_with_padding(&input, 4);
+        assert_eq!(result, vec![fp(1), fp(2), fp(3), fp(4)]);
+    }
+
+    // Test padding with multiple vectors
+    #[test]
+    fn multiple_vectors_with_padding() {
+        let input = vec![vec![fp(1), fp(2)], vec![fp(3)], vec![fp(4), fp(5), fp(6)]];
+        let pad_size = 4;
+
+        assert_eq!(
+            concatenate_with_padding(&input, pad_size),
+            [
+                fp(1),
+                fp(2),
+                Fp::zero(),
+                Fp::zero(), // First vector with padding
+                fp(3),
+                Fp::zero(),
+                Fp::zero(),
+                Fp::zero(), // Second vector with padding
+                fp(4),
+                fp(5),
+                fp(6),
+                Fp::zero(), // Third vector with padding
+            ]
+        );
+    }
+
+    // Test with pad_size = 1 (should mirror input exactly)
+    #[test]
+    fn pad_size_one() {
+        assert_eq!(
+            concatenate_with_padding(&[vec![fp(1)], vec![fp(2), fp(3)]], 1),
+            [fp(1), fp(2), fp(3)]
+        );
+    }
 }
 
 pub(crate) fn create_ro<


### PR DESCRIPTION
**Why?**
Part of #31. Realizes the zero step and uses the base case inside the
folding chip

**What?**

- Implementation of `IVC::new` method, where IVC is 'incrementally
  verifiable computation'.

- The `CommitmentKey::commit` now returns option to be able to handle an
  error (smaller key size than the input data size) on the function
  output, rather than panic internally

- Infrastructure for sha256 example for storing the commitment key in
  the local folder cache.

- Impl `assign_all_*` for `*CyclicAssignor` for easy assign collections
  & iterators.

**How?**

- Updated `sha256/main.rs`:
  - Implemented `get_or_create_commitment_key` function to manage
    commitment keys efficiently, either loading them from a file or
    generating new ones if not present.
  - Added logging for better tracking and debugging purposes.
  - Modified the main function to accommodate changes in commitment key
    handling and logging.

- Updated `commitment.rs`:
  - Enhanced `CommitmentKey` struct to handle errors more gracefully by
    returning `Option` instead of panicking.
  - Added functionality to save and load commitment keys to and from
    files, improving usability and persistence.

- In `incrementally_verifiable_computation.rs`, implemented `IVC::new`
  - `IVC::new` establishes the initial state of the IVC system, setting
    up the primary and secondary step circuits and configuring the
    necessary parameters.

- Updated `public_params.rs` to accommodate the new commitment key
  handling and structure changes in IVC and related components.

- Made various updates across other modules (`main_gate.rs`,
  `nifs/vanilla.rs`, `plonk/mod.rs`, `poseidon/random_oracle.rs`,
  `table.rs`) to support the new functionality and changes in the IVC
  system, including adjustments to handle commitment keys, error
  handling, and integration with the random oracle model.