### PR TITLE
fix(pp): without witness

### DIFF
--- a/src/ivc/incrementally_verifiable_computation.rs
+++ b/src/ivc/incrementally_verifiable_computation.rs
@@ -609,10 +609,11 @@ where
             })
         }
 
-        if let Err(err) = pp.primary.S().is_sat_perm(
-            &self.primary.relaxed_trace.U,
-            &self.primary.relaxed_trace.W,
-        ) {
+        if let Err(err) = pp
+            .primary
+            .S()
+            .is_sat_perm(&self.primary.relaxed_trace.U, &self.primary.relaxed_trace.W)
+        {
             errors.push(VerificationError::NotSat {
                 err,
                 is_primary: false,

--- a/src/ivc/public_params.rs
+++ b/src/ivc/public_params.rs
@@ -255,7 +255,7 @@ where
         .try_collect_plonk_structure()?;
 
         let secondary_S = CircuitRunner::new(
-            primary.k_table_size,
+            secondary.k_table_size,
             StepFoldingCircuit::<'_, A2, C1, SC2, RP2::OnCircuit, MAIN_GATE_T> {
                 step_circuit: secondary.step_circuit,
                 input: StepInputs::without_witness::<A1, SC1>(

--- a/src/ivc/public_params.rs
+++ b/src/ivc/public_params.rs
@@ -244,7 +244,7 @@ where
             primary.k_table_size,
             StepFoldingCircuit::<'_, A1, C2, SC1, RP1::OnCircuit, MAIN_GATE_T> {
                 step_circuit: primary.step_circuit,
-                input: StepInputs::without_witness::<SC1>(
+                input: StepInputs::without_witness::<A2, SC2>(
                     primary.k_table_size,
                     NUM_IO,
                     &StepParams::new(limb_width, limbs_count, primary.ro_constant.clone()),
@@ -258,7 +258,7 @@ where
             primary.k_table_size,
             StepFoldingCircuit::<'_, A2, C1, SC2, RP2::OnCircuit, MAIN_GATE_T> {
                 step_circuit: secondary.step_circuit,
-                input: StepInputs::without_witness::<SC2>(
+                input: StepInputs::without_witness::<A1, SC1>(
                     secondary.k_table_size,
                     NUM_IO,
                     &StepParams::new(limb_width, limbs_count, secondary.ro_constant.clone()),

--- a/src/ivc/step_folding_circuit.rs
+++ b/src/ivc/step_folding_circuit.rs
@@ -106,12 +106,12 @@ where
     C: CurveAffine,
     RO: ROCircuitTrait<C::Base>,
 {
-    pub fn without_witness<SC: StepCircuit<ARITY, C::Base>>(
+    pub fn without_witness<const A2: usize, SC: StepCircuit<A2, C::Scalar>>(
         k_table_size: u32,
         num_io: usize,
         step_pp: &'link StepParams<C::Base, RO>,
     ) -> Self {
-        let mut cs = ConstraintSystem::<C::Base>::default();
+        let mut cs = ConstraintSystem::<C::Scalar>::default();
         SC::configure(&mut cs);
         let ConstraintSystemMetainfo {
             num_challenges,

--- a/src/nifs/tests.rs
+++ b/src/nifs/tests.rs
@@ -68,7 +68,10 @@ where
         None
     );
     let pair1_relaxed = pair1.to_relax(S.k);
-    assert_eq!(S.is_sat_perm(&pair1_relaxed.U, &pair1_relaxed.W).err(), None);
+    assert_eq!(
+        S.is_sat_perm(&pair1_relaxed.U, &pair1_relaxed.W).err(),
+        None
+    );
     let pair2 =
         VanillaFS::generate_plonk_trace(&ck, &public_inputs2, &W2, &pp, &mut ro_nark_prepare)?;
     assert_eq!(
@@ -77,7 +80,10 @@ where
         None
     );
     let pair2_relaxed = pair2.to_relax(S.k);
-    assert_eq!(S.is_sat_perm(&pair2_relaxed.U, &pair2_relaxed.W).err(), None);
+    assert_eq!(
+        S.is_sat_perm(&pair2_relaxed.U, &pair2_relaxed.W).err(),
+        None
+    );
 
     Ok((ck, S, pair1, pair2))
 }


### PR DESCRIPTION
**Motivation**
When creating a circuit we have to take `U` & `u` from another circuit,
not the one being formed, so now there is an error here and the
`without_witness` function is not working as expected

**Overview**
- It's simple to pass the correct generic inside
- cargo-fmt (I didn't understand how the problem got in master, but I fixed it)