### PR TITLE
fix(icomp): {off,on}-circuit computation of X{0,1}

### DIFF
--- a/src/ivc/fold_relaxed_plonk_instance_chip.rs
+++ b/src/ivc/fold_relaxed_plonk_instance_chip.rs
@@ -987,7 +987,7 @@ fn scalar_module_as_limbs<C: CurveAffine>(
     .to_vec())
 }
 
-fn assign_next_advice_from_point<C: CurveAffine, AR: Into<String>>(
+pub(crate) fn assign_next_advice_from_point<C: CurveAffine, AR: Into<String>>(
     assignor: &mut impl AdviceCyclicAssignor<C::Base>,
     region: &mut RegionCtx<C::Base>,
     input: &C,

--- a/src/ivc/incrementally_verifiable_computation.rs
+++ b/src/ivc/incrementally_verifiable_computation.rs
@@ -179,6 +179,8 @@ where
                 z_0: &primary_z_0,
                 z_i: &primary_z_0,
                 relaxed: &pre_round_secondary_plonk_trace.u.to_relax(),
+                limb_width: pp.primary.params.limb_width,
+                limbs_count: pp.primary.params.limbs_count,
             }
             .generate(),
             RandomOracleComputationInstance::<'_, A1, C1, _, RP1::OffCircuit> {
@@ -188,6 +190,8 @@ where
                 z_0: &primary_z_0,
                 z_i: &primary.process_step(&primary_z_0, pp.primary.k_table_size)?,
                 relaxed: &pre_round_secondary_plonk_trace.u.to_relax(),
+                limb_width: pp.primary.params.limb_width,
+                limbs_count: pp.primary.params.limbs_count,
             }
             .generate(),
         ];
@@ -233,6 +237,8 @@ where
                 z_0: &secondary_z_0,
                 z_i: &secondary_z_0,
                 relaxed: &primary_plonk_trace.u.to_relax(),
+                limb_width: pp.secondary.params.limb_width,
+                limbs_count: pp.secondary.params.limbs_count,
             }
             .generate(),
             RandomOracleComputationInstance::<'_, A2, C2, _, RP2::OffCircuit> {
@@ -242,6 +248,8 @@ where
                 z_0: &secondary_z_0,
                 z_i: &secondary.process_step(&secondary_z_0, pp.secondary.k_table_size)?,
                 relaxed: &primary_plonk_trace.u.to_relax(),
+                limb_width: pp.secondary.params.limb_width,
+                limbs_count: pp.secondary.params.limbs_count,
             }
             .generate(),
         ];
@@ -327,6 +335,8 @@ where
                     z_0: &self.primary.z_0,
                     z_i: &self.primary.z_i,
                     relaxed: &self.secondary.relaxed_trace.U,
+                    limb_width: pp.secondary.params.limb_width,
+                    limbs_count: pp.secondary.params.limbs_count,
                 }
                 .generate(),
                 RandomOracleComputationInstance::<'_, A1, C1, _, RP1::OffCircuit> {
@@ -339,6 +349,8 @@ where
                         .step_circuit
                         .process_step(&self.primary.z_i, pp.primary.k_table_size)?,
                     relaxed: &secondary_new_trace.U,
+                    limb_width: pp.secondary.params.limb_width,
+                    limbs_count: pp.secondary.params.limbs_count,
                 }
                 .generate(),
             ],
@@ -400,6 +412,8 @@ where
                     z_0: &self.secondary.z_0,
                     z_i: &self.secondary.z_i,
                     relaxed: &self.primary.relaxed_trace.U,
+                    limb_width: pp.primary.params.limb_width,
+                    limbs_count: pp.primary.params.limbs_count,
                 }
                 .generate(),
                 RandomOracleComputationInstance::<'_, A2, C2, _, RP2::OffCircuit> {
@@ -412,6 +426,8 @@ where
                         .step_circuit
                         .process_step(&self.secondary.z_i, pp.secondary.k_table_size)?,
                     relaxed: &primary_new_trace.U,
+                    limb_width: pp.primary.params.limb_width,
+                    limbs_count: pp.primary.params.limbs_count,
                 }
                 .generate(),
             ],
@@ -468,6 +484,8 @@ where
             z_0: &self.primary.z_0,
             z_i: &self.primary.z_i,
             relaxed: &self.secondary.relaxed_trace.U,
+            limb_width: pp.primary.params.limb_width,
+            limbs_count: pp.primary.params.limbs_count
         }
         .generate::<C2::Scalar>();
 
@@ -485,6 +503,8 @@ where
             z_0: &self.secondary.z_0,
             z_i: &self.secondary.z_i,
             relaxed: &self.primary.relaxed_trace.U,
+            limb_width: pp.secondary.params.limb_width,
+            limbs_count: pp.secondary.params.limbs_count
         }
         .generate::<C1::Scalar>();
 

--- a/src/ivc/incrementally_verifiable_computation.rs
+++ b/src/ivc/incrementally_verifiable_computation.rs
@@ -172,7 +172,7 @@ where
         )?;
 
         primary_td.instance = vec![
-            RandomOracleComputationInstance::<'_, A1, C1, _, RP1::OffCircuit> {
+            RandomOracleComputationInstance::<'_, A1, C2, RP1::OffCircuit> {
                 random_oracle_constant: pp.primary.params.ro_constant.clone(),
                 public_params_hash: &primary_public_params_hash,
                 step: 0,
@@ -183,7 +183,7 @@ where
                 limbs_count: pp.primary.params.limbs_count,
             }
             .generate(),
-            RandomOracleComputationInstance::<'_, A1, C1, _, RP1::OffCircuit> {
+            RandomOracleComputationInstance::<'_, A1, C2, RP1::OffCircuit> {
                 random_oracle_constant: pp.primary.params.ro_constant.clone(),
                 public_params_hash: &primary_public_params_hash,
                 step: 1,
@@ -231,7 +231,7 @@ where
             vec![C1::identity(); primary_nifs_pp.S.get_degree_for_folding().saturating_sub(1)];
 
         secondary_td.instance = vec![
-            RandomOracleComputationInstance::<'_, A2, C2, _, RP2::OffCircuit> {
+            RandomOracleComputationInstance::<'_, A2, C1, RP2::OffCircuit> {
                 random_oracle_constant: pp.secondary.params.ro_constant.clone(),
                 public_params_hash: &secondary_public_params_hash,
                 step: 0,
@@ -242,7 +242,7 @@ where
                 limbs_count: pp.secondary.params.limbs_count,
             }
             .generate(),
-            RandomOracleComputationInstance::<'_, A2, C2, _, RP2::OffCircuit> {
+            RandomOracleComputationInstance::<'_, A2, C1, RP2::OffCircuit> {
                 random_oracle_constant: pp.secondary.params.ro_constant.clone(),
                 public_params_hash: &secondary_public_params_hash,
                 step: 1,
@@ -333,7 +333,7 @@ where
         let (mut primary_td, primary_step_config) = Self::prepare_primary_td::<T, RP1>(
             pp.primary.k_table_size,
             [
-                RandomOracleComputationInstance::<'_, A1, C1, _, RP1::OffCircuit> {
+                RandomOracleComputationInstance::<'_, A1, C2, RP1::OffCircuit> {
                     random_oracle_constant: pp.primary.params.ro_constant.clone(),
                     public_params_hash: &primary_public_params_hash,
                     step: self.step,
@@ -344,7 +344,7 @@ where
                     limbs_count: pp.secondary.params.limbs_count,
                 }
                 .generate(),
-                RandomOracleComputationInstance::<'_, A1, C1, _, RP1::OffCircuit> {
+                RandomOracleComputationInstance::<'_, A1, C2, RP1::OffCircuit> {
                     random_oracle_constant: pp.primary.params.ro_constant.clone(),
                     public_params_hash: &primary_public_params_hash,
                     step: self.step + 1,
@@ -410,7 +410,7 @@ where
         let (mut secondary_td, secondary_step_config) = Self::prepare_secondary_td::<T, RP2>(
             pp.secondary.k_table_size,
             [
-                RandomOracleComputationInstance::<'_, A2, C2, _, RP2::OffCircuit> {
+                RandomOracleComputationInstance::<'_, A2, C1, RP2::OffCircuit> {
                     random_oracle_constant: pp.secondary.params.ro_constant.clone(),
                     public_params_hash: &secondary_public_params_hash,
                     step: self.step,
@@ -421,7 +421,7 @@ where
                     limbs_count: pp.primary.params.limbs_count,
                 }
                 .generate(),
-                RandomOracleComputationInstance::<'_, A2, C2, _, RP2::OffCircuit> {
+                RandomOracleComputationInstance::<'_, A2, C1, RP2::OffCircuit> {
                     random_oracle_constant: pp.secondary.params.ro_constant.clone(),
                     public_params_hash: &secondary_public_params_hash,
                     step: self.step + 1,
@@ -482,7 +482,7 @@ where
         RP1: ROPair<C1::Scalar, Config = MainGateConfig<T>>,
         RP2: ROPair<C2::Scalar, Config = MainGateConfig<T>>,
     {
-        let expected_X0 = RandomOracleComputationInstance::<'_, A1, C1, _, RP1::OffCircuit> {
+        let expected_X0 = RandomOracleComputationInstance::<'_, A1, C2, RP1::OffCircuit> {
             random_oracle_constant: pp.primary.params.ro_constant.clone(),
             public_params_hash: &pp.digest().map_err(Error::WhileHash)?,
             step: self.step,
@@ -501,7 +501,7 @@ where
             }));
         }
 
-        let expected_X1 = RandomOracleComputationInstance::<'_, A2, C2, _, RP2::OffCircuit> {
+        let expected_X1 = RandomOracleComputationInstance::<'_, A2, C1, RP2::OffCircuit> {
             random_oracle_constant: pp.secondary.params.ro_constant.clone(),
             public_params_hash: &pp.digest().map_err(Error::WhileHash)?,
             step: self.step,

--- a/src/ivc/incrementally_verifiable_computation.rs
+++ b/src/ivc/incrementally_verifiable_computation.rs
@@ -195,6 +195,7 @@ where
             }
             .generate(),
         ];
+        debug!("Primary off circuit instance: {:?}", &primary_td.instance);
 
         let primary_z_output = StepFoldingCircuit::<'_, A1, C2, SC1, RP1::OnCircuit, T> {
             step_circuit: &primary,
@@ -253,6 +254,10 @@ where
             }
             .generate(),
         ];
+        debug!(
+            "Secondary off circuit instance: {:?}",
+            &secondary_td.instance
+        );
 
         let secondary_z_output = StepFoldingCircuit::<'_, A2, C1, SC2, RP2::OnCircuit, T> {
             step_circuit: &secondary,
@@ -485,7 +490,7 @@ where
             z_i: &self.primary.z_i,
             relaxed: &self.secondary.relaxed_trace.U,
             limb_width: pp.primary.params.limb_width,
-            limbs_count: pp.primary.params.limbs_count
+            limbs_count: pp.primary.params.limbs_count,
         }
         .generate::<C2::Scalar>();
 
@@ -504,7 +509,7 @@ where
             z_i: &self.secondary.z_i,
             relaxed: &self.primary.relaxed_trace.U,
             limb_width: pp.secondary.params.limb_width,
-            limbs_count: pp.secondary.params.limbs_count
+            limbs_count: pp.secondary.params.limbs_count,
         }
         .generate::<C1::Scalar>();
 

--- a/src/ivc/instance_computation.rs
+++ b/src/ivc/instance_computation.rs
@@ -88,3 +88,123 @@ where
         .unwrap()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroUsize;
+
+    use halo2_proofs::circuit::{floor_planner::single_pass::SingleChipLayouter, Layouter};
+    use halo2curves::{bn256, grumpkin};
+
+    type C1 = <bn256::G1 as halo2curves::group::prime::PrimeCurve>::Affine;
+    type C2 = <grumpkin::G1 as halo2curves::group::prime::PrimeCurve>::Affine;
+    type Base = <C1 as CurveAffine>::Base;
+    type Scalar = <C1 as CurveAffine>::ScalarExt;
+
+    use crate::{
+        ivc::fold_relaxed_plonk_instance_chip::{
+            assign_next_advice_from_point, FoldRelaxedPlonkInstanceChip,
+        },
+        main_gate::AdviceCyclicAssignor,
+        poseidon::{poseidon_circuit::PoseidonChip, PoseidonHash, Spec},
+        table::TableData,
+    };
+
+    use super::*;
+
+    #[test_log::test]
+    fn consistency() {
+        let random_oracle_constant = Spec::<Base, 10, 9>::new(10, 10);
+
+        let public_params_hash = C1::random(&mut rand::thread_rng());
+
+        let step = 0x128;
+        let z_0 = [Base::from_u128(0x1024); 10];
+        let z_i = [Base::from_u128(0x2048); 10];
+        let relaxed = RelaxedPlonkInstance::new(2, 10, 10);
+
+        let off_circuit_hash: Base = RandomOracleComputationInstance::<
+            '_,
+            10,
+            C2,
+            C1,
+            PoseidonHash<<C1 as CurveAffine>::Base, 10, 9>,
+        > {
+            random_oracle_constant: random_oracle_constant.clone(),
+            public_params_hash: &public_params_hash,
+            step,
+            z_0: &z_0,
+            z_i: &z_i,
+            relaxed: &relaxed,
+        }
+        .generate();
+
+        let mut td = TableData::new(15, vec![]);
+
+        let config = td.prepare_assembly(|cs| -> MainGateConfig<10> { MainGate::configure(cs) });
+
+        let on_circuit_hash = SingleChipLayouter::<'_, Base, _>::new(&mut td, vec![])
+            .unwrap()
+            .assign_region(
+                || "test",
+                |region| {
+                    let mut ctx = RegionCtx::new(region, 0);
+
+                    let mut advice_columns_assigner = config.advice_cycle_assigner();
+
+                    let public_params_hash = assign_next_advice_from_point(
+                        &mut advice_columns_assigner,
+                        &mut ctx,
+                        &public_params_hash,
+                        || "public_params",
+                    )
+                    .unwrap();
+
+                    let step = advice_columns_assigner
+                        .assign_next_advice(&mut ctx, || "step", Base::from_u128(step as u128))
+                        .unwrap();
+
+                    let assigned_z_0 = advice_columns_assigner
+                        .assign_all_advice(&mut ctx, || "z0", z_0.iter().copied())
+                        .map(|inp| inp.try_into().unwrap())
+                        .unwrap();
+
+                    let assigned_z_i = advice_columns_assigner
+                        .assign_all_advice(&mut ctx, || "zi", z_i.iter().copied())
+                        .map(|inp| inp.try_into().unwrap())
+                        .unwrap();
+
+                    let assigned_relaxed = FoldRelaxedPlonkInstanceChip::new(
+                        relaxed.clone(),
+                        NonZeroUsize::new(10).unwrap(),
+                        NonZeroUsize::new(10).unwrap(),
+                        config.clone(),
+                    )
+                    .assign_current_relaxed(&mut ctx)
+                    .unwrap();
+
+                    AssignedRandomOracleComputationInstance::<
+                            PoseidonChip<Base, 10, 9>,
+                            10,
+                            10,
+                            C1,
+                        > {
+                            random_oracle_constant: random_oracle_constant.clone(),
+                            public_params_hash: &public_params_hash,
+                            step: &step,
+                            z_0: &assigned_z_0,
+                            z_i: &assigned_z_i,
+                            relaxed: &assigned_relaxed,
+                        }
+                        .generate(&mut ctx, config.clone())
+                },
+            )
+            .unwrap()
+            .value()
+            .unwrap()
+            .copied()
+            .unwrap();
+
+        assert_eq!(on_circuit_hash, off_circuit_hash);
+    }
+}

--- a/src/ivc/instance_computation.rs
+++ b/src/ivc/instance_computation.rs
@@ -1,3 +1,4 @@
+/// Module name acronym `instance_computation` -> `icomp`
 use std::num::NonZeroUsize;
 
 use ff::{FromUniformBytes, PrimeField, PrimeFieldBits};

--- a/src/ivc/step_folding_circuit.rs
+++ b/src/ivc/step_folding_circuit.rs
@@ -8,6 +8,7 @@ use halo2_proofs::{
 };
 use halo2curves::CurveAffine;
 use itertools::Itertools;
+use log::*;
 use serde::Serialize;
 
 use crate::{
@@ -250,12 +251,16 @@ where
                     public_params_hash: &w.public_params_hash,
                     step: &assigned_step,
                     z_0: &assigned_z_0,
-                    z_i: &assigned_z_0,
+                    z_i: assigned_z_i,
                     relaxed: &w.assigned_relaxed,
                 }
                 .generate(&mut ctx, config.main_gate_config.clone())?;
 
+                debug!("expected X0: {expected_X0:?}");
+
                 ctx.constrain_equal(expected_X0.cell(), w.input_instance[0].0.cell())?;
+
+                debug!("input instance 0: {:?}", w.input_instance[0].0);
 
                 Ok(())
             },
@@ -323,6 +328,8 @@ where
                 )
             },
         )?;
+
+        debug!("output instance 0: {:?}", output_hash);
 
         // Check that old_X1 == new_X0
         layouter.constrain_instance(

--- a/src/poseidon/poseidon_circuit.rs
+++ b/src/poseidon/poseidon_circuit.rs
@@ -44,6 +44,17 @@ impl<F: PrimeFieldBits + FromUniformBytes<64>, const T: usize, const RATE: usize
         self.update(&point)
     }
 
+    fn inspect(&self, scan: impl Fn(&[F])) {
+        if let Some(buf) = self
+            .buf
+            .iter()
+            .map(|b| *b.value().unwrap())
+            .collect::<Option<Vec<_>>>()
+        {
+            scan(&buf)
+        }
+    }
+
     fn squeeze_n_bits(
         &mut self,
         ctx: &mut RegionCtx<'_, F>,

--- a/src/poseidon/poseidon_hash.rs
+++ b/src/poseidon/poseidon_hash.rs
@@ -165,7 +165,8 @@ where
 
     fn output<C: CurveAffine<Base = F>>(&mut self, num_bits: NonZeroUsize) -> C::Scalar {
         let buf = mem::take(&mut self.buf);
-        debug!("OFF_CIRCUIT_INPUT_OF_HASH: {buf:?}");
+        debug!("Off circuit input of hash: {buf:?}");
+
         let exact = buf.len() % RATE == 0;
 
         for chunk in buf.chunks(RATE) {

--- a/src/poseidon/poseidon_hash.rs
+++ b/src/poseidon/poseidon_hash.rs
@@ -140,6 +140,10 @@ where
         self
     }
 
+    fn inspect(&self, inspect: impl Fn(&[F])) {
+        inspect(&self.buf)
+    }
+
     fn squeeze<C: CurveAffine<Base = F>>(&mut self, num_bits: NonZeroUsize) -> C::Scalar {
         self.output::<C>(num_bits)
     }

--- a/src/poseidon/random_oracle.rs
+++ b/src/poseidon/random_oracle.rs
@@ -57,6 +57,8 @@ pub trait ROTrait<F: PrimeField> {
         self
     }
 
+    fn inspect(&self, scan: impl Fn(&[F]));
+
     /// Returns a challenge by hashing the internal state
     fn squeeze<C: CurveAffine<Base = F>>(&mut self, num_bits: NonZeroUsize) -> C::Scalar;
 }
@@ -93,6 +95,8 @@ pub trait ROCircuitTrait<F: PrimeFieldBits + FromUniformBytes<64>> {
         });
         self
     }
+
+    fn inspect(&self, scan: impl Fn(&[F]));
 
     /// Returns a challenge of `num_bits` by hashing the internal state
     fn squeeze_n_bits(


### PR DESCRIPTION
**Issue Link / Motivation**
During the computation in circuit relaxed plonk instance, the instance & challenge fields were submitted to a set of limbs. Whereas for off-circuit were represented as field elements. This led to non-consistent values X0 & X1

**Changes Overview**
To avoid the extra cost of on-circuit calculations, an off-circuit decomposition of these fields into limbs was added

**Test**
Unit-test for {on,off}-circuit consistency was added