### PR TITLE
refactor(ivc): simplify pp

### DIFF
--- a/src/ivc/incrementally_verifiable_computation.rs
+++ b/src/ivc/incrementally_verifiable_computation.rs
@@ -72,11 +72,11 @@ where
     C2::Base: PrimeFieldBits + FromUniformBytes<64>,
 {
     pub fn new<const T: usize, RP1, RP2>(
-        _pp: &mut PublicParams<C1, C2, RP1, RP2>,
+        _pp: &PublicParams<C1, C2, RP1, RP2>,
         _primary: SC1,
-        _z0_primary: [C1::Base; A1],
+        _z0_primary: [C1::Scalar; A1],
         _secondary: SC2,
-        _z0_secondary: [C2::Base; A2],
+        _z0_secondary: [C2::Scalar; A2],
     ) -> Result<Self, Error>
     where
         RP1: ROPair<C1::Base, Config = MainGateConfig<T>>,


### PR DESCRIPTION
**Motivation**
In the course of IVC implementation, the public parameters were significantly simplified

**Overview**
- `ck` now provided as referense outside, it allows not to deal with management of such a large object internally and makes the system more flexible
- Only table size instead of `TableData`, each step creates its own `TableData`
- `digest` skips `self.ck`, details at #136
- Instead of general serialization, the transformations needed for hashing became part of the digest method, which is much more correct (as it is not misleading)
