### PR TITLE
fix(pp): using sfc instead of sc for pre-config

### DIFF
--- a/src/ivc/public_params.rs
+++ b/src/ivc/public_params.rs
@@ -396,13 +396,13 @@ mod pp_test {
             CircuitPublicParamsInput {
                 step_circuit: &trivial::Circuit::default(),
                 k_table_size: K as u32,
-                commitment_key: &CommitmentKey::setup(K + 1, b"1"),
+                commitment_key: &CommitmentKey::setup(K, b"1"),
                 ro_constant: spec1,
             },
             CircuitPublicParamsInput {
                 step_circuit: &trivial::Circuit::default(),
                 k_table_size: K as u32,
-                commitment_key: &CommitmentKey::setup(K + 1, b"2"),
+                commitment_key: &CommitmentKey::setup(K, b"2"),
                 ro_constant: spec2,
             },
             LIMB_WIDTH,

--- a/src/ivc/public_params.rs
+++ b/src/ivc/public_params.rs
@@ -244,13 +244,15 @@ where
             primary.k_table_size,
             StepFoldingCircuit::<'_, A1, C2, SC1, RP1::OnCircuit, MAIN_GATE_T> {
                 step_circuit: primary.step_circuit,
-                input: StepInputs::without_witness::<A2, SC2>(
+                input: StepInputs::without_witness::<
+                    StepFoldingCircuit<'_, A2, C1, SC2, RP2::OnCircuit, MAIN_GATE_T>,
+                >(
                     primary.k_table_size,
                     NUM_IO,
                     &StepParams::new(limb_width, limbs_count, primary.ro_constant.clone()),
                 ),
             },
-            vec![C1::Scalar::ZERO, C1::Scalar::ZERO],
+            vec![C1::Scalar::ZERO; NUM_IO],
         )
         .try_collect_plonk_structure()?;
 
@@ -258,13 +260,15 @@ where
             secondary.k_table_size,
             StepFoldingCircuit::<'_, A2, C1, SC2, RP2::OnCircuit, MAIN_GATE_T> {
                 step_circuit: secondary.step_circuit,
-                input: StepInputs::without_witness::<A1, SC1>(
+                input: StepInputs::without_witness::<
+                    StepFoldingCircuit<'_, A1, C2, SC1, RP1::OnCircuit, MAIN_GATE_T>,
+                >(
                     secondary.k_table_size,
                     NUM_IO,
                     &StepParams::new(limb_width, limbs_count, secondary.ro_constant.clone()),
                 ),
             },
-            vec![C2::Scalar::ZERO, C2::Scalar::ZERO],
+            vec![C2::Scalar::ZERO; NUM_IO],
         )
         .try_collect_plonk_structure()?;
 
@@ -375,7 +379,7 @@ mod pp_test {
         let spec1 = RandomOracleConstant::<5, 4, Scalar1>::new(10, 10);
         let spec2 = RandomOracleConstant::<5, 4, Scalar2>::new(10, 10);
 
-        const K: usize = 15;
+        const K: usize = 16;
 
         PublicParams::<
             '_,
@@ -392,13 +396,13 @@ mod pp_test {
             CircuitPublicParamsInput {
                 step_circuit: &trivial::Circuit::default(),
                 k_table_size: K as u32,
-                commitment_key: &CommitmentKey::setup(K, b"1"),
+                commitment_key: &CommitmentKey::setup(K + 1, b"1"),
                 ro_constant: spec1,
             },
             CircuitPublicParamsInput {
                 step_circuit: &trivial::Circuit::default(),
                 k_table_size: K as u32,
-                commitment_key: &CommitmentKey::setup(K, b"2"),
+                commitment_key: &CommitmentKey::setup(K + 1, b"2"),
                 ro_constant: spec2,
             },
             LIMB_WIDTH,

--- a/src/ivc/step_folding_circuit.rs
+++ b/src/ivc/step_folding_circuit.rs
@@ -106,13 +106,15 @@ where
     C: CurveAffine,
     RO: ROCircuitTrait<C::Base>,
 {
-    pub fn without_witness<const A2: usize, SC: StepCircuit<A2, C::Scalar>>(
+    pub fn without_witness<PairedCircuit: Circuit<C::Scalar>>(
         k_table_size: u32,
         num_io: usize,
         step_pp: &'link StepParams<C::Base, RO>,
     ) -> Self {
         let mut cs = ConstraintSystem::<C::Scalar>::default();
-        SC::configure(&mut cs);
+
+        PairedCircuit::configure(&mut cs);
+
         let ConstraintSystemMetainfo {
             num_challenges,
             round_sizes,


### PR DESCRIPTION
**Motivation**
The IVC framework used `StepFoldingCircuit` but the `PublicParams` generation step used only `StepCircuit` itself, this error resulted in a non-consistent PlonkStructure (`S`)

Part of #192 (only one error left at the end)

**Overview**
Corrected the generic. To generate primary use secondary and vice versa
