### PR TITLE
feat(pp): add cache for pp

### DIFF
--- a/examples/sha256/main.rs
+++ b/examples/sha256/main.rs
@@ -395,16 +395,16 @@ fn main() {
         RandomOracle,
         RandomOracle,
     >::new(
-        CircuitPublicParamsInput {
-            k_table_size: CIRCUIT_TABLE_SIZE1 as u32,
-            commitment_key: &primary_commitment_key,
-            ro_constant: primary_spec,
-        },
-        CircuitPublicParamsInput {
-            k_table_size: CIRCUIT_TABLE_SIZE2 as u32,
-            commitment_key: &secondary_commitment_key,
-            ro_constant: secondary_spec,
-        },
+        CircuitPublicParamsInput::new(
+            CIRCUIT_TABLE_SIZE1 as u32,
+            &primary_commitment_key,
+            primary_spec,
+        ),
+        CircuitPublicParamsInput::new(
+            CIRCUIT_TABLE_SIZE2 as u32,
+            &secondary_commitment_key,
+            secondary_spec,
+        ),
         LIMB_WIDTH,
         LIMBS_COUNT,
     )

--- a/examples/trivial/main.rs
+++ b/examples/trivial/main.rs
@@ -91,16 +91,16 @@ fn main() {
         RandomOracle,
         RandomOracle,
     >::new(
-        CircuitPublicParamsInput {
-            k_table_size: CIRCUIT_TABLE_SIZE1 as u32,
-            commitment_key: &primary_commitment_key,
-            ro_constant: primary_spec,
-        },
-        CircuitPublicParamsInput {
-            k_table_size: CIRCUIT_TABLE_SIZE2 as u32,
-            commitment_key: &secondary_commitment_key,
-            ro_constant: secondary_spec,
-        },
+        CircuitPublicParamsInput::new(
+            CIRCUIT_TABLE_SIZE1 as u32,
+            &primary_commitment_key,
+            primary_spec,
+        ),
+        CircuitPublicParamsInput::new(
+            CIRCUIT_TABLE_SIZE2 as u32,
+            &secondary_commitment_key,
+            secondary_spec,
+        ),
         LIMB_WIDTH,
         LIMBS_COUNT_LIMIT,
     )

--- a/src/ivc/step_folding_circuit.rs
+++ b/src/ivc/step_folding_circuit.rs
@@ -32,9 +32,33 @@ where
     F: PrimeFieldBits + FromUniformBytes<64>,
     RO: ROCircuitTrait<F>,
 {
-    pub limb_width: NonZeroUsize,
-    pub limbs_count: NonZeroUsize,
-    pub ro_constant: RO::Args,
+    limb_width: NonZeroUsize,
+    limbs_count: NonZeroUsize,
+    ro_constant: RO::Args,
+}
+
+impl<F, RO> StepParams<F, RO>
+where
+    F: PrimeFieldBits + FromUniformBytes<64>,
+    RO: ROCircuitTrait<F>,
+{
+    pub fn new(limb_width: NonZeroUsize, limbs_count: NonZeroUsize, ro_constant: RO::Args) -> Self {
+        Self {
+            limb_width,
+            limbs_count,
+            ro_constant,
+        }
+    }
+
+    pub fn limb_width(&self) -> NonZeroUsize {
+        self.limb_width
+    }
+    pub fn limbs_count(&self) -> NonZeroUsize {
+        self.limbs_count
+    }
+    pub fn ro_constant(&self) -> &RO::Args {
+        &self.ro_constant
+    }
 }
 
 impl<F, RO> fmt::Debug for StepParams<F, RO>


### PR DESCRIPTION
**Motivation**
In the IVC process, two digests are counted each time step, so it is logical to store them in the cache-fields

Taked from #170 & improved

**Overview**
- store digest into cash-fields with type `OnceCell`
- Since it is now possible that public params can change and their cache not, we add measures to protect against such a scenario by making all fields private. This way no one can change public params & invalidate cash.
