### PR TITLE
fix(ivc): add permutation check

### DIFF
--- a/examples/trivial/main.rs
+++ b/examples/trivial/main.rs
@@ -21,7 +21,7 @@ const ARITY: usize = BLOCK_SIZE / 2;
 
 const CIRCUIT_TABLE_SIZE1: usize = 16;
 const CIRCUIT_TABLE_SIZE2: usize = 16;
-const COMMITMENT_KEY_SIZE: usize = 25;
+const COMMITMENT_KEY_SIZE: usize = 19;
 const T: usize = 5;
 const RATE: usize = 4;
 

--- a/src/ivc/incrementally_verifiable_computation.rs
+++ b/src/ivc/incrementally_verifiable_computation.rs
@@ -609,6 +609,28 @@ where
             })
         }
 
+        if let Err(err) = pp.primary.S().is_sat_perm(
+            &self.primary.relaxed_trace.U,
+            &self.primary.relaxed_trace.W,
+        ) {
+            errors.push(VerificationError::NotSat {
+                err,
+                is_primary: false,
+                is_relaxed: true,
+            })
+        }
+
+        if let Err(err) = pp.secondary.S().is_sat_perm(
+            &self.secondary.relaxed_trace.U,
+            &self.secondary.relaxed_trace.W,
+        ) {
+            errors.push(VerificationError::NotSat {
+                err,
+                is_primary: false,
+                is_relaxed: true,
+            })
+        }
+
         if errors.is_empty() {
             Ok(())
         } else {

--- a/src/nifs/tests.rs
+++ b/src/nifs/tests.rs
@@ -67,6 +67,8 @@ where
             .err(),
         None
     );
+    let pair1_relaxed = pair1.to_relax(S.k);
+    assert_eq!(S.is_sat_perm(&pair1_relaxed.U, &pair1_relaxed.W).err(), None);
     let pair2 =
         VanillaFS::generate_plonk_trace(&ck, &public_inputs2, &W2, &pp, &mut ro_nark_prepare)?;
     assert_eq!(
@@ -74,6 +76,8 @@ where
             .err(),
         None
     );
+    let pair2_relaxed = pair2.to_relax(S.k);
+    assert_eq!(S.is_sat_perm(&pair2_relaxed.U, &pair2_relaxed.W).err(), None);
 
     Ok((ck, S, pair1, pair2))
 }


### PR DESCRIPTION
Add permutation checks in both `ivc.verify` and `test_nifs`, which is necessary for soundness of the folding scheme.