### PR TITLE
feat(icomp): `generate_with_inspect`

### DIFF
--- a/src/ivc/incrementally_verifiable_computation.rs
+++ b/src/ivc/incrementally_verifiable_computation.rs
@@ -182,7 +182,7 @@ where
                 limb_width: pp.primary.params.limb_width,
                 limbs_count: pp.primary.params.limbs_count,
             }
-            .generate(),
+            .generate_with_inspect(|buf| debug!("primary X0 zero-step: {buf:?}")),
             RandomOracleComputationInstance::<'_, A1, C2, RP1::OffCircuit> {
                 random_oracle_constant: pp.primary.params.ro_constant.clone(),
                 public_params_hash: &primary_public_params_hash,
@@ -193,7 +193,7 @@ where
                 limb_width: pp.primary.params.limb_width,
                 limbs_count: pp.primary.params.limbs_count,
             }
-            .generate(),
+            .generate_with_inspect(|buf| debug!("primary X1 zero-step: {buf:?}")),
         ];
         debug!("Primary off circuit instance: {:?}", &primary_td.instance);
 
@@ -241,7 +241,7 @@ where
                 limb_width: pp.secondary.params.limb_width,
                 limbs_count: pp.secondary.params.limbs_count,
             }
-            .generate(),
+            .generate_with_inspect(|buf| debug!("secondary X0 zero-step: {buf:?}")),
             RandomOracleComputationInstance::<'_, A2, C1, RP2::OffCircuit> {
                 random_oracle_constant: pp.secondary.params.ro_constant.clone(),
                 public_params_hash: &secondary_public_params_hash,
@@ -252,7 +252,7 @@ where
                 limb_width: pp.secondary.params.limb_width,
                 limbs_count: pp.secondary.params.limbs_count,
             }
-            .generate(),
+            .generate_with_inspect(|buf| debug!("secondary X1 zero-step: {buf:?}")),
         ];
         debug!(
             "Secondary off circuit instance: {:?}",

--- a/src/ivc/step_folding_circuit.rs
+++ b/src/ivc/step_folding_circuit.rs
@@ -254,7 +254,11 @@ where
                     z_i: assigned_z_i,
                     relaxed: &w.assigned_relaxed,
                 }
-                .generate(&mut ctx, config.main_gate_config.clone())?;
+                .generate_with_inspect(
+                    &mut ctx,
+                    config.main_gate_config.clone(),
+                    |buf| debug!("expected X0 {buf:?}"),
+                )?;
 
                 debug!("expected X0: {expected_X0:?}");
 
@@ -322,9 +326,10 @@ where
                     z_i: &z_output,
                     relaxed: &assigned_new_U,
                 }
-                .generate(
+                .generate_with_inspect(
                     &mut RegionCtx::new(region, 0),
                     config.main_gate_config.clone(),
+                    |buf| debug!("new X0 {buf:?}"),
                 )
             },
         )?;

--- a/src/poseidon/poseidon_circuit.rs
+++ b/src/poseidon/poseidon_circuit.rs
@@ -44,7 +44,7 @@ impl<F: PrimeFieldBits + FromUniformBytes<64>, const T: usize, const RATE: usize
         self.update(&point)
     }
 
-    fn inspect(&self, scan: impl Fn(&[F])) {
+    fn inspect(&mut self, scan: impl FnOnce(&[F])) -> &mut Self {
         if let Some(buf) = self
             .buf
             .iter()
@@ -53,6 +53,7 @@ impl<F: PrimeFieldBits + FromUniformBytes<64>, const T: usize, const RATE: usize
         {
             scan(&buf)
         }
+        self
     }
 
     fn squeeze_n_bits(

--- a/src/poseidon/poseidon_hash.rs
+++ b/src/poseidon/poseidon_hash.rs
@@ -140,8 +140,9 @@ where
         self
     }
 
-    fn inspect(&self, inspect: impl Fn(&[F])) {
-        inspect(&self.buf)
+    fn inspect(&mut self, inspect: impl FnOnce(&[F])) -> &mut Self {
+        inspect(&self.buf);
+        self
     }
 
     fn squeeze<C: CurveAffine<Base = F>>(&mut self, num_bits: NonZeroUsize) -> C::Scalar {

--- a/src/poseidon/random_oracle.rs
+++ b/src/poseidon/random_oracle.rs
@@ -57,7 +57,7 @@ pub trait ROTrait<F: PrimeField> {
         self
     }
 
-    fn inspect(&self, scan: impl Fn(&[F]));
+    fn inspect(&mut self, scan: impl FnOnce(&[F])) -> &mut Self;
 
     /// Returns a challenge by hashing the internal state
     fn squeeze<C: CurveAffine<Base = F>>(&mut self, num_bits: NonZeroUsize) -> C::Scalar;
@@ -96,7 +96,7 @@ pub trait ROCircuitTrait<F: PrimeFieldBits + FromUniformBytes<64>> {
         self
     }
 
-    fn inspect(&self, scan: impl Fn(&[F]));
+    fn inspect(&mut self, scan: impl FnOnce(&[F])) -> &mut Self;
 
     /// Returns a challenge of `num_bits` by hashing the internal state
     fn squeeze_n_bits(


### PR DESCRIPTION
**Motivation**
One of the main calls for debugging {on,off}-circuit compatibility is to check that the ro inputs are the same. It is convenient to debug this via logs, to make it systematic this method is added.

**Overview**
- change {RO,ROCircuit} traits method `inspect`
- add `generate_with_inspect` methods for instance computation helpers
