### PR TITLE
fix(expression): improve expression reduction efficiency

### DIFF
--- a/src/polynomial/mod.rs
+++ b/src/polynomial/mod.rs
@@ -695,11 +695,11 @@ impl<F: PrimeField> MultiPolynomial<F> {
             if idx >= self.monomials.len() {
                 break;
             }
-            if self.monomials[idx] == reduced[reduced.len() - 1] {
+            if self.monomials[idx].coeff == F::ZERO {
+                continue;
+            } else if self.monomials[idx] == reduced[reduced.len() - 1] {
                 let size = reduced.len();
                 reduced[size - 1].add(&self.monomials[idx]);
-            } else if self.monomials[idx].coeff == F::ZERO {
-                continue;
             } else {
                 reduced.push(self.monomials[idx].clone());
             }


### PR DESCRIPTION
This is continuation of previous fix. I realize that by changing the order of the if-else statement, we can make it faster in the case that there are a lot of Monomial term with zero coefficient.

