### PR TITLE
refactor(plonk): simplify plonk structure by removing commitment

### DIFF
--- a/src/ivc/public_params.rs
+++ b/src/ivc/public_params.rs
@@ -129,29 +129,21 @@ where
         {
             primary_ck: &'l CommitmentKey<C2>,
             primary_params: &'l SynthesizeStepParams<C2, RP2::OnCircuit>,
-            primary_structure: PlonkStructure<C1>,
+            primary_structure: PlonkStructure<C1::ScalarExt>,
 
             secondary_ck: &'l CommitmentKey<C1>,
             secondary_params: &'l SynthesizeStepParams<C1, RP1::OnCircuit>,
-            secondary_structure: PlonkStructure<C2>,
+            secondary_structure: PlonkStructure<C2::ScalarExt>,
         }
 
         Wrapper::<'_, C1, C2, RP1, RP2> {
             primary_params: &self.primary.params,
             primary_ck: &self.primary.ck,
-            primary_structure: self
-                .primary
-                .td
-                .plonk_structure(&self.secondary.ck)
-                .unwrap_or_default(),
+            primary_structure: self.primary.td.plonk_structure().unwrap_or_default(),
 
             secondary_params: &self.secondary.params,
             secondary_ck: &self.secondary.ck,
-            secondary_structure: self
-                .secondary
-                .td
-                .plonk_structure(&self.primary.ck)
-                .unwrap_or_default(),
+            secondary_structure: self.secondary.td.plonk_structure().unwrap_or_default(),
         }
         .serialize(serializer)
     }

--- a/src/nifs/mod.rs
+++ b/src/nifs/mod.rs
@@ -19,7 +19,7 @@ use rayon::prelude::*;
 pub mod vanilla;
 
 /// Trait representing the NIFS folding scheme.
-trait FoldingScheme<C: CurveAffine, RO: ROTrait<C::Base>> {
+pub trait FoldingScheme<C: CurveAffine, RO: ROTrait<C::Base>> {
     /// Metadata for prover including hash of public params
     type ProverParam;
 
@@ -32,9 +32,7 @@ trait FoldingScheme<C: CurveAffine, RO: ROTrait<C::Base>> {
     /// The Instance of the Accumulator (e.g. [`RelaxedPlonkInstace`])
     type AccumulatorInstance;
 
-    fn setup_params(
-        td: &TableData<C::ScalarExt>,
-    ) -> Result<(Self::ProverParam, Self::VerifierParam), Error>;
+    fn setup_params(td: &TableData<C::ScalarExt>) -> (Self::ProverParam, Self::VerifierParam);
 
     /// Perform the folding operation as a prover.
     fn prove(

--- a/src/nifs/mod.rs
+++ b/src/nifs/mod.rs
@@ -32,7 +32,9 @@ pub trait FoldingScheme<C: CurveAffine, RO: ROTrait<C::Base>> {
     /// The Instance of the Accumulator (e.g. [`RelaxedPlonkInstace`])
     type AccumulatorInstance;
 
-    fn setup_params(td: &TableData<C::ScalarExt>) -> (Self::ProverParam, Self::VerifierParam);
+    fn setup_params(
+        td: &TableData<C::ScalarExt>,
+    ) -> Result<(Self::ProverParam, Self::VerifierParam), Error>;
 
     /// Perform the folding operation as a prover.
     fn prove(
@@ -55,6 +57,8 @@ pub trait FoldingScheme<C: CurveAffine, RO: ROTrait<C::Base>> {
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
+    #[error("parameter not setup")]
+    ParamNotSetup,
     #[error(transparent)]
     Eval(#[from] EvalError),
     #[error(transparent)]

--- a/src/nifs/tests.rs
+++ b/src/nifs/tests.rs
@@ -41,7 +41,7 @@ where
     const R_F: usize = 4;
     const R_P: usize = 3;
 
-    let S = td1.plonk_structure(ck).unwrap();
+    let S = td1.plonk_structure().unwrap();
     let mut f_U =
         RelaxedPlonkInstance::new(td1.instance.len(), S.num_challenges, S.round_sizes.len());
     let mut f_W = RelaxedPlonkWitness::new(td1.k, &S.round_sizes);

--- a/src/nifs/vanilla.rs
+++ b/src/nifs/vanilla.rs
@@ -25,6 +25,11 @@ pub type CrossTerms<C> = Vec<Vec<<C as CurveAffine>::ScalarExt>>;
 /// Cryptographic commitments to the [`CrossTerms`].
 pub type CrossTermCommits<C> = Vec<C>;
 
+pub struct PlonkAccumulator<C: CurveAffine> {
+    pub(crate) instance: RelaxedPlonkInstance<C>,
+    pub(crate) witness: RelaxedPlonkWitness<C::ScalarExt>,
+}
+
 /// VanillaFS: Vanilla version of Non Interactive Folding Scheme
 ///
 /// Given a polynomial relation `P(x_1,...,x_n)` with polynomial degree `d.
@@ -65,7 +70,7 @@ impl<C: CurveAffine, RO: ROTrait<C::Base>> VanillaFS<C, RO> {
     /// to be combined into one.
     pub fn commit_cross_terms(
         ck: &CommitmentKey<C>,
-        S: &PlonkStructure<C>,
+        S: &PlonkStructure<C::ScalarExt>,
         U1: &RelaxedPlonkInstance<C>,
         W1: &RelaxedPlonkWitness<C::ScalarExt>,
         U2: &PlonkInstance<C>,
@@ -162,8 +167,7 @@ impl<C: CurveAffine, RO: ROTrait<C::Base>> VanillaFS<C, RO> {
         ),
         Error,
     > {
-        // TODO: hash gate into ro (#85)
-        let S = td.plonk_structure(ck).unwrap();
+        let S = td.plonk_structure().unwrap();
 
         let (U2, W2) = td.run_sps_protocol(ck, ro_nark, S.num_challenges)?;
         let (cross_terms, cross_term_commits) = Self::commit_cross_terms(ck, &S, U1, W1, &U2, &W2)?;
@@ -206,5 +210,40 @@ impl<C: CurveAffine, RO: ROTrait<C::Base>> VanillaFS<C, RO> {
         let r = Self::generate_challenge(*pp_digest, ro_acc, &U1, &U2, &self.cross_term_commits)?;
 
         Ok(U1.fold(&U2, &self.cross_term_commits, &r))
+    }
+}
+
+impl<C: CurveAffine, RO: ROTrait<C::Base>> FoldingScheme<C, RO> for VanillaFS<C, RO> {
+    type ProverParam = PlonkStructure<C::ScalarExt>;
+    type VerifierParam = PlonkStructure<C::ScalarExt>;
+    type Accumulator = PlonkAccumulator<C>;
+    type AccumulatorInstance = RelaxedPlonkInstance<C>;
+    fn setup_params(
+        td: &TableData<<C as CurveAffine>::ScalarExt>,
+    ) -> (Self::ProverParam, Self::VerifierParam) {
+        let pp = td.plonk_structure().unwrap();
+        (pp.clone(), pp)
+    }
+
+    // Perform the folding operation as a prover.
+    fn prove(
+        _ck: &CommitmentKey<C>,
+        _pp: &Self::ProverParam,
+        _ro_acc: &mut RO,
+        _accumulator: Self::Accumulator,
+        _incoming: Self::Accumulator,
+    ) -> Result<Self::Accumulator, Error> {
+        todo!()
+    }
+
+    // Perform the folding operation as a verifier.
+    fn verify(
+        _vp: &Self::VerifierParam,
+        _ro_nark: &mut RO,
+        _ro_acc: &mut RO,
+        _accumulator: Self::AccumulatorInstance,
+        _incoming: Self::AccumulatorInstance,
+    ) -> Result<Self::AccumulatorInstance, Error> {
+        todo!()
     }
 }

--- a/src/nifs/vanilla.rs
+++ b/src/nifs/vanilla.rs
@@ -218,11 +218,12 @@ impl<C: CurveAffine, RO: ROTrait<C::Base>> FoldingScheme<C, RO> for VanillaFS<C,
     type VerifierParam = PlonkStructure<C::ScalarExt>;
     type Accumulator = PlonkAccumulator<C>;
     type AccumulatorInstance = RelaxedPlonkInstance<C>;
+
     fn setup_params(
         td: &TableData<<C as CurveAffine>::ScalarExt>,
-    ) -> (Self::ProverParam, Self::VerifierParam) {
-        let pp = td.plonk_structure().unwrap();
-        (pp.clone(), pp)
+    ) -> Result<(Self::ProverParam, Self::VerifierParam), Error> {
+        let pp = td.plonk_structure().ok_or(Error::ParamNotSetup)?;
+        Ok((pp.clone(), pp))
     }
 
     // Perform the folding operation as a prover.

--- a/src/plonk/mod.rs
+++ b/src/plonk/mod.rs
@@ -62,16 +62,13 @@ pub enum DeciderError {
 
 #[derive(Clone, PartialEq, Serialize, Default)]
 #[serde(bound(serialize = "
-    C: Serialize,
-    C::ScalarExt: Serialize
+    F: Serialize
 "))]
-pub struct PlonkStructure<C: CurveAffine> {
+pub struct PlonkStructure<F: PrimeField> {
     /// k is a parameter such that 2^k is the total number of rows
     pub(crate) k: usize,
     pub(crate) selectors: Vec<Vec<bool>>,
-    pub(crate) fixed_columns: Vec<Vec<C::ScalarExt>>,
-    /// concatenate selectors and num_fixed_columns together, then commit
-    pub(crate) fixed_commitment: C,
+    pub(crate) fixed_columns: Vec<Vec<F>>,
 
     pub(crate) num_advice_columns: usize,
 
@@ -84,9 +81,9 @@ pub struct PlonkStructure<C: CurveAffine> {
     pub(crate) round_sizes: Vec<usize>,
 
     /// singla polynomial relation that combines custom gates and lookup relations
-    pub(crate) poly: MultiPolynomial<C::ScalarExt>,
-    pub(crate) permutation_matrix: SparseMatrix<C::ScalarExt>,
-    pub(crate) lookup_arguments: Option<lookup::Arguments<C::ScalarExt>>,
+    pub(crate) poly: MultiPolynomial<F>,
+    pub(crate) permutation_matrix: SparseMatrix<F>,
+    pub(crate) lookup_arguments: Option<lookup::Arguments<F>>,
 }
 
 #[derive(Clone, Debug)]
@@ -151,13 +148,6 @@ pub struct PlonkTrace<C: CurveAffine> {
     pub w: PlonkWitness<C::Scalar>,
 }
 
-impl<C: CurveAffine, RO: ROTrait<C::Base>> AbsorbInRO<C::Base, RO> for PlonkStructure<C> {
-    // TODO: add hash of other fields including gates
-    fn absorb_into(&self, ro: &mut RO) {
-        ro.absorb_point(&self.fixed_commitment);
-    }
-}
-
 impl<C: CurveAffine, RO: ROTrait<C::Base>> AbsorbInRO<C::Base, RO> for PlonkInstance<C> {
     fn absorb_into(&self, ro: &mut RO) {
         for pt in self.W_commitments.iter() {
@@ -188,7 +178,7 @@ impl<C: CurveAffine, RO: ROTrait<C::Base>> AbsorbInRO<C::Base, RO> for RelaxedPl
     }
 }
 
-impl<C: CurveAffine> PlonkStructure<C> {
+impl<F: PrimeField> PlonkStructure<F> {
     /// return the index offset of fixed variables(i.e. not folded)
     pub fn num_non_fold_vars(&self) -> usize {
         self.fixed_columns.len() + self.selectors.len()
@@ -216,7 +206,7 @@ impl<C: CurveAffine> PlonkStructure<C> {
             .unwrap_or(false)
     }
 
-    pub fn is_sat<F, RO: ROTrait<C::Base>>(
+    pub fn is_sat<C, RO: ROTrait<C::Base>>(
         &self,
         ck: &CommitmentKey<C>,
         ro_nark: &mut RO,
@@ -225,7 +215,6 @@ impl<C: CurveAffine> PlonkStructure<C> {
     ) -> Result<(), DeciderError>
     where
         C: CurveAffine<ScalarExt = F>,
-        F: PrimeField,
     {
         U.sps_verify(ro_nark)?;
         let check_commitments = U
@@ -264,7 +253,7 @@ impl<C: CurveAffine> PlonkStructure<C> {
         }
     }
 
-    pub fn is_sat_relaxed<F>(
+    pub fn is_sat_relaxed<C>(
         &self,
         ck: &CommitmentKey<C>,
         U: &RelaxedPlonkInstance<C>,
@@ -272,7 +261,6 @@ impl<C: CurveAffine> PlonkStructure<C> {
     ) -> Result<(), DeciderError>
     where
         C: CurveAffine<ScalarExt = F>,
-        F: PrimeField,
     {
         let check_W_commitments = U
             .W_commitments
@@ -317,14 +305,13 @@ impl<C: CurveAffine> PlonkStructure<C> {
     }
 
     // permutation check for folding instance-witness pair
-    pub fn is_sat_perm<F>(
+    pub fn is_sat_perm<C>(
         &self,
         U: &RelaxedPlonkInstance<C>,
         W: &RelaxedPlonkWitness<F>,
     ) -> Result<(), DeciderError>
     where
         C: CurveAffine<ScalarExt = F>,
-        F: PrimeField,
     {
         let Z = U
             .instance
@@ -347,9 +334,9 @@ impl<C: CurveAffine> PlonkStructure<C> {
     }
 
     /// check whether the log-derivative equation is satisfied
-    pub fn is_sat_log_derivative(&self, W: &[Vec<C::ScalarExt>]) -> bool {
+    pub fn is_sat_log_derivative(&self, W: &[Vec<F>]) -> bool {
         let nrow = 2usize.pow(self.k as u32);
-        let check_is_zero = |hs: &[Vec<C::ScalarExt>], gs: &[Vec<C::ScalarExt>]| -> bool {
+        let check_is_zero = |hs: &[Vec<F>], gs: &[Vec<F>]| -> bool {
             hs.iter()
                 .zip(gs)
                 .map(|(h, g)| {
@@ -357,20 +344,19 @@ impl<C: CurveAffine> PlonkStructure<C> {
                     h.iter()
                         .zip_eq(g)
                         .map(|(hi, gi)| *hi - *gi)
-                        .fold(C::ScalarExt::ZERO, |acc, d| acc + d)
+                        .fold(F::ZERO, |acc, d| acc + d)
                 })
-                .filter(|v| C::ScalarExt::ZERO.ne(v))
+                .filter(|v| F::ZERO.ne(v))
                 .count()
                 == 0
         };
-        let gather_vectors =
-            |W: &Vec<C::ScalarExt>, start_index: usize| -> Vec<Vec<C::ScalarExt>> {
-                let indexes = iter::successors(Some(start_index), |idx| Some(idx + 2));
-                (0..self.num_lookups())
-                    .zip(indexes)
-                    .map(|(_, idx)| W[idx * nrow..(idx * nrow + nrow)].to_vec())
-                    .collect::<Vec<_>>()
-            };
+        let gather_vectors = |W: &Vec<F>, start_index: usize| -> Vec<Vec<F>> {
+            let indexes = iter::successors(Some(start_index), |idx| Some(idx + 2));
+            (0..self.num_lookups())
+                .zip(indexes)
+                .map(|(_, idx)| W[idx * nrow..(idx * nrow + nrow)].to_vec())
+                .collect::<Vec<_>>()
+        };
 
         if self.has_vector_lookup() {
             let hs = gather_vectors(&W[2], 0);

--- a/src/table.rs
+++ b/src/table.rs
@@ -178,31 +178,10 @@ impl<F: PrimeField> TableData<F> {
         Ok(())
     }
 
-    pub fn plonk_structure<C: CurveAffine<ScalarExt = F>>(
-        &self,
-        ck: &CommitmentKey<C>,
-    ) -> Option<PlonkStructure<C>> {
+    pub fn plonk_structure(&self) -> Option<PlonkStructure<F>> {
         if self.advice.is_empty() {
             return None;
         }
-
-        let selectors = self.selector.clone();
-        let selector_columns =
-            self.selector
-                .iter()
-                .flatten()
-                .map(|sel| if *sel { F::ONE } else { F::ZERO });
-        // TODO: avoid clone
-        let fixed_commitment = ck.commit(
-            &self
-                .fixed_columns
-                .clone()
-                .into_iter()
-                .flatten()
-                .chain(selector_columns)
-                .collect::<Vec<_>>(),
-        );
-
         let num_gates = self
             .cs
             .gates()
@@ -268,13 +247,12 @@ impl<F: PrimeField> TableData<F> {
 
         Some(PlonkStructure {
             k: self.k as usize,
-            selectors,
+            selectors: self.selector.clone(),
             fixed_columns: self.fixed_columns.clone(),
             num_advice_columns: self.cs.num_advice_columns(),
             num_challenges,
             round_sizes,
             poly,
-            fixed_commitment,
             permutation_matrix,
             lookup_arguments: self.lookup_arguments.clone(),
         })


### PR DESCRIPTION
* Remove the commitment calculation for fixed columns, see #85 
* Simplified PlonkStructure
* Added skeleton of folding scheme trait for VanillaFS 

I decided to merge this PR earlier before fully finish the impl of VanillaFS because I found all the PRs that related to PlonkStructure and/or PoseidonHash will require me to do rebase. It's better to merge earlier.