### PR TITLE
feat(poseidon): impl `absorb_{point,field}_iter`

### DIFF
--- a/src/nifs/vanilla.rs
+++ b/src/nifs/vanilla.rs
@@ -128,9 +128,7 @@ impl<C: CurveAffine> VanillaFS<C> {
         ro_acc.absorb_point(pp_digest);
         U1.absorb_into(ro_acc);
         U2.absorb_into(ro_acc);
-        cross_term_commits
-            .iter()
-            .for_each(|cm| ro_acc.absorb_point(cm));
+        ro_acc.absorb_point_iter(cross_term_commits.iter());
 
         Ok(ro_acc.squeeze::<C>(NUM_CHALLENGE_BITS))
     }

--- a/src/nifs/vanilla.rs
+++ b/src/nifs/vanilla.rs
@@ -8,7 +8,7 @@ use crate::plonk::{
 };
 use crate::plonk::{PlonkTrace, RelaxedPlonkTrace};
 use crate::polynomial::ColumnIndex;
-use crate::poseidon::{AbsorbInRO, ROTrait};
+use crate::poseidon::ROTrait;
 use crate::sps::SpecialSoundnessVerifier;
 use crate::table::TableData;
 use halo2_proofs::arithmetic::CurveAffine;
@@ -125,12 +125,12 @@ impl<C: CurveAffine> VanillaFS<C> {
         U2: &PlonkInstance<C>,
         cross_term_commits: &[C],
     ) -> Result<<C as CurveAffine>::ScalarExt, Error> {
-        ro_acc.absorb_point(pp_digest);
-        U1.absorb_into(ro_acc);
-        U2.absorb_into(ro_acc);
-        ro_acc.absorb_point_iter(cross_term_commits.iter());
-
-        Ok(ro_acc.squeeze::<C>(NUM_CHALLENGE_BITS))
+        Ok(ro_acc
+            .absorb_point(pp_digest)
+            .absorb(U1)
+            .absorb(U2)
+            .absorb_point_iter(cross_term_commits.iter())
+            .squeeze::<C>(NUM_CHALLENGE_BITS))
     }
 }
 

--- a/src/plonk/mod.rs
+++ b/src/plonk/mod.rs
@@ -159,31 +159,19 @@ impl<C: CurveAffine> PlonkTrace<C> {
 
 impl<C: CurveAffine, RO: ROTrait<C::Base>> AbsorbInRO<C::Base, RO> for PlonkInstance<C> {
     fn absorb_into(&self, ro: &mut RO) {
-        for pt in self.W_commitments.iter() {
-            ro.absorb_point(pt);
-        }
-        for inst in self.instance.iter() {
-            ro.absorb_field(fe_to_fe(inst).unwrap());
-        }
-        for cha in self.challenges.iter() {
-            ro.absorb_field(fe_to_fe(cha).unwrap());
-        }
+        ro.absorb_point_iter(self.W_commitments.iter())
+            .absorb_field_iter(self.instance.iter().map(|inst| fe_to_fe(inst).unwrap()))
+            .absorb_field_iter(self.challenges.iter().map(|cha| fe_to_fe(cha).unwrap()));
     }
 }
 
 impl<C: CurveAffine, RO: ROTrait<C::Base>> AbsorbInRO<C::Base, RO> for RelaxedPlonkInstance<C> {
     fn absorb_into(&self, ro: &mut RO) {
-        for pt in self.W_commitments.iter() {
-            ro.absorb_point(pt);
-        }
-        ro.absorb_point(&self.E_commitment);
-        for inst in self.instance.iter() {
-            ro.absorb_field(fe_to_fe(inst).unwrap());
-        }
-        for cha in self.challenges.iter() {
-            ro.absorb_field(fe_to_fe(cha).unwrap());
-        }
-        ro.absorb_field(fe_to_fe(&self.u).unwrap());
+        ro.absorb_point_iter(self.W_commitments.iter())
+            .absorb_point(&self.E_commitment)
+            .absorb_field_iter(self.instance.iter().map(|inst| fe_to_fe(inst).unwrap()))
+            .absorb_field_iter(self.challenges.iter().map(|cha| fe_to_fe(cha).unwrap()))
+            .absorb_field(fe_to_fe(&self.u).unwrap());
     }
 }
 

--- a/src/poseidon/poseidon_hash.rs
+++ b/src/poseidon/poseidon_hash.rs
@@ -118,11 +118,12 @@ where
         }
     }
 
-    fn absorb_field(&mut self, base: F) {
+    fn absorb_field(&mut self, base: F) -> &mut Self {
         self.update(&[base]);
+        self
     }
 
-    fn absorb_point<C: CurveAffine<Base = F>>(&mut self, point: &C) {
+    fn absorb_point<C: CurveAffine<Base = F>>(&mut self, point: &C) -> &mut Self {
         let encoded = point.coordinates().map(|coordinates| {
             [coordinates.x(), coordinates.y()]
                 .into_iter()
@@ -134,6 +135,8 @@ where
         } else {
             self.update(&[C::Base::ZERO, C::Base::ZERO]) // C is infinity
         }
+
+        self
     }
 
     fn squeeze<C: CurveAffine<Base = F>>(&mut self, num_bits: NonZeroUsize) -> C::Scalar {
@@ -224,9 +227,7 @@ mod tests {
         type PH = PoseidonHash<<EpAffine as CurveAffine>::Base, T, RATE>;
         let spec = Spec::<Fp, T, RATE>::new(R_F, R_P);
         let mut poseidon = PH::new(spec);
-        for i in 0..5 {
-            poseidon.absorb_field(Fp::from(i as u64));
-        }
+        poseidon.absorb_field_iter((0..5).map(|i| Fp::from(i as u64)));
         let output = poseidon.squeeze::<EpAffine>(NonZeroUsize::new(128).unwrap());
         // let out_hash = Fq::from_str_vartime("13037709793114148810823325920380362524528554380279235267325741570708489436263").unwrap();
         let out_hash = Fq::from_str_vartime("277726250230731218669330566268314254439").unwrap();

--- a/src/poseidon/poseidon_hash.rs
+++ b/src/poseidon/poseidon_hash.rs
@@ -225,12 +225,14 @@ mod tests {
         const R_P: usize = 3;
 
         type PH = PoseidonHash<<EpAffine as CurveAffine>::Base, T, RATE>;
-        let spec = Spec::<Fp, T, RATE>::new(R_F, R_P);
-        let mut poseidon = PH::new(spec);
-        poseidon.absorb_field_iter((0..5).map(|i| Fp::from(i as u64)));
-        let output = poseidon.squeeze::<EpAffine>(NonZeroUsize::new(128).unwrap());
-        // let out_hash = Fq::from_str_vartime("13037709793114148810823325920380362524528554380279235267325741570708489436263").unwrap();
-        let out_hash = Fq::from_str_vartime("277726250230731218669330566268314254439").unwrap();
-        assert_eq!(output, out_hash);
+
+        let output = PH::new(Spec::<Fp, T, RATE>::new(R_F, R_P))
+            .absorb_field_iter((0..5).map(|i| Fp::from(i as u64)))
+            .squeeze::<EpAffine>(NonZeroUsize::new(128).unwrap());
+
+        assert_eq!(
+            output,
+            Fq::from_str_vartime("277726250230731218669330566268314254439").unwrap()
+        );
     }
 }

--- a/src/poseidon/random_oracle.rs
+++ b/src/poseidon/random_oracle.rs
@@ -25,10 +25,29 @@ pub trait ROTrait<F: PrimeField> {
     fn new(constants: Self::Constants) -> Self;
 
     /// Adds a base to the internal state
-    fn absorb_field(&mut self, base: F);
+    fn absorb_field(&mut self, base: F) -> &mut Self;
+
+    /// Adds a base to the internal state
+    fn absorb_field_iter(&mut self, iter: impl Iterator<Item = F>) -> &mut Self {
+        iter.for_each(|base| {
+            self.absorb_field(base);
+        });
+        self
+    }
 
     /// Adds a point to the internal state
-    fn absorb_point<C: CurveAffine<Base = F>>(&mut self, p: &C);
+    fn absorb_point<C: CurveAffine<Base = F>>(&mut self, p: &C) -> &mut Self;
+
+    fn absorb_point_iter<'item, C: CurveAffine<Base = F>>(
+        &mut self,
+        points: impl Iterator<Item = &'item C>,
+    ) -> &mut Self {
+        points.for_each(|p| {
+            self.absorb_point(p);
+        });
+
+        self
+    }
 
     /// Returns a challenge by hashing the internal state
     fn squeeze<C: CurveAffine<Base = F>>(&mut self, num_bits: NonZeroUsize) -> C::Scalar;

--- a/src/poseidon/random_oracle.rs
+++ b/src/poseidon/random_oracle.rs
@@ -24,6 +24,14 @@ pub trait ROTrait<F: PrimeField> {
     /// Initializes the hash function
     fn new(constants: Self::Constants) -> Self;
 
+    fn absorb(&mut self, value: &impl AbsorbInRO<F, Self>) -> &mut Self
+    where
+        Self: Sized,
+    {
+        value.absorb_into(self);
+        self
+    }
+
     /// Adds a base to the internal state
     fn absorb_field(&mut self, base: F) -> &mut Self;
 

--- a/src/table.rs
+++ b/src/table.rs
@@ -298,12 +298,9 @@ impl<F: PrimeField> TableData<F> {
     ) -> Result<(PlonkInstance<C>, PlonkWitness<F>), SpsError> {
         let (mut plonk_instance, plonk_witness) = self.run_sps_protocol_0(ck)?;
 
-        self.instance.iter().for_each(|inst| {
-            ro_nark.absorb_field(fe_to_fe(inst).unwrap());
-        });
-        plonk_instance.W_commitments.iter().for_each(|C| {
-            ro_nark.absorb_point(C);
-        });
+        ro_nark
+            .absorb_field_iter(self.instance.iter().map(|inst| fe_to_fe(inst).unwrap()))
+            .absorb_point_iter(plonk_instance.W_commitments.iter());
 
         plonk_instance
             .challenges
@@ -352,11 +349,10 @@ impl<F: PrimeField> TableData<F> {
                 err,
             })?;
 
-        self.instance.iter().for_each(|inst| {
-            ro_nark.absorb_field(fe_to_fe(inst).unwrap());
-        });
-        ro_nark.absorb_point(&C1);
-        let r1 = ro_nark.squeeze::<C>(NUM_CHALLENGE_BITS);
+        let r1 = ro_nark
+            .absorb_field_iter(self.instance.iter().map(|inst| fe_to_fe(inst).unwrap()))
+            .absorb_point(&C1)
+            .squeeze::<C>(NUM_CHALLENGE_BITS);
 
         // round 2
         let lookup_coeff = lookup_coeff.evaluate_coefficient_2(r1);
@@ -372,8 +368,7 @@ impl<F: PrimeField> TableData<F> {
                 annotation: "W2",
                 err,
             })?;
-        ro_nark.absorb_point(&C2);
-        let r2 = ro_nark.squeeze::<C>(NUM_CHALLENGE_BITS);
+        let r2 = ro_nark.absorb_point(&C2).squeeze::<C>(NUM_CHALLENGE_BITS);
 
         Ok((
             PlonkInstance {
@@ -398,9 +393,7 @@ impl<F: PrimeField> TableData<F> {
             return Err(SpsError::LackOfAdvices);
         }
 
-        self.instance.iter().for_each(|inst| {
-            ro_nark.absorb_field(fe_to_fe(inst).unwrap());
-        });
+        ro_nark.absorb_field_iter(self.instance.iter().map(|inst| fe_to_fe(inst).unwrap()));
 
         let k_power_of_2 = 2usize.pow(self.k);
 
@@ -412,8 +405,7 @@ impl<F: PrimeField> TableData<F> {
                 annotation: "W1",
                 err,
             })?;
-        ro_nark.absorb_point(&C1);
-        let r1 = ro_nark.squeeze::<C>(NUM_CHALLENGE_BITS);
+        let r1 = ro_nark.absorb_point(&C1).squeeze::<C>(NUM_CHALLENGE_BITS);
 
         // round 2
         let lookup_coeff = self
@@ -433,8 +425,7 @@ impl<F: PrimeField> TableData<F> {
                 annotation: "W2",
                 err,
             })?;
-        ro_nark.absorb_point(&C2);
-        let r2 = ro_nark.squeeze::<C>(NUM_CHALLENGE_BITS);
+        let r2 = ro_nark.absorb_point(&C2).squeeze::<C>(NUM_CHALLENGE_BITS);
 
         // round 3
         let lookup_coeff = lookup_coeff.evaluate_coefficient_2(r2);
@@ -450,8 +441,7 @@ impl<F: PrimeField> TableData<F> {
                 annotation: "W3",
                 err,
             })?;
-        ro_nark.absorb_point(&C3);
-        let r3 = ro_nark.squeeze::<C>(NUM_CHALLENGE_BITS);
+        let r3 = ro_nark.absorb_point(&C3).squeeze::<C>(NUM_CHALLENGE_BITS);
 
         Ok((
             PlonkInstance {


### PR DESCRIPTION
**Motivation**
- A very common construction we have, when we need to iterate and absorb, it is better to combine them.
- The `chain` absorption design is much more "heap", so much easier to read when you need to aggregate a lot of data in one place
- Consistency with on-circuit random oracle

**Overview**
Fixed the design all over the place

In some places string merging (because return (&mut Self`) can make it confusing that `ro_nark` absorbed the data and then provides it in the same way, so tell me if this seems critical to you as well
