### PR TITLE
refactor(ivc): rewrite part of ivc circuit

### DIFF
--- a/examples/sha256/main.rs
+++ b/examples/sha256/main.rs
@@ -348,7 +348,7 @@ fn get_or_create_commitment_key<C: CurveAffine>(
 ) -> io::Result<CommitmentKey<C>> {
     const FOLDER: &str = ".cache/examples";
 
-    let file_path = Path::new(FOLDER).join(label).join("{k}.bin");
+    let file_path = Path::new(FOLDER).join(label).join(format!("{k}.bin"));
 
     if file_path.exists() {
         debug!("{file_path:?} exists, load key");

--- a/examples/trivial/main.rs
+++ b/examples/trivial/main.rs
@@ -108,7 +108,7 @@ fn main() {
     info!("public params: {pp:?}");
 
     debug!("start ivc");
-    let _ivc = IVC::new(
+    let mut ivc = IVC::new(
         &pp,
         sc1,
         array::from_fn(|i| C1Scalar::from_u128(i as u128)),
@@ -119,5 +119,5 @@ fn main() {
 
     debug!("base case ready");
 
-    //ivc.fold_step(&pp).unwrap();
+    ivc.fold_step(&pp).unwrap();
 }

--- a/examples/trivial/main.rs
+++ b/examples/trivial/main.rs
@@ -108,7 +108,7 @@ fn main() {
     info!("public params: {pp:?}");
 
     debug!("start ivc");
-    let _ivc = IVC::new(
+    let mut ivc = IVC::new(
         &pp,
         sc1,
         array::from_fn(|i| C1Scalar::from_u128(i as u128)),
@@ -118,4 +118,6 @@ fn main() {
     .unwrap();
 
     debug!("base case ready");
+
+    ivc.fold_step(&pp).unwrap();
 }

--- a/examples/trivial/main.rs
+++ b/examples/trivial/main.rs
@@ -108,7 +108,7 @@ fn main() {
     info!("public params: {pp:?}");
 
     debug!("start ivc");
-    let mut ivc = IVC::new(
+    let _ivc = IVC::new(
         &pp,
         sc1,
         array::from_fn(|i| C1Scalar::from_u128(i as u128)),
@@ -119,5 +119,5 @@ fn main() {
 
     debug!("base case ready");
 
-    ivc.fold_step(&pp).unwrap();
+    //ivc.fold_step(&pp).unwrap();
 }

--- a/src/gadgets/nonnative/bn/big_uint_mul_mod_chip/mod.rs
+++ b/src/gadgets/nonnative/bn/big_uint_mul_mod_chip/mod.rs
@@ -971,7 +971,7 @@ impl<F: PrimeField> Deref for ModOperationResult<F> {
 #[derive(Debug)]
 pub struct MultContext<F: PrimeField> {
     lhs: Vec<AssignedCell<F, F>>,
-    rhs: Vec<AssignedCell<F, F>>,
+    pub rhs: Vec<AssignedCell<F, F>>,
     res: OverflowingBigUint<F>,
 }
 

--- a/src/ivc/fold_relaxed_plonk_instance_chip.rs
+++ b/src/ivc/fold_relaxed_plonk_instance_chip.rs
@@ -211,7 +211,8 @@ impl<C: CurveAffine> AssignedRelaxedPlonkInstance<C> {
     }
 }
 impl<C: CurveAffine> AssignedRelaxedPlonkInstance<C> {
-    fn to_relaxed_plonk_instance(
+    #[cfg(test)]
+    pub fn to_relaxed_plonk_instance(
         &self,
         limb_width: NonZeroUsize,
         limbs_count: NonZeroUsize,

--- a/src/ivc/fold_relaxed_plonk_instance_chip.rs
+++ b/src/ivc/fold_relaxed_plonk_instance_chip.rs
@@ -309,7 +309,7 @@ pub(crate) struct AssignedWitness<C: CurveAffine> {
 
     /// Vector of vectors of assigned values for each limb of the input instances.
     /// Sourced directly from [`PlonkInstance::instance`] provided to [`FoldRelaxedPlonkInstanceChip::fold`].
-    input_instances: Vec<Vec<AssignedValue<C::Base>>>,
+    pub input_instances: Vec<Vec<AssignedValue<C::Base>>>,
 
     /// Vector of vectors of assigned values for each limb of the input challenges.
     /// Sourced directly from [`PlonkInstance::challenges`] provided to [`FoldRelaxedPlonkInstanceChip::fold`].
@@ -352,7 +352,7 @@ pub enum Error {
 
     #[error("Error constructing elliptic curve coordinates for {variable_name}: {variable_str}")]
     CantBuildCoordinates {
-        variable_name: &'static str,
+        variable_name: String,
         variable_str: String,
     },
 
@@ -818,9 +818,9 @@ where
             .collect::<Result<Vec<_>, _>>()?;
         let assigned_E = assign_point!(&self.relaxed.E_commitment)?;
 
+        assert_eq!(self.relaxed.instance.len(), 2);
         let assigned_X0 = assign_diff_field_as_bn!(&self.relaxed.instance[0], || "X0")?;
         let assigned_X1 = assign_diff_field_as_bn!(&self.relaxed.instance[1], || "X1")?;
-        assert_eq!(self.relaxed.instance.len(), 2);
 
         let assigned_challenges = self
             .relaxed
@@ -1028,7 +1028,7 @@ fn assign_next_advice_from_point<C: CurveAffine, AR: Into<String>>(
 ) -> Result<AssignedPoint<C>, Error> {
     let coordinates: Coordinates<C> =
         Option::from(input.coordinates()).ok_or(Error::CantBuildCoordinates {
-            variable_name: "point",
+            variable_name: (annotation)().into(),
             variable_str: format!("{:?}", input),
         })?;
 

--- a/src/ivc/fold_relaxed_plonk_instance_chip.rs
+++ b/src/ivc/fold_relaxed_plonk_instance_chip.rs
@@ -72,6 +72,28 @@ use crate::{
     util::{self, CellsValuesView},
 };
 
+/// Holds the assigned values and points of PlonkInstance
+pub(crate) struct AssignedPlonkInstance<C: CurveAffine> {
+    pub W_commitments: Vec<AssignedPoint<C>>,
+    pub challenges: Vec<AssignedValue<C::Base>>,
+    pub X0: AssignedValue<C::Base>,
+    pub X1: AssignedValue<C::Base>,
+}
+
+impl<C: CurveAffine> AssignedPlonkInstance<C> {
+    // This is a hack for now
+    pub fn to_instance(&self) -> PlonkInstance<C> {
+        let W_commitments = self.W_commitments.iter().map(|w| w.to_curve().unwrap()).collect::<Vec<_>>();
+        let instance = [self.X0.value().copied().unwrap(), self.X1.value().copied().unwrap()];
+        let challenges = self.challenges.iter().map(|cha| cha.value().copied().unwrap()).collect::<Vec<_>>();
+        PlonkInstance {
+            W_commitments,
+            instance,
+            challenges,
+        }
+    }
+}
+
 pub(crate) struct FoldRelaxedPlonkInstanceChip<const T: usize, C: CurveAffine>
 where
     C::Base: PrimeFieldBits + FromUniformBytes<64>,

--- a/src/ivc/fold_relaxed_plonk_instance_chip.rs
+++ b/src/ivc/fold_relaxed_plonk_instance_chip.rs
@@ -1096,7 +1096,7 @@ mod tests {
     fn get_table_data() -> (TableData<Base>, MainGateConfig<T>) {
         let mut td = TableData::new(K, vec![]);
         let _ = td.cs.instance_column();
-        let config = td.prepare_assembly(MainGate::<Base, T>::configure);
+        let config = td.configure(MainGate::<Base, T>::configure);
 
         (td, config)
     }
@@ -1773,7 +1773,7 @@ mod tests {
 
         let mut ro = PoseidonHash::new(spec.clone());
         let mut td = TableData::<ScalarExt>::new(K as u32, vec![]);
-        let _config = td.prepare_assembly(MainGate::<ScalarExt, T>::configure);
+        let _config = td.configure(MainGate::<ScalarExt, T>::configure);
 
         VanillaFS::generate_challenge(pp_hash, &mut ro, relaxed, input, cross_term_commits).unwrap()
     }

--- a/src/ivc/incrementally_verifiable_computation.rs
+++ b/src/ivc/incrementally_verifiable_computation.rs
@@ -218,7 +218,7 @@ where
             )?;
 
             debug!("start primary td postpone");
-            primary_td.postpone_assembly();
+            primary_td.batch_invert_assigned();
             debug!("primary synthesized, start sps");
 
             let (primary_plonk_instance, primary_plonk_witness) = primary_td.run_sps_protocol(
@@ -286,7 +286,7 @@ where
             )?;
 
             debug!("start secondary td postpone");
-            secondary_td.postpone_assembly();
+            secondary_td.batch_invert_assigned();
             debug!("secondary synthesized");
 
             let (secondary_plonk_instance, secondary_plonk_witness) = secondary_td

--- a/src/ivc/incrementally_verifiable_computation.rs
+++ b/src/ivc/incrementally_verifiable_computation.rs
@@ -338,11 +338,14 @@ where
         RP2: ROPair<C2::Scalar, Config = MainGateConfig<T>>,
     {
         let step = self.step;
+        debug!("start fold step: {step}");
 
         let (primary_config, mut primary_td) =
             pp.primary.prepare_td(&[C1::Scalar::ZERO, C1::Scalar::ZERO]);
 
         (self.secondary.relaxed_trace, self.primary.z_next) = {
+            debug!("start off-circuit part: nifs::prove");
+
             let nifs::vanilla::ProveResultCtx {
                 S: _,
                 w: _,
@@ -359,6 +362,8 @@ where
                 &self.secondary.relaxed_trace.U,
                 &self.secondary.relaxed_trace.W,
             )?;
+            debug!("nifs processed");
+            debug!("start on-circuit part");
 
             let mut layouter =
                 SingleChipLayouter::<'_, C1::Scalar, _>::new(&mut primary_td, vec![])?;

--- a/src/ivc/incrementally_verifiable_computation.rs
+++ b/src/ivc/incrementally_verifiable_computation.rs
@@ -181,13 +181,7 @@ where
         debug!("cross term commits len: primary={primary_cross_term_commits_len}, secondary={secondary_cross_term_commits_len}");
 
         let (primary_ctx, primary_plonk_instance) = {
-            debug!("primary step circuit configured");
-            let mut layouter =
-                SingleChipLayouter::<'_, C1::Scalar, _>::new(&mut primary_td, vec![])?;
-
-            debug!("primary z{step} assigned");
             debug!("start primary synthesize");
-
             let StepSynthesisResult {
                 z_output: primary_assigned_z_output,
                 // Not used in zero step, only in verify-step, when folding is over
@@ -196,7 +190,7 @@ where
                 new_X0: primary_new_X0,
             } = primary.synthesize(
                 primary_config,
-                &mut layouter,
+                &mut SingleChipLayouter::<'_, C1::Scalar, _>::new(&mut primary_td, vec![])?,
                 step_circuit::StepInputs {
                     step_public_params: pp.primary.params(),
                     public_params_hash: primary_public_params_hash,
@@ -243,9 +237,6 @@ where
         debug!("primary ctx ready");
 
         let (secondary_ctx, secondary_prev_td) = {
-            let mut layouter =
-                SingleChipLayouter::<'_, C2::Scalar, _>::new(&mut secondary_td, vec![])?;
-
             debug!("start secondary synthesize");
             let StepSynthesisResult {
                 z_output: secondary_assigned_z_output,
@@ -255,7 +246,7 @@ where
                 new_X0: secondary_new_X0,
             } = secondary.synthesize(
                 secondary_config,
-                &mut layouter,
+                &mut SingleChipLayouter::<'_, C2::Scalar, _>::new(&mut secondary_td, vec![])?,
                 StepInputs {
                     step_public_params: pp.secondary.params(),
                     public_params_hash: secondary_public_params_hash,

--- a/src/ivc/incrementally_verifiable_computation.rs
+++ b/src/ivc/incrementally_verifiable_computation.rs
@@ -142,11 +142,11 @@ where
         info!("start ivc base case");
         let step = 0;
 
-        let (primary_config, mut primary_td, _primary_instance_col) =
+        let (primary_config, mut primary_td, primary_instance_col) =
             pp.primary.prepare_td(&[C1::Scalar::ZERO, C1::Scalar::ZERO]);
         debug!("primary step circuit configured");
 
-        let (secondary_config, mut secondary_td, _secondary_instance_col) = pp
+        let (secondary_config, mut secondary_td, secondary_instance_col) = pp
             .secondary
             .prepare_td(&[C2::Scalar::ZERO, C2::Scalar::ZERO]);
         debug!("secondary step circuit configured");
@@ -225,14 +225,13 @@ where
                 },
             )?;
 
+            layouter.constrain_instance(primary_new_X0.cell(), primary_instance_col, 0)?;
+            layouter.constrain_instance(primary_new_X1.cell(), primary_instance_col, 1)?;
+
             primary_td.instance = vec![
                 *primary_new_X0.value().unwrap().unwrap(),
                 *primary_new_X1.value().unwrap().unwrap(),
             ];
-
-            // TODO How to
-            //layouter.constrain_instance(primary_new_X0.cell(), primary_instance_col, 0);
-            //layouter.constrain_instance(primary_new_X1.cell(), primary_instance_col, 1);
 
             debug!("start primary td postpone");
             primary_td.batch_invert_assigned();
@@ -303,14 +302,13 @@ where
                 },
             )?;
 
+            layouter.constrain_instance(secondary_new_X0.cell(), secondary_instance_col, 0)?;
+            layouter.constrain_instance(secondary_new_X1.cell(), secondary_instance_col, 1)?;
+
             secondary_td.instance = vec![
                 *secondary_new_X0.value().unwrap().unwrap(),
                 *secondary_new_X1.value().unwrap().unwrap(),
             ];
-
-            // TODO How to
-            //layouter.constrain_instance(secondary_new_X0.cell(), secondary_instance_col, 0);
-            //layouter.constrain_instance(secondary_new_X1.cell(), secondary_instance_col, 1);
 
             debug!("start secondary td postpone");
             secondary_td.batch_invert_assigned();
@@ -358,7 +356,7 @@ where
         let step = self.step;
         debug!("start fold step: {step}");
 
-        let (primary_config, mut primary_td, _) =
+        let (primary_config, mut primary_td, primary_instance_col) =
             pp.primary.prepare_td(&[C1::Scalar::ZERO, C1::Scalar::ZERO]);
 
         (self.secondary.relaxed_trace, self.primary.z_next) = {
@@ -440,6 +438,9 @@ where
                 },
             )?;
 
+            layouter.constrain_instance(primary_new_X0.cell(), primary_instance_col, 0)?;
+            layouter.constrain_instance(primary_new_X1.cell(), primary_instance_col, 1)?;
+
             primary_td.instance = vec![
                 *primary_new_X0.value().unwrap().unwrap(),
                 *primary_new_X1.value().unwrap().unwrap(),
@@ -463,7 +464,7 @@ where
             self.secondary.z_next,
             self.secondary_prev_td,
         ) = {
-            let (secondary_config, mut secondary_td, _) = pp
+            let (secondary_config, mut secondary_td, secondary_instance_col) = pp
                 .secondary
                 .prepare_td(&[C2::Scalar::ZERO, C2::Scalar::ZERO]);
 
@@ -540,6 +541,10 @@ where
                     cross_term_commits: primary_nifs.cross_term_commits,
                 },
             )?;
+
+            layouter.constrain_instance(secondary_new_X0.cell(), secondary_instance_col, 0)?;
+            layouter.constrain_instance(secondary_new_X1.cell(), secondary_instance_col, 1)?;
+
             secondary_td.instance = vec![
                 *secondary_new_X0.value().unwrap().unwrap(),
                 *secondary_new_X1.value().unwrap().unwrap(),

--- a/src/ivc/incrementally_verifiable_computation.rs
+++ b/src/ivc/incrementally_verifiable_computation.rs
@@ -1,15 +1,21 @@
 use std::io;
 
-use ff::{FromUniformBytes, PrimeFieldBits};
+use ff::{Field, FromUniformBytes, PrimeFieldBits};
 use group::prime::PrimeCurveAffine;
+use halo2_proofs::circuit::{floor_planner::single_pass::SingleChipLayouter, Layouter};
 use halo2curves::CurveAffine;
+use log::*;
 use serde::Serialize;
 
 use crate::{
-    ivc::public_params::PublicParams,
-    main_gate::{AssignedValue, MainGateConfig},
-    plonk::{PlonkTrace, RelaxedPlonkTrace},
-    poseidon::ROPair,
+    ivc::{
+        public_params::PublicParams,
+        step_circuit::{StepCircuitExt, StepInputs, StepSynthesisResult},
+    },
+    main_gate::{AdviceCyclicAssignor, AssignedValue, MainGateConfig, RegionCtx},
+    plonk::{PlonkInstance, PlonkTrace, RelaxedPlonkTrace},
+    poseidon::{random_oracle::ROTrait, ROPair},
+    sps,
 };
 
 pub use super::{
@@ -40,6 +46,8 @@ pub enum Error {
     Step(#[from] step_circuit::SynthesisError),
     #[error("TODO")]
     WhileHash(io::Error),
+    #[error("TODO")]
+    Sps(#[from] sps::Error),
 }
 
 // TODO #31 docs
@@ -55,7 +63,7 @@ where
     primary: StepCircuitContext<A1, C1, SC1>,
     secondary: StepCircuitContext<A2, C2, SC2>,
 
-    primary_trace: PlonkTrace<C2>,
+    secondary_trace: PlonkTrace<C2>,
 
     step: usize,
 }
@@ -71,19 +79,233 @@ where
     C1::Base: PrimeFieldBits + FromUniformBytes<64>,
     C2::Base: PrimeFieldBits + FromUniformBytes<64>,
 {
+    /// Initializes a new instance of an Incrementally Verifiable Computation (IVC) system.
+    ///
+    /// This method establishes the zero round (base case) of the IVC within the context.
+    /// It sets up the primary and secondary step circuits, along with their initial states (z0),
+    /// and configures the necessary parameters and traces for both circuits.
+    ///
+    /// # Type Parameters
+    /// * `T` - A constant size parameter for the [`crate::main_gate::MainGateConfig`].
+    /// * `RP1`, `RP2` - Types representing the random oracle pair (on-circuit & off-circuit) for
+    /// the primary and secondary curves, respectively.
+    ///
+    /// # Algorithmic Summary
+    ///
+    /// 1. **Table Data Preparation**: For both primary and secondary circuits, it initializes
+    ///    [`TableData`] structures with the provided Plonk configuration parameters. These
+    ///    structures are essential for building the circuit layout and assembling the proof
+    ///    system.
+    ///
+    /// 2. **Circuit Configuration**: It configures the step circuits for both primary and
+    ///    secondary contexts. This involves defining the layout and constraints of the circuits
+    ///    based on the `StepCircuit` trait implementations for `SC1` and `SC2`.
+    ///
+    /// 3. **Initial State Assignment**: The initial states (`z0_primary` and `z0_secondary`) are
+    ///    assigned to the constraint system. This forms the base case for the IVC scheme, representing
+    ///    the starting point of the computation.
+    ///
+    /// 4. **Synthesizing the Primary Step Circuit**: Constructs the primary step circuit by
+    ///    applying constraints and recording output states (`z_i`), encoding the computation for
+    ///    the zero round. After run The Sumcheck Protocol over Polynomial Systems (SPS Protocol) for
+    ///    receive generates [`PlonkInstance`] (`u`) & [`crate::plonk::PlonkWitness`]
+    ///
+    /// 5. **Synthesizing the Secondary Step Circuit**: Similarly, constructs the secondary step
+    ///    circuit. Notably, it passes the [`PlonkInstance`] from the primary circuit synthesis as
+    ///    [`StepInputs::u`].After run The Sumcheck Protocol over Polynomial Systems (SPS Protocol) for
+    ///    receive generates [`PlonkInstance`] (`u`) & [`crate::plonk::PlonkWitness`]
+    ///
+    /// 6. **Creating StepCircuitContext**: For both primary and secondary circuits, a
+    ///    [`StepCircuitContext`] is created, encapsulating the step circuit, its relaxed trace, and
+    ///    the initial and final states.
+    ///
+    /// 7. **Finalizing IVC Instance**: The function concludes by constructing and returning the
+    ///    `IVC` instance, which holds the contexts for both circuits.
     pub fn new<const T: usize, RP1, RP2>(
-        _pp: &PublicParams<'_, A1, A2, T, C1, C2, SC1, SC2, RP1, RP2>,
-        _primary: SC1,
-        _z0_primary: [C1::Scalar; A1],
-        _secondary: SC2,
-        _z0_secondary: [C2::Scalar; A2],
+        pp: &PublicParams<'_, A1, A2, T, C1, C2, SC1, SC2, RP1, RP2>,
+        primary: SC1,
+        z0_primary: [C1::Scalar; A1],
+        secondary: SC2,
+        z0_secondary: [C2::Scalar; A2],
     ) -> Result<Self, Error>
     where
         RP1: ROPair<C1::Scalar, Config = MainGateConfig<T>>,
         RP2: ROPair<C2::Scalar, Config = MainGateConfig<T>>,
     {
         // TODO #31
-        todo!("Logic at `RecursiveSNARK::new`")
+        info!("start ivc base case");
+
+        let primary_public_params_hash = pp.digest()?;
+        let secondary_public_params_hash = pp.digest()?;
+
+        let (primary_config, mut primary_td) =
+            pp.primary.prepare_td(&[C1::Scalar::ZERO, C1::Scalar::ZERO]);
+        debug!("primary step circuit configured");
+
+        let (secondary_config, mut secondary_td) = pp
+            .secondary
+            .prepare_td(&[C2::Scalar::ZERO, C2::Scalar::ZERO]);
+        debug!("secondary step circuit configured");
+
+        let primary_cross_term_commits_len = secondary_td
+            .plonk_structure()
+            .unwrap()
+            .get_degree_for_folding();
+
+        let secondary_cross_term_commits_len = primary_td
+            .plonk_structure()
+            .unwrap()
+            .get_degree_for_folding();
+
+        debug!("cross term commits len: primary={primary_cross_term_commits_len}, secondary={secondary_cross_term_commits_len}");
+
+        let (primary_ctx, primary_plonk_instance) = {
+            let mut layouter =
+                SingleChipLayouter::<'_, C1::Scalar, _>::new(&mut primary_td, vec![])?;
+
+            let primary_assigned_z0: [_; A1] = layouter.assign_region(
+                || "assigned_z0_primary",
+                |region| {
+                    primary_config
+                        .main_gate_config
+                        .advice_cycle_assigner()
+                        .assign_all_advice(
+                            &mut RegionCtx::new(region, 0),
+                            || "z0_primary",
+                            z0_primary.iter().copied(),
+                        )
+                        .map(|inp| inp.try_into().unwrap())
+                },
+            )?;
+            debug!("primary z0 assigned");
+            debug!("start primary synthesize");
+
+            let StepSynthesisResult {
+                z_output: primary_assigned_z_output,
+                // Not used in zero step, only in verify-step, when folding is over
+                output_hash: _primary_output_hash,
+                // Not used in zero step, only in verify-step, when folding is over
+                X1: _primary_X1,
+            } = primary.synthesize(
+                primary_config,
+                &mut layouter,
+                step_circuit::StepInputs {
+                    step_public_params: &pp.primary.params,
+                    public_params_hash: primary_public_params_hash,
+                    step: C1::Scalar::ZERO,
+                    z_0: primary_assigned_z0.clone(),
+                    z_i: primary_assigned_z0.clone(),
+                    // Can be any
+                    U: PlonkInstance::default().to_relax(),
+                    // Can be any
+                    u: PlonkInstance::default(),
+                    cross_term_commits: vec![C2::identity(); primary_cross_term_commits_len],
+                },
+            )?;
+
+            debug!("start primary td postpone");
+            primary_td.postpone_assembly();
+            debug!("primary synthesized, start sps");
+
+            let (primary_plonk_instance, primary_plonk_witness) = primary_td.run_sps_protocol(
+                pp.primary.ck,
+                &mut RP2::OffCircuit::new(pp.secondary.params.ro_constant.clone()),
+                primary_td.plonk_structure().unwrap().num_challenges,
+            )?;
+
+            (
+                StepCircuitContext::<A1, C1, SC1> {
+                    step_circuit: primary,
+                    relaxed_trace: RelaxedPlonkTrace {
+                        U: primary_plonk_instance.to_relax(),
+                        W: primary_plonk_witness.to_relax(pp.primary.td_k() as usize),
+                    },
+                    z_0: primary_assigned_z0,
+                    z_i: primary_assigned_z_output,
+                },
+                primary_plonk_instance,
+            )
+        };
+        debug!("primary ctx ready");
+
+        let (secondary_ctx, secondary_trace) = {
+            let mut layouter =
+                SingleChipLayouter::<'_, C2::Scalar, _>::new(&mut secondary_td, vec![])?;
+
+            let secondary_assigned_z0: [_; A2] = layouter.assign_region(
+                || "assigned_z0_secondary",
+                |region| {
+                    secondary_config
+                        .main_gate_config
+                        .advice_cycle_assigner()
+                        .assign_all_advice(
+                            &mut RegionCtx::new(region, 0),
+                            || "z0_secondary",
+                            z0_secondary.iter().copied(),
+                        )
+                        .map(|inp| inp.try_into().unwrap())
+                },
+            )?;
+            debug!("secondary z0 assigned");
+            debug!("start secondary synthesize");
+
+            let StepSynthesisResult {
+                z_output: secondary_assigned_z_output,
+                // Not used in zero step, only in verify-step, when folding is over
+                output_hash: _secondary_output_hash,
+                // Not used in zero step, only in verify-step, when folding is over
+                X1: _secondary_X1,
+            } = secondary.synthesize(
+                secondary_config,
+                &mut layouter,
+                StepInputs {
+                    step_public_params: &pp.secondary.params,
+                    public_params_hash: secondary_public_params_hash,
+                    step: C2::Scalar::ZERO,
+                    z_0: secondary_assigned_z0.clone(),
+                    z_i: secondary_assigned_z0.clone(),
+                    // Can be any
+                    U: primary_plonk_instance.to_relax(),
+                    u: primary_plonk_instance.clone(),
+                    cross_term_commits: vec![C1::identity(); secondary_cross_term_commits_len],
+                },
+            )?;
+
+            debug!("start secondary td postpone");
+            secondary_td.postpone_assembly();
+            debug!("secondary synthesized");
+
+            let (secondary_plonk_instance, secondary_plonk_witness) = secondary_td
+                .run_sps_protocol(
+                    pp.secondary.ck,
+                    &mut RP1::OffCircuit::new(pp.primary.params.ro_constant.clone()),
+                    secondary_td.plonk_structure().unwrap().num_challenges,
+                )?;
+
+            (
+                StepCircuitContext::<A2, C2, SC2> {
+                    step_circuit: secondary,
+                    relaxed_trace: RelaxedPlonkTrace {
+                        U: secondary_plonk_instance.to_relax(),
+                        W: secondary_plonk_witness.to_relax(pp.secondary.td_k() as usize),
+                    },
+                    z_0: secondary_assigned_z0,
+                    z_i: secondary_assigned_z_output,
+                },
+                PlonkTrace {
+                    u: secondary_plonk_instance,
+                    w: secondary_plonk_witness,
+                },
+            )
+        };
+        debug!("secondary ctx ready");
+
+        Ok(Self {
+            step: 1,
+            secondary_trace,
+            primary: primary_ctx,
+            secondary: secondary_ctx,
+        })
     }
 
     pub fn prove_step<const T: usize, RP1, RP2>(

--- a/src/ivc/incrementally_verifiable_computation.rs
+++ b/src/ivc/incrementally_verifiable_computation.rs
@@ -149,12 +149,14 @@ where
         let secondary_ps = secondary_td
             .plonk_structure()
             .ok_or(Error::MissedPlonkStructure { is_primary: false })?;
-        let primary_cross_term_commits_len = secondary_ps.get_degree_for_folding();
+        let primary_cross_term_commits_len =
+            secondary_ps.get_degree_for_folding().saturating_sub(1);
 
         let primary_ps = primary_td
             .plonk_structure()
             .ok_or(Error::MissedPlonkStructure { is_primary: true })?;
-        let secondary_cross_term_commits_len = primary_ps.get_degree_for_folding();
+        let secondary_cross_term_commits_len =
+            primary_ps.get_degree_for_folding().saturating_sub(1);
 
         let primary_public_params_hash = public_params::calc_digest::<C1, C2, C2, RP1, RP2>(
             pp.primary.params(),

--- a/src/ivc/public_params.rs
+++ b/src/ivc/public_params.rs
@@ -73,7 +73,7 @@ where
         is_primary_circuit: bool,
         ro_constant: RP::Args,
         limb_width: NonZeroUsize,
-        n_limbs: NonZeroUsize,
+        limbs_count: NonZeroUsize,
     ) -> Result<Self, Error> {
         debug!("start creating circuit pp");
 
@@ -95,7 +95,7 @@ where
             ck: commitment_key,
             params: SynthesizeStepParams {
                 limb_width,
-                n_limbs,
+                limbs_count,
                 is_primary_circuit,
                 ro_constant,
             },

--- a/src/ivc/public_params.rs
+++ b/src/ivc/public_params.rs
@@ -39,7 +39,7 @@ where
 
     td: TableData<C::Scalar>,
     X0: Column<Instance>,
-    config: StepConfig<ARITY, C::Scalar, SC, MAIN_GATE_T>,
+    config: StepConfig<ARITY, MAIN_GATE_T, C::Scalar, SC>,
 }
 
 impl<'key, const ARITY: usize, const MAIN_GATE_T: usize, C, SC, RP> fmt::Debug
@@ -102,10 +102,20 @@ where
         })
     }
 
-    pub fn prepare_td(&self, instance_columns: &[C::Scalar]) -> TableData<C::Scalar> {
+    pub fn td_k(&self) -> u32 {
+        self.td.k
+    }
+
+    pub fn prepare_td(
+        &self,
+        instance_columns: &[C::Scalar],
+    ) -> (
+        StepConfig<ARITY, MAIN_GATE_T, C::Scalar, SC>,
+        TableData<C::Scalar>,
+    ) {
         let mut td = self.td.clone();
         td.instance = instance_columns.to_vec();
-        td
+        (self.config.clone(), td)
     }
 }
 

--- a/src/ivc/public_params.rs
+++ b/src/ivc/public_params.rs
@@ -79,7 +79,7 @@ where
 
         let mut td = TableData::new(k_table_size, vec![C::Scalar::ZERO, C::Scalar::ZERO]);
 
-        let (X0, config) = td.prepare_assembly(|cs| {
+        let (X0, config) = td.configure(|cs| {
             let X0 = cs.instance_column();
 
             (

--- a/src/ivc/public_params.rs
+++ b/src/ivc/public_params.rs
@@ -80,10 +80,11 @@ where
         let mut td = TableData::new(k_table_size, vec![C::Scalar::ZERO, C::Scalar::ZERO]);
 
         let (X0, config) = td.configure(|cs| {
-            let X0 = cs.instance_column();
+            let instance = cs.instance_column();
+            cs.enable_equality(instance);
 
             (
-                X0,
+                instance,
                 <SC as StepCircuitExt<'_, ARITY, C::Scalar>>::configure::<MAIN_GATE_T>(cs),
             )
         });

--- a/src/ivc/public_params.rs
+++ b/src/ivc/public_params.rs
@@ -1,4 +1,4 @@
-use std::{fmt, num::NonZeroUsize};
+use std::{fmt, io, num::NonZeroUsize};
 
 use ff::{Field, FromUniformBytes, PrimeFieldBits};
 use group::prime::PrimeCurveAffine;
@@ -250,7 +250,7 @@ where
 
     /// This method calculate digest of [`PublicParams`], but ignore [`CircuitPublicParams::ck`]
     /// from both step circuits params
-    pub fn digest<C: CurveAffine>(&self) -> Result<C, crate::ivc::Error> {
+    pub fn digest<C: CurveAffine>(&self) -> Result<C, io::Error> {
         calc_digest::<C1, C2, C, RP1, RP2>(
             &self.primary.params,
             &self
@@ -273,7 +273,7 @@ pub fn calc_digest<C1: CurveAffine, C2: CurveAffine, CO: CurveAffine, RP1, RP2>(
     primary_plonk_struct: &PlonkStructure<C1::Scalar>,
     secondary_params: &SynthesizeStepParams<C2::Scalar, RP2::OnCircuit>,
     secondary_plonk_struct: &PlonkStructure<C2::Scalar>,
-) -> Result<CO, crate::ivc::Error>
+) -> Result<CO, io::Error>
 where
     C1: CurveAffine<Base = <C2 as PrimeCurveAffine>::Scalar> + Serialize,
     C2: CurveAffine<Base = <C1 as PrimeCurveAffine>::Scalar> + Serialize,
@@ -309,7 +309,6 @@ where
         primary_params,
         secondary_params,
     })
-    .map_err(crate::ivc::Error::WhileHash)
 }
 
 #[cfg(test)]

--- a/src/ivc/public_params.rs
+++ b/src/ivc/public_params.rs
@@ -112,10 +112,11 @@ where
     ) -> (
         StepConfig<ARITY, MAIN_GATE_T, C::Scalar, SC>,
         TableData<C::Scalar>,
+        Column<Instance>,
     ) {
         let mut td = self.td.clone();
         td.instance = instance_columns.to_vec();
-        (self.config.clone(), td)
+        (self.config.clone(), td, self.X0)
     }
 
     pub fn params(&self) -> &SynthesizeStepParams<C::Scalar, RP::OnCircuit> {

--- a/src/ivc/step_circuit.rs
+++ b/src/ivc/step_circuit.rs
@@ -119,7 +119,7 @@ where
     RO: ROCircuitTrait<F>,
 {
     pub limb_width: NonZeroUsize,
-    pub n_limbs: NonZeroUsize,
+    pub limbs_count: NonZeroUsize,
     /// A boolean indicating if this is the primary circuit
     pub is_primary_circuit: bool,
     pub ro_constant: RO::Args,
@@ -133,7 +133,7 @@ where
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SynthesizeStepParams")
             .field("limb_width", &self.limb_width)
-            .field("n_limbs", &self.n_limbs)
+            .field("n_limbs", &self.limbs_count)
             .field("is_primary_circuit", &self.is_primary_circuit)
             .field("ro_constant", &self.ro_constant)
             .finish()
@@ -334,7 +334,7 @@ where
         Ok(StepSynthesisResult {
             z_output,
             output_hash,
-            X1: assigned_input_witness.input_challenges.get(1).cloned(),
+            X1: assigned_input_witness.input_instances.get(1).cloned(),
         })
     }
 
@@ -355,7 +355,7 @@ where
                 let chip = if public_params.is_primary_circuit {
                     FoldRelaxedPlonkInstanceChip::new_default(
                         public_params.limb_width,
-                        public_params.n_limbs,
+                        public_params.limbs_count,
                         u.challenges.len(),
                         u.W_commitments.len(),
                         config.clone(),
@@ -364,7 +364,7 @@ where
                     FoldRelaxedPlonkInstanceChip::from_instance(
                         u.clone(),
                         public_params.limb_width,
-                        public_params.n_limbs,
+                        public_params.limbs_count,
                         config.clone(),
                     )
                 };
@@ -400,7 +400,7 @@ where
                 let chip = FoldRelaxedPlonkInstanceChip::from_relaxed(
                     U.clone(),
                     input.step_public_params.limb_width,
-                    input.step_public_params.n_limbs,
+                    input.step_public_params.limbs_count,
                     config.main_gate_config.clone(),
                 );
 

--- a/src/ivc/step_circuit.rs
+++ b/src/ivc/step_circuit.rs
@@ -197,8 +197,8 @@ where
 pub struct StepSynthesisResult<const ARITY: usize, F: PrimeField> {
     /// Output of current synthesis step
     pub z_output: [AssignedValue<F>; ARITY],
-    pub output_hash: AssignedValue<F>,
-    pub X1: Option<Vec<AssignedValue<F>>>,
+    pub new_X1: AssignedValue<F>,
+    pub new_X0: AssignedValue<F>,
 }
 
 /// Trait extends [`StepCircuit`] to represent the augmented function `F'` in the IVC scheme.
@@ -333,8 +333,12 @@ where
 
         Ok(StepSynthesisResult {
             z_output,
-            output_hash,
-            X1: assigned_input_witness.input_instances.get(1).cloned(),
+            new_X0: assigned_input_witness
+                .input_instances
+                .first()
+                .and_then(|inst| inst.get(1).cloned())
+                .unwrap(),
+            new_X1: output_hash,
         })
     }
 

--- a/src/nifs/tests.rs
+++ b/src/nifs/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::nifs::vanilla::ProveResultCtx;
 use crate::nifs::{vanilla::VanillaFS, Error as NIFSError};
 use crate::plonk::{RelaxedPlonkInstance, RelaxedPlonkWitness};
 use crate::util::create_ro;
@@ -56,7 +57,13 @@ where
 
     let mut ro_acc_prover = create_ro::<C::Base, T, RATE, R_F, R_P>();
     let mut ro_acc_verifier = create_ro::<C::Base, T, RATE, R_F, R_P>();
-    let (nifs, (U_from_prove, W)) = VanillaFS::prove(
+
+    let ProveResultCtx {
+        U: U_from_prove,
+        nifs,
+        W,
+        ..
+    } = VanillaFS::prove(
         ck,
         pp_digest,
         &mut ro_nark_prover,
@@ -87,7 +94,12 @@ where
         .unwrap();
     assert_eq!(S.is_sat(ck, &mut ro_nark_decider, &U1, &W1).err(), None);
 
-    let (nifs, (U_from_prove, _W)) = VanillaFS::prove(
+    let ProveResultCtx {
+        U: U_from_prove,
+        nifs,
+        W,
+        ..
+    } = VanillaFS::prove(
         ck,
         pp_digest,
         &mut ro_nark_prover,
@@ -96,6 +108,7 @@ where
         &f_U,
         &f_W,
     )?;
+
     let U_from_verify = nifs
         .verify(
             pp_digest,
@@ -108,7 +121,7 @@ where
     assert_eq!(U_from_prove, U_from_verify);
 
     f_U = U_from_verify;
-    f_W = _W;
+    f_W = W;
     assert_eq!(S.is_sat_relaxed(ck, &f_U, &f_W).err(), None);
     assert_eq!(S.is_sat_perm(&f_U, &f_W).err(), None);
     Ok(())

--- a/src/nifs/vanilla.rs
+++ b/src/nifs/vanilla.rs
@@ -126,18 +126,13 @@ impl<C: CurveAffine, RO: ROTrait<C::Base>> VanillaFS<C, RO> {
         debug!("degree: {degree}");
 
         let cross_terms: Vec<Vec<C::ScalarExt>> = (1..degree)
-            .par_bridge()
             .map(|k| {
-                let coeff = normalized.coeff_of(
+                normalized.coeff_of(
                     ColumnIndex::Challenge {
                         column_index: r_index,
                     },
                     k,
-                );
-
-                debug!("coeff found");
-
-                coeff
+                )
             })
             .map(|multipoly| {
                 (0..num_row)

--- a/src/plonk/mod.rs
+++ b/src/plonk/mod.rs
@@ -137,12 +137,14 @@ pub struct RelaxedPlonkWitness<F: PrimeField> {
 }
 
 // TODO #31 docs
+#[derive(Debug)]
 pub struct RelaxedPlonkTrace<C: CurveAffine> {
     pub U: RelaxedPlonkInstance<C>,
     pub W: RelaxedPlonkWitness<C::Scalar>,
 }
 
 // TODO #31 docs
+#[derive(Debug)]
 pub struct PlonkTrace<C: CurveAffine> {
     pub u: PlonkInstance<C>,
     pub w: PlonkWitness<C::Scalar>,
@@ -182,6 +184,11 @@ impl<F: PrimeField> PlonkStructure<F> {
     /// return the index offset of fixed variables(i.e. not folded)
     pub fn num_non_fold_vars(&self) -> usize {
         self.fixed_columns.len() + self.selectors.len()
+    }
+
+    pub fn get_degree_for_folding(&self) -> usize {
+        let offset = self.num_non_fold_vars();
+        self.poly.degree_for_folding(offset)
     }
 
     /// return the number of variables to be folded

--- a/src/polynomial/mod.rs
+++ b/src/polynomial/mod.rs
@@ -680,13 +680,11 @@ impl<F: PrimeField> MultiPolynomial<F> {
             self.monomials
                 .par_iter()
                 .filter_map(|mono| {
-                    if mono.exponents[*index] == degree {
+                    mono.exponents.get(*index)?.eq(&degree).then(|| {
                         let mut exponents = mono.exponents.clone();
                         exponents.remove(*index);
-                        Some(Monomial::new(index_to_poly.clone(), mono.coeff, exponents))
-                    } else {
-                        None
-                    }
+                        Monomial::new(index_to_poly.clone(), mono.coeff, exponents)
+                    })
                 })
                 .collect::<Vec<_>>(),
         );

--- a/src/polynomial/mod.rs
+++ b/src/polynomial/mod.rs
@@ -676,19 +676,20 @@ impl<F: PrimeField> MultiPolynomial<F> {
 
         debug!("monomials len {}", self.monomials.len());
 
-        poly.monomials = self
-            .monomials
-            .par_iter()
-            .filter_map(|mono| {
-                if mono.exponents[*index] == degree {
-                    let mut exponents = mono.exponents.clone();
-                    exponents.remove(*index);
-                    Some(Monomial::new(index_to_poly.clone(), mono.coeff, exponents))
-                } else {
-                    None
-                }
-            })
-            .collect();
+        poly.monomials.extend(
+            self.monomials
+                .par_iter()
+                .filter_map(|mono| {
+                    if mono.exponents[*index] == degree {
+                        let mut exponents = mono.exponents.clone();
+                        exponents.remove(*index);
+                        Some(Monomial::new(index_to_poly.clone(), mono.coeff, exponents))
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>(),
+        );
 
         poly
     }

--- a/src/poseidon/random_oracle.rs
+++ b/src/poseidon/random_oracle.rs
@@ -82,7 +82,7 @@ where
     F: ff::PrimeFieldBits + ff::FromUniformBytes<64>,
 {
     /// Argument for creating on-circuit & off-circuit versions of oracles
-    type Args: fmt::Debug + serde::Serialize;
+    type Args: fmt::Debug + serde::Serialize + Clone;
     type Config;
 
     type OffCircuit: ROTrait<F, Constants = Self::Args>;

--- a/src/table.rs
+++ b/src/table.rs
@@ -41,6 +41,15 @@ use halo2_proofs::{
 use log::*;
 use std::collections::HashMap;
 
+// TODO: (1) separate TableData into 
+// TableData {
+//   CircuitInfo,
+//   WitnessData,
+// }
+// (2) separate assembly into assembly_circuit_info
+// which only collect circuit related info (e.g. custom gates, copy constraints info, lookup_arguments, fixed columns)
+// and assembly_witness_data (i.e. advice columns)
+// see TODO in CircuitPublicParams::new
 #[derive(Debug, Clone)]
 pub struct TableData<F: PrimeField> {
     // TODO: without usable_rows still safe?

--- a/src/table.rs
+++ b/src/table.rs
@@ -487,6 +487,7 @@ impl<F: PrimeField> TableData<F> {
             return Err(SpsError::LackOfAdvices);
         }
 
+        debug!("run sps with challenges: {num_challenges}");
         match num_challenges {
             0 => self.run_sps_protocol_0(ck),
             1 => self.run_sps_protocol_1(ck, ro_nark),


### PR DESCRIPTION
This only serves as code skeleton to demonstrate purpose, not functional ready.
`step_circuit.rs` and `public_param.rs` are almost done.
`ivc` is still working on.

The main changes so far and the reasons:

(1) change from StepCircuitExt (trait) into IVCStepCircuit(struct). Here IVCStepCircuit is the circuit we are folding at each step. It implements `halo2::Circuit` trait. So we can treat it as normal halo2 circuit as well as step circuit for another IVCStepCircuit. This allows us to recursively to parallel folded IVCStepCircuit. Also, we don't need to distinguish IVCStepCircuit from other circuit (from functional point of view).

(2) In `IVCStepCircuit::synthesize`, we call `fn assign_circuit_inputs` first. Then pass the assigned_inputs to (a) `fn synhesize_step_base` and (b) `fn synthesize_step_non_base`. Previously, we pass the inputs to (a) and (b), this way doesn't guarantee the consistency between them. By passing assigned_inputs to (a) and (b), it ensures all the inputs are properly constraint.

(3) separation of TableData into two parts (left as TODO)
```
pub struct TableData {
   circuit_info,
  witness_data,
}
```
Then separate `fn assembly` into two parts:
`fn assembly_circuit_info` and `fn assembly_witness_data`
We need create table data in `pp.primary.td` (`PublicParam->CircuitPublicParam->TableData`) when calling `pp.new()`. Each step, the witness_data is changing, but the circuit_info is un-changed. With this separation,  we can get the circuit info in the very beginning and only get the witness data of each step later on.

