### PR TITLE
feat(ivc): `debug_mode`

### DIFF
--- a/examples/sha256/main.rs
+++ b/examples/sha256/main.rs
@@ -410,7 +410,7 @@ fn main() {
     .unwrap();
     info!("public params: {pp:?}");
 
-    IVC::fold(
+    IVC::fold_with_debug_mode(
         &pp,
         sc1,
         array::from_fn(|i| C1Scalar::from_u128(i as u128)),

--- a/examples/trivial/main.rs
+++ b/examples/trivial/main.rs
@@ -110,13 +110,13 @@ fn main() {
     info!("public params: {pp:?}");
 
     debug!("start ivc");
-    IVC::fold(
+    IVC::fold_with_debug_mode(
         &pp,
         sc1,
         array::from_fn(|i| C1Scalar::from_u128(i as u128)),
         sc2,
         array::from_fn(|i| C2Scalar::from_u128(i as u128)),
-        NonZeroUsize::new(1).unwrap(),
+        NonZeroUsize::new(5).unwrap(),
     )
     .unwrap();
 }

--- a/src/ivc/incrementally_verifiable_computation.rs
+++ b/src/ivc/incrementally_verifiable_computation.rs
@@ -60,11 +60,19 @@ pub enum Error {
 }
 
 impl Error {
-    fn from_mock_verify(errors: Vec<halo2_proofs::dev::VerifyFailure>, is_primary: bool) -> Self {
+    fn from_mock_verify(
+        errors: Vec<halo2_proofs::dev::VerifyFailure>,
+        is_primary: bool,
+        step: usize,
+    ) -> Self {
         Self::VerifyFailed(
             errors
                 .into_iter()
-                .map(|err| VerificationError::MockRunFailed { err, is_primary })
+                .map(|err| VerificationError::MockRunFailed {
+                    err,
+                    is_primary,
+                    step,
+                })
                 .collect(),
         )
     }
@@ -84,6 +92,7 @@ pub enum VerificationError {
     MockRunFailed {
         err: halo2_proofs::dev::VerifyFailure,
         is_primary: bool,
+        step: usize,
     },
 }
 
@@ -235,7 +244,7 @@ where
                 vec![primary_instance.to_vec()],
             )?
             .verify()
-            .map_err(|err| Error::from_mock_verify(err, true))?;
+            .map_err(|err| Error::from_mock_verify(err, true, 0))?;
         }
 
         let primary_witness = CircuitRunner::new(
@@ -306,7 +315,7 @@ where
                 vec![secondary_instance.to_vec()],
             )?
             .verify()
-            .map_err(|err| Error::from_mock_verify(err, false))?;
+            .map_err(|err| Error::from_mock_verify(err, false, 0))?;
         }
 
         let secondary_witness = CircuitRunner::new(
@@ -411,7 +420,7 @@ where
                 vec![primary_instance.to_vec()],
             )?
             .verify()
-            .map_err(|err| Error::from_mock_verify(err, true))?;
+            .map_err(|err| Error::from_mock_verify(err, true, self.step))?;
         }
 
         let primary_witness = CircuitRunner::new(
@@ -485,7 +494,7 @@ where
                 vec![secondary_instance.to_vec()],
             )?
             .verify()
-            .map_err(|err| Error::from_mock_verify(err, false))?;
+            .map_err(|err| Error::from_mock_verify(err, false, self.step))?;
         }
 
         let secondary_witness = CircuitRunner::new(


### PR DESCRIPTION
**Motivation**
Our current constraint system used for folding is extremely poor at describing which constraints did not converge. Therefore, when developing and adapting new step-circuits, we will definitely face the problem of debugging. Moreover, both bugs and new features are possible within our folding, which will also require debugging information.

That's why I suggest optional use of `MockProver` within a separate method (with bool flag in main methods). This would not slow down the basic IVC use case, however, such as using it as part of tests.

**Overview**
Just one bool-flag with one separate pub method specially for debug.
