### PR TITLE
feat(Ivc): decider verification of IVC 

### DIFF
--- a/src/ivc/incrementally_verifiable_computation.rs
+++ b/src/ivc/incrementally_verifiable_computation.rs
@@ -51,8 +51,8 @@ pub enum Error {
     Step(#[from] step_circuit::SynthesisError),
     #[error("number of steps is not match")]
     NumStepNotMatch,
-    #[error("input hash not match")]
-    InputHashNotMatch,
+    #[error("step circuit input not match")]
+    SCInputNotMatch,
     #[error("TODO")]
     WhileHash(io::Error),
     #[error("TODO")]
@@ -249,12 +249,11 @@ where
             return Err(Error::NumStepNotMatch);
         }
         if self.primary.z_0 != primary_z_0 || self.secondary.z_0 != secondary_z_0 {
-            return Err(Error::InputHashNotMatch);
+            return Err(Error::SCInputNotMatch);
         }
 
         // verify X0
         let ro1 = &mut RP1::OffCircuit::new(pp.primary.params.ro_constant.clone());
-        // TODO: cache the result in IVC struct (?) so that we don't need to re-calculate it
         let primary_hash = pp.digest::<C2>().map_err(Error::WhileHash)?;
         ro1.absorb_point(&primary_hash);
         ro1.absorb_field(C1::Scalar::from_u128(self.step as u128));

--- a/src/ivc/incrementally_verifiable_computation.rs
+++ b/src/ivc/incrementally_verifiable_computation.rs
@@ -45,6 +45,8 @@ pub enum Error {
     Plonk(#[from] halo2_proofs::plonk::Error),
     #[error(transparent)]
     Step(#[from] step_circuit::SynthesisError),
+    #[error("IVC Param not match")]
+    IVCParamNotMatch,
     #[error("TODO")]
     WhileHash(io::Error),
     #[error("TODO")]
@@ -229,16 +231,26 @@ where
     pub fn verify<const T: usize, RP1, RP2>(
         &mut self,
         _pp: &PublicParams<'_, A1, A2, T, C1, C2, SC1, SC2, RP1, RP2>,
-        _steps_count: usize,
-        _z0_primary: [C1::Scalar; A1],
-        _z0_secondary: [C2::Scalar; A2],
+        num_steps: usize,
+        z0_primary: [C1::Scalar; A1],
+        z0_secondary: [C2::Scalar; A2],
     ) -> Result<(), Error>
     where
         RP1: ROPair<C1::Scalar>,
         RP2: ROPair<C2::Scalar>,
     {
-        // TODO #31
-        todo!("Logic at `RecursiveSNARK::verify`")
+        let is_step_zero = num_steps == 0;
+        let is_num_step_not_match = num_steps != self.step;
+        let is_inputs_match = self.primary.z_0 != z0_primary || self.secondary.z_0 != z0_secondary;
+        if is_step_zero || is_num_step_not_match || is_inputs_match {
+            return Err(Error::IVCParamNotMatch);
+        }
+
+        // check output hash
+
+        // check instance-witness pair satisfiability
+
+        Ok(())
     }
 
     fn prepare_primary_td<const T: usize, RP1>(

--- a/src/plonk/mod.rs
+++ b/src/plonk/mod.rs
@@ -42,7 +42,7 @@ pub mod permutation;
 pub mod util;
 
 #[derive(Debug, thiserror::Error, PartialEq)]
-pub enum DeciderError {
+pub enum Error {
     #[error(transparent)]
     Sps(#[from] SpsError),
     #[error(transparent)]
@@ -221,7 +221,7 @@ impl<F: PrimeField> PlonkStructure<F> {
         ro_nark: &mut RO,
         U: &PlonkInstance<C>,
         W: &PlonkWitness<F>,
-    ) -> Result<(), DeciderError>
+    ) -> Result<(), Error>
     where
         C: CurveAffine<ScalarExt = F>,
     {
@@ -253,12 +253,12 @@ impl<F: PrimeField> PlonkStructure<F> {
 
         match (res == 0, check_commitments == 0, is_h_equal_g) {
             (true, true, true) => Ok(()),
-            (false, _, _) => Err(DeciderError::EvaluationMismatch {
+            (false, _, _) => Err(Error::EvaluationMismatch {
                 mismatch_count: res,
                 total_row: nrow,
             }),
-            (_, _, false) => Err(DeciderError::LogDerivativeNotSat),
-            _ => Err(DeciderError::CommitmentMismatch),
+            (_, _, false) => Err(Error::LogDerivativeNotSat),
+            _ => Err(Error::CommitmentMismatch),
         }
     }
 
@@ -267,7 +267,7 @@ impl<F: PrimeField> PlonkStructure<F> {
         ck: &CommitmentKey<C>,
         U: &RelaxedPlonkInstance<C>,
         W: &RelaxedPlonkWitness<F>,
-    ) -> Result<(), DeciderError>
+    ) -> Result<(), Error>
     where
         C: CurveAffine<ScalarExt = F>,
     {
@@ -304,12 +304,12 @@ impl<F: PrimeField> PlonkStructure<F> {
 
         match (res == 0, check_W_commitments == 0, is_E_equal, is_h_equal_g) {
             (true, true, true, true) => Ok(()),
-            (false, _, _, _) => Err(DeciderError::EvaluationMismatch {
+            (false, _, _, _) => Err(Error::EvaluationMismatch {
                 mismatch_count: res,
                 total_row: nrow,
             }),
-            (_, _, _, false) => Err(DeciderError::LogDerivativeNotSat),
-            _ => Err(DeciderError::CommitmentMismatch),
+            (_, _, _, false) => Err(Error::LogDerivativeNotSat),
+            _ => Err(Error::CommitmentMismatch),
         }
     }
 
@@ -318,7 +318,7 @@ impl<F: PrimeField> PlonkStructure<F> {
         &self,
         U: &RelaxedPlonkInstance<C>,
         W: &RelaxedPlonkWitness<F>,
-    ) -> Result<(), DeciderError>
+    ) -> Result<(), Error>
     where
         C: CurveAffine<ScalarExt = F>,
     {
@@ -338,7 +338,7 @@ impl<F: PrimeField> PlonkStructure<F> {
         if mismatch_count == 0 {
             Ok(())
         } else {
-            Err(DeciderError::PermCheckFail { mismatch_count })
+            Err(Error::PermCheckFail { mismatch_count })
         }
     }
 


### PR DESCRIPTION
Add `IVC::verify` to check the validity after `n` steps of IVC folding, this is the non zkSNARK version of the decider.
Some of the verifications need to be uncommented after adding `secondary_trace` into the `IVC` structure.