### PR TITLE
feat(ivc): `TableData` inside pp

### DIFF
--- a/src/ivc/incrementally_verifiable_computation.rs
+++ b/src/ivc/incrementally_verifiable_computation.rs
@@ -72,44 +72,44 @@ where
     C2::Base: PrimeFieldBits + FromUniformBytes<64>,
 {
     pub fn new<const T: usize, RP1, RP2>(
-        _pp: &PublicParams<C1, C2, RP1, RP2>,
+        _pp: &PublicParams<'_, A1, A2, T, C1, C2, SC1, SC2, RP1, RP2>,
         _primary: SC1,
         _z0_primary: [C1::Scalar; A1],
         _secondary: SC2,
         _z0_secondary: [C2::Scalar; A2],
     ) -> Result<Self, Error>
     where
-        RP1: ROPair<C1::Base, Config = MainGateConfig<T>>,
-        RP2: ROPair<C2::Base, Config = MainGateConfig<T>>,
+        RP1: ROPair<C1::Scalar, Config = MainGateConfig<T>>,
+        RP2: ROPair<C2::Scalar, Config = MainGateConfig<T>>,
     {
         // TODO #31
         todo!("Logic at `RecursiveSNARK::new`")
     }
 
-    pub fn prove_step<RO1, RO2>(
+    pub fn prove_step<const T: usize, RP1, RP2>(
         &mut self,
-        _pp: &PublicParams<C1, C2, RO1, RO2>,
+        _pp: &PublicParams<'_, A1, A2, T, C1, C2, SC1, SC2, RP1, RP2>,
         _z0_primary: [C1::Scalar; A1],
         _z0_secondary: [C2::Scalar; A2],
     ) -> Result<(), Error>
     where
-        RO1: ROPair<C1::Base>,
-        RO2: ROPair<C2::Base>,
+        RP1: ROPair<C1::Scalar>,
+        RP2: ROPair<C2::Scalar>,
     {
         // TODO #31
         todo!("Logic at `RecursiveSNARK::prove_step`")
     }
 
-    pub fn verify<RO1, RO2>(
+    pub fn verify<const T: usize, RP1, RP2>(
         &mut self,
-        _pp: &PublicParams<C1, C2, RO1, RO2>,
+        _pp: &PublicParams<'_, A1, A2, T, C1, C2, SC1, SC2, RP1, RP2>,
         _steps_count: usize,
         _z0_primary: [C1::Scalar; A1],
         _z0_secondary: [C2::Scalar; A2],
     ) -> Result<(), Error>
     where
-        RO1: ROPair<C1::Base>,
-        RO2: ROPair<C2::Base>,
+        RP1: ROPair<C1::Scalar>,
+        RP2: ROPair<C2::Scalar>,
     {
         // TODO #31
         todo!("Logic at `RecursiveSNARK::verify`")

--- a/src/ivc/mod.rs
+++ b/src/ivc/mod.rs
@@ -6,4 +6,4 @@ mod incrementally_verifiable_computation;
 mod public_params;
 
 pub use incrementally_verifiable_computation::*;
-pub use public_params::PublicParams;
+pub use public_params::{CircuitPublicParamsInput, PublicParams};

--- a/src/ivc/public_params.rs
+++ b/src/ivc/public_params.rs
@@ -1,7 +1,8 @@
 use std::{fmt, num::NonZeroUsize};
 
-use ff::{FromUniformBytes, PrimeFieldBits};
+use ff::{Field, FromUniformBytes, PrimeFieldBits};
 use group::prime::PrimeCurveAffine;
+use halo2_proofs::plonk::{Column, Instance};
 use halo2curves::CurveAffine;
 use log::*;
 use serde::Serialize;
@@ -9,41 +10,62 @@ use serde::Serialize;
 use crate::{
     commitment::CommitmentKey,
     digest::{self, DigestToCurve},
+    ivc::step_circuit::StepCircuitExt,
+    plonk::PlonkStructure,
     poseidon::ROPair,
+    table::TableData,
 };
 
-use super::step_circuit::SynthesizeStepParams;
+use super::{
+    step_circuit::{self, StepConfig, SynthesizeStepParams},
+    StepCircuit,
+};
 
-pub(crate) struct CircuitPublicParams<'key, C, RP>
-where
-    C: CurveAffine,
-    C::Base: PrimeFieldBits + FromUniformBytes<64>,
-    RP: ROPair<C::Base>,
-{
-    pub ck: &'key CommitmentKey<C>,
-    pub k_table_size: u32,
-    pub params: SynthesizeStepParams<C, RP::OnCircuit>,
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("While configure table data: {0:?}")]
+    Configure(#[from] step_circuit::ConfigureError),
 }
 
-impl<'key, C: fmt::Debug, RP> fmt::Debug for CircuitPublicParams<'key, C, RP>
+pub(crate) struct CircuitPublicParams<'key, const ARITY: usize, const MAIN_GATE_T: usize, C, SC, RP>
 where
     C: CurveAffine,
-    C::Base: PrimeFieldBits + FromUniformBytes<64>,
-    RP: ROPair<C::Base>,
+    C::Scalar: PrimeFieldBits + FromUniformBytes<64>,
+    SC: StepCircuit<ARITY, C::Scalar>,
+    RP: ROPair<C::Scalar>,
+{
+    pub ck: &'key CommitmentKey<C>,
+    pub params: SynthesizeStepParams<C::Scalar, RP::OnCircuit>,
+
+    td: TableData<C::Scalar>,
+    X0: Column<Instance>,
+    config: StepConfig<ARITY, C::Scalar, SC, MAIN_GATE_T>,
+}
+
+impl<'key, const ARITY: usize, const MAIN_GATE_T: usize, C, SC, RP> fmt::Debug
+    for CircuitPublicParams<'key, ARITY, MAIN_GATE_T, C, SC, RP>
+where
+    C: fmt::Debug + CurveAffine,
+    C::ScalarExt: PrimeFieldBits + FromUniformBytes<64>,
+    SC: StepCircuit<ARITY, C::ScalarExt>,
+    RP: ROPair<C::ScalarExt>,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("CircuitPublicParams")
             .field("ck_len", &self.ck.len())
+            .field("td_k", &self.td.k)
             .field("params", &self.params)
             .finish()
     }
 }
 
-impl<'key, C, RP> CircuitPublicParams<'key, C, RP>
+impl<'key, const ARITY: usize, const MAIN_GATE_T: usize, C, SC, RP>
+    CircuitPublicParams<'key, ARITY, MAIN_GATE_T, C, SC, RP>
 where
-    C: CurveAffine,
-    C::Base: PrimeFieldBits + FromUniformBytes<64>,
-    RP: ROPair<C::Base>,
+    C: fmt::Debug + CurveAffine,
+    C::Scalar: PrimeFieldBits + FromUniformBytes<64>,
+    SC: StepCircuit<ARITY, C::Scalar>,
+    RP: ROPair<C::Scalar>,
 {
     fn new(
         k_table_size: u32,
@@ -52,10 +74,24 @@ where
         ro_constant: RP::Args,
         limb_width: NonZeroUsize,
         n_limbs: NonZeroUsize,
-    ) -> Self {
+    ) -> Result<Self, Error> {
         debug!("start creating circuit pp");
-        Self {
-            k_table_size,
+
+        let mut td = TableData::new(k_table_size, vec![C::Scalar::ZERO, C::Scalar::ZERO]);
+
+        let (X0, config) = td.prepare_assembly(|cs| {
+            let X0 = cs.instance_column();
+
+            (
+                X0,
+                <SC as StepCircuitExt<'_, ARITY, C::Scalar>>::configure::<MAIN_GATE_T>(cs),
+            )
+        });
+
+        Ok(Self {
+            td,
+            X0,
+            config: config?,
             ck: commitment_key,
             params: SynthesizeStepParams {
                 limb_width,
@@ -63,36 +99,72 @@ where
                 is_primary_circuit,
                 ro_constant,
             },
-        }
+        })
+    }
+
+    pub fn prepare_td(&self, instance_columns: &[C::Scalar]) -> TableData<C::Scalar> {
+        let mut td = self.td.clone();
+        td.instance = instance_columns.to_vec();
+        td
     }
 }
 
-pub struct PublicParams<'key, C1, C2, RP1, RP2>
-where
+pub struct PublicParams<
+    'key,
+    const A1: usize,
+    const A2: usize,
+    const MAIN_GATE_T: usize,
+    C1,
+    C2,
+    SC1,
+    SC2,
+    RP1,
+    RP2,
+> where
     C1: CurveAffine<Base = <C2 as PrimeCurveAffine>::Scalar> + Serialize,
     C2: CurveAffine<Base = <C1 as PrimeCurveAffine>::Scalar> + Serialize,
 
-    C1::Base: PrimeFieldBits + FromUniformBytes<64> + Serialize,
-    C1::Scalar: PrimeFieldBits + FromUniformBytes<64> + Serialize,
-
-    RP1: ROPair<C1::Base>,
-    RP2: ROPair<C2::Base>,
-{
-    pub(crate) primary: CircuitPublicParams<'key, C2, RP2>,
-    pub(crate) secondary: CircuitPublicParams<'key, C1, RP1>,
-}
-
-impl<'key, C1: fmt::Debug, C2: fmt::Debug, RP1, RP2> fmt::Debug
-    for PublicParams<'key, C1, C2, RP1, RP2>
-where
-    C1: CurveAffine<Base = <C2 as PrimeCurveAffine>::Scalar> + Serialize,
-    C2: CurveAffine<Base = <C1 as PrimeCurveAffine>::Scalar> + Serialize,
     C1::Base: PrimeFieldBits + FromUniformBytes<64> + Serialize,
     C2::Base: PrimeFieldBits + FromUniformBytes<64> + Serialize,
-    RP1: ROPair<C1::Base>,
-    RP2: ROPair<C2::Base>,
+
+    SC1: StepCircuit<A1, C1::Scalar>,
+    SC2: StepCircuit<A2, C2::Scalar>,
+
+    RP1: ROPair<C1::Scalar>,
+    RP2: ROPair<C2::Scalar>,
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    pub(crate) primary: CircuitPublicParams<'key, A1, MAIN_GATE_T, C1, SC1, RP1>,
+    pub(crate) secondary: CircuitPublicParams<'key, A2, MAIN_GATE_T, C2, SC2, RP2>,
+}
+
+impl<
+        'key,
+        const A1: usize,
+        const A2: usize,
+        const MAIN_GATE_T: usize,
+        C1,
+        C2,
+        SC1,
+        SC2,
+        RP1,
+        RP2,
+    > fmt::Debug for PublicParams<'key, A1, A2, MAIN_GATE_T, C1, C2, SC1, SC2, RP1, RP2>
+where
+    C1: CurveAffine<Base = <C2 as PrimeCurveAffine>::Scalar> + Serialize,
+    C2: CurveAffine<Base = <C1 as PrimeCurveAffine>::Scalar> + Serialize,
+
+    C1::Base: PrimeFieldBits + FromUniformBytes<64> + Serialize,
+    C2::Base: PrimeFieldBits + FromUniformBytes<64> + Serialize,
+
+    SC1: StepCircuit<A1, C1::Scalar>,
+    SC2: StepCircuit<A2, C2::Scalar>,
+
+    RP1: ROPair<C1::Scalar>,
+    RP2: ROPair<C2::Scalar>,
+    C1: fmt::Debug,
+    C2: fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("PublicParams")
             .field("primary", &self.primary)
             .field("secondary", &self.secondary)
@@ -100,7 +172,24 @@ where
     }
 }
 
-impl<'key, C1, C2, RP1, RP2> PublicParams<'key, C1, C2, RP1, RP2>
+pub struct CircuitPublicParamsInput<'key, C: CurveAffine, RPArgs> {
+    pub commitment_key: &'key CommitmentKey<C>,
+    pub k_table_size: u32,
+    pub ro_constant: RPArgs,
+}
+
+impl<
+        'key,
+        const A1: usize,
+        const A2: usize,
+        const MAIN_GATE_T: usize,
+        C1,
+        C2,
+        SC1,
+        SC2,
+        RP1,
+        RP2,
+    > PublicParams<'key, A1, A2, MAIN_GATE_T, C1, C2, SC1, SC2, RP1, RP2>
 where
     C1: CurveAffine<Base = <C2 as PrimeCurveAffine>::Scalar> + Serialize,
     C2: CurveAffine<Base = <C1 as PrimeCurveAffine>::Scalar> + Serialize,
@@ -108,37 +197,37 @@ where
     C1::Base: PrimeFieldBits + FromUniformBytes<64> + Serialize,
     C2::Base: PrimeFieldBits + FromUniformBytes<64> + Serialize,
 
-    RP1: ROPair<C1::Base>,
-    RP2: ROPair<C2::Base>,
+    SC1: StepCircuit<A1, C1::Scalar>,
+    SC2: StepCircuit<A2, C2::Scalar>,
+
+    RP1: ROPair<C1::Scalar>,
+    RP2: ROPair<C2::Scalar>,
 {
     pub fn new(
-        k: u32,
-        primary_commitment_key: &'key CommitmentKey<C2>,
-        secondary_commitment_key: &'key CommitmentKey<C1>,
-        primary_ro_constant: RP2::Args,
-        secondary_ro_constant: RP1::Args,
+        primary: CircuitPublicParamsInput<'key, C1, RP1::Args>,
+        secondary: CircuitPublicParamsInput<'key, C2, RP2::Args>,
         limb_width: NonZeroUsize,
         limbs_count_limit: NonZeroUsize,
-    ) -> Self {
+    ) -> Result<Self, Error> {
         debug!("start creating pp");
-        Self {
-            primary: CircuitPublicParams::<C2, _>::new(
-                k,
-                primary_commitment_key,
+        Ok(Self {
+            primary: CircuitPublicParams::new(
+                primary.k_table_size,
+                primary.commitment_key,
                 true,
-                primary_ro_constant,
+                primary.ro_constant,
                 limb_width,
                 limbs_count_limit,
-            ),
-            secondary: CircuitPublicParams::<C1, _>::new(
-                k,
-                secondary_commitment_key,
+            )?,
+            secondary: CircuitPublicParams::new(
+                secondary.k_table_size,
+                secondary.commitment_key,
                 false,
-                secondary_ro_constant,
+                secondary.ro_constant,
                 limb_width,
                 limbs_count_limit,
-            ),
-        }
+            )?,
+        })
     }
 
     /// This method calculate digest of [`PublicParams`], but ignore [`CircuitPublicParams::ck`]
@@ -154,18 +243,26 @@ where
             C1::Base: PrimeFieldBits + FromUniformBytes<64> + Serialize,
             C2::Base: PrimeFieldBits + FromUniformBytes<64> + Serialize,
 
-            RP1: ROPair<C1::Base>,
-            RP2: ROPair<C2::Base>,
+            RP1: ROPair<C1::Scalar>,
+            RP2: ROPair<C2::Scalar>,
         {
-            primary_k_table_size: u32,
-            secondary_k_table_size: u32,
-            primary_params: &'l SynthesizeStepParams<C2, RP2::OnCircuit>,
-            secondary_params: &'l SynthesizeStepParams<C1, RP1::OnCircuit>,
+            primary_plonk_struct: PlonkStructure<C1::Scalar>,
+            secondary_plonk_struct: PlonkStructure<C2::Scalar>,
+            primary_params: &'l SynthesizeStepParams<C1::Scalar, RP1::OnCircuit>,
+            secondary_params: &'l SynthesizeStepParams<C2::Scalar, RP2::OnCircuit>,
         }
 
         digest::DefaultHasher::digest_to_curve(&Wrapper::<'_, C1, C2, RP1, RP2> {
-            primary_k_table_size: self.primary.k_table_size,
-            secondary_k_table_size: self.secondary.k_table_size,
+            primary_plonk_struct: self
+                .primary
+                .td
+                .plonk_structure()
+                .expect("unrechable, prepared in constructor"),
+            secondary_plonk_struct: self
+                .secondary
+                .td
+                .plonk_structure()
+                .expect("unrechable, prepared in constructor"),
             primary_params: &self.primary.params,
             secondary_params: &self.secondary.params,
         })
@@ -174,8 +271,10 @@ where
 }
 #[cfg(test)]
 mod pp_test {
-    use halo2curves::{bn256, grumpkin, CurveExt};
+    use group::Group;
+    use halo2curves::{bn256, grumpkin};
 
+    use crate::ivc::step_circuit;
     use bn256::G1 as C1;
     use grumpkin::G1 as C2;
 
@@ -194,19 +293,40 @@ mod pp_test {
 
     #[test]
     fn digest() {
-        let spec1 = RandomOracleConstant::<5, 4, <C1 as CurveExt>::Base>::new(10, 10);
-        let spec2 = RandomOracleConstant::<5, 4, <C2 as CurveExt>::Base>::new(10, 10);
+        type Scalar1 = <C1 as Group>::Scalar;
+        type Scalar2 = <C2 as Group>::Scalar;
+
+        let spec1 = RandomOracleConstant::<5, 4, Scalar1>::new(10, 10);
+        let spec2 = RandomOracleConstant::<5, 4, Scalar2>::new(10, 10);
 
         const K: usize = 5;
-        PublicParams::<C1Affine, C2Affine, RandomOracle<5, 4>, RandomOracle<5, 4>>::new(
-            K as u32,
-            &CommitmentKey::setup(K, b"1"),
-            &CommitmentKey::setup(K, b"2"),
-            spec2,
-            spec1,
+
+        PublicParams::<
+            '_,
+            1,
+            1,
+            5,
+            C1Affine,
+            C2Affine,
+            step_circuit::trivial::Circuit<1, Scalar1>,
+            step_circuit::trivial::Circuit<1, Scalar2>,
+            RandomOracle<5, 4>,
+            RandomOracle<5, 4>,
+        >::new(
+            CircuitPublicParamsInput {
+                k_table_size: K as u32,
+                commitment_key: &CommitmentKey::setup(K, b"1"),
+                ro_constant: spec1,
+            },
+            CircuitPublicParamsInput {
+                k_table_size: K as u32,
+                commitment_key: &CommitmentKey::setup(K, b"2"),
+                ro_constant: spec2,
+            },
             LIMB_WIDTH,
             LIMBS_COUNT_LIMIT,
         )
+        .unwrap()
         .digest::<C1Affine>()
         .unwrap();
     }


### PR DESCRIPTION
**Motivation**
For security considerations, we need to commit all gates and parameters inside pp, rather than expecting them to be consistent between steps. For this purpose, we put them back inside PP and put them in digest.

**Overview**
- Now `PublicParams` can create table data by cloning an already prepared version.

- Also these changes required some modification of the step circuit module to get rid of curve there and switch to the field

- Generic for `PublicParams` is certainly a fear, but I'll take the time later to try to simplify it

- The constructor has been augmented with a type because the number of
  arguments is too large

