### PR TITLE
feat(commitment): fast & unsafe work with files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ prettytable-rs = "0.10.0"
 test-log = "0.2.12"
 halo2_gadgets = { git = "https://github.com/snarkify/halo2", branch = "snarkify/dev", features = ["unstable"] }
 bincode = "1.3"
+tempfile = "3.9.0"
 
 [dev-dependencies.cargo-husky]
 version = "1"


### PR DESCRIPTION
**Issue Link / Motivation**
Close #132

**Changes Overview**
The methods work directly with memory and simply move it to and from files. Crude, but fast.

**Testing plan**
Unit test with tempdir creation