### PR TITLE
fix(bn): pass m_bn as value

### DIFF
--- a/examples/sha256/main.rs
+++ b/examples/sha256/main.rs
@@ -314,12 +314,12 @@ impl<F: PrimeField> StepCircuit<ARITY, F> for TestSha256Circuit<F> {
             .map(|value| BlockWord(Value::known(value)))
             .collect::<Box<[BlockWord]>>();
 
-        Ok(Sha256::digest_cells(
+        Sha256::digest_cells(
             table16_chip,
             layouter.namespace(|| "'abc' * 2"),
             values.as_ref(),
             &input,
-        )?)
+        )
     }
 }
 

--- a/src/gadgets/nonnative/bn/big_uint_mul_mod_chip/tests.rs
+++ b/src/gadgets/nonnative/bn/big_uint_mul_mod_chip/tests.rs
@@ -132,6 +132,9 @@ mod mult_mod_tests {
                                 res
                             }));
 
+                        let module = BigUint::from_assigned_cells(&module, LIMB_WIDTH, LIMBS_COUNT)
+                            .unwrap()
+                            .unwrap_or(BigUint::from_u64(0, LIMB_WIDTH, LIMBS_COUNT).unwrap());
                         let ModOperationResult {
                             quotient,
                             remainder,
@@ -709,6 +712,9 @@ mod red_mod_tests {
                                 res
                             }));
 
+                        let module = BigUint::from_assigned_cells(&module, LIMB_WIDTH, LIMBS_COUNT)
+                            .unwrap()
+                            .unwrap_or(BigUint::from_u64(0, LIMB_WIDTH, LIMBS_COUNT).unwrap());
                         let ModOperationResult {
                             quotient,
                             remainder,

--- a/src/ivc/fold_relaxed_plonk_instance_chip.rs
+++ b/src/ivc/fold_relaxed_plonk_instance_chip.rs
@@ -975,17 +975,9 @@ fn scalar_module_as_limbs<C: CurveAffine>(
     limb_width: NonZeroUsize,
     limbs_count: NonZeroUsize,
 ) -> Result<Vec<C::Base>, big_uint::Error> {
-    Ok(BigUint::<C::Base>::from_biguint(
-        &num_bigint::BigUint::from_str_radix(
-            <C::Scalar as PrimeField>::MODULUS.trim_start_matches("0x"),
-            16,
-        )
-        .unwrap(),
-        limb_width,
-        limbs_count,
-    )?
-    .limbs()
-    .to_vec())
+    Ok(scalar_module_as_bn::<C>(limb_width, limbs_count)?
+        .limbs()
+        .to_vec())
 }
 
 pub(crate) fn assign_next_advice_from_point<C: CurveAffine, AR: Into<String>>(
@@ -1037,7 +1029,6 @@ mod tests {
     use crate::{
         commitment::CommitmentKey,
         constants::MAX_BITS,
-        main_gate::FixedCyclicAssignor,
         nifs::vanilla::VanillaFS,
         poseidon::{poseidon_circuit::PoseidonChip, PoseidonHash, ROTrait, Spec},
         table::WitnessData,
@@ -1340,13 +1331,6 @@ mod tests {
                         as_bits: r,
                     };
 
-                    config.fixed_cycle_assigner().assign_all_fixed(
-                        &mut ctx,
-                        || "m_bn",
-                        scalar_module_as_limbs::<C1>(LIMB_WIDTH, LIMBS_COUNT)
-                            .unwrap()
-                            .into_iter(),
-                    )?;
                     let m_bn = scalar_module_as_bn::<C1>(LIMB_WIDTH, LIMBS_COUNT).unwrap();
 
                     Ok(chip
@@ -1458,13 +1442,6 @@ mod tests {
                         .try_into()
                         .unwrap();
 
-                    config.fixed_cycle_assigner().assign_all_fixed(
-                        &mut ctx,
-                        || "m_bn",
-                        scalar_module_as_limbs::<C1>(LIMB_WIDTH, LIMBS_COUNT)
-                            .unwrap()
-                            .into_iter(),
-                    )?;
                     let m_bn = scalar_module_as_bn::<C1>(LIMB_WIDTH, LIMBS_COUNT).unwrap();
 
                     ctx.next();
@@ -1600,14 +1577,6 @@ mod tests {
                         .iter()
                         .map(|instance| assign_scalar_as_bn!(&mut ctx, instance, "input instance"))
                         .collect::<Result<Vec<_>, _>>()?;
-
-                    config.fixed_cycle_assigner().assign_all_fixed(
-                        &mut ctx,
-                        || "m_bn",
-                        scalar_module_as_limbs::<C1>(LIMB_WIDTH, LIMBS_COUNT)
-                            .unwrap()
-                            .into_iter(),
-                    )?;
 
                     ctx.next();
 


### PR DESCRIPTION
**Issue Link / Motivation**
<!-- Link to the related issue(s). If there's no issue, briefly explain the need for this change. -->
After separation of data collections in TableData, the witness data is collected without the need of fixed data collection. This makes some part of the bn chip method error because we cannot rely on the return value of `assign_fixed` method. It will be None. Instead, we directly pass the input of `assign_fixed` instead of return of `assign_fixed`.

**Changes Overview**
Before fix: `m_bn` is assigned as fixed values, then we pass `m_bn` as AssignedCells into other functions. Inside other function call, we just need `m_bn` value from the AssignedCell without copy constraint.

After fix: Pass `m_bn` as BigUint instead of AssignedCell.
