### PR TITLE
fix: use 'tracing_test' instead of 'test_log'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ tracing = { version = "0.1.40", features = ["attributes"] }
 
 [dev-dependencies]
 prettytable-rs = "0.10.0"
-test-log = "0.2.12"
+tracing-test = "0.2.4"
 halo2_gadgets = { git = "https://github.com/snarkify/halo2", branch = "snarkify/dev", features = ["unstable"] }
 bincode = "1.3"
 tempfile = "3.9.0"

--- a/examples/sha256/table16/compression.rs
+++ b/examples/sha256/table16/compression.rs
@@ -964,6 +964,7 @@ mod tests {
     use sirius::run_mock_prover_test;
     use std::marker::PhantomData;
 
+    #[traced_test]
     #[test]
     fn compress() {
         struct MyCircuit<F: PrimeField> {

--- a/examples/sha256/table16/message_schedule.rs
+++ b/examples/sha256/table16/message_schedule.rs
@@ -409,6 +409,7 @@ mod tests {
     use sirius::run_mock_prover_test;
     use std::marker::PhantomData;
 
+    #[traced_test]
     #[test]
     fn message_schedule() {
         struct MyCircuit<F: PrimeField> {

--- a/examples/sha256/table16/mod.rs
+++ b/examples/sha256/table16/mod.rs
@@ -477,6 +477,7 @@ mod tests {
     };
     use halo2curves::pasta::pallas;
 
+    #[traced_test]
     #[test]
     fn print_sha256_circuit() {
         use plotters::prelude::*;

--- a/examples/sha256/table16/spread_table.rs
+++ b/examples/sha256/table16/spread_table.rs
@@ -300,6 +300,7 @@ mod tests {
     use halo2curves::pasta::Fp;
     use sirius::run_mock_prover_test;
 
+    #[traced_test]
     #[test]
     fn lookup_table() {
         /// This represents an advice column at a certain row in the ConstraintSystem

--- a/src/commitment.rs
+++ b/src/commitment.rs
@@ -127,9 +127,11 @@ impl<C: CurveAffine> CommitmentKey<C> {
 mod file_tests {
     use halo2curves::bn256::G1Affine;
     use tempfile::tempdir;
+    use tracing_test::traced_test;
 
     use super::*;
 
+    #[traced_test]
     #[test]
     fn consistency() {
         const K: usize = 10;

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -75,9 +75,11 @@ mod tests {
     use ff::PrimeField;
     use halo2curves::bn256::{Fr, G1Affine};
     use serde::*;
+    use tracing_test::traced_test;
 
     use super::{into_curve_by_bits, DigestToCurve};
 
+    #[traced_test]
     #[test]
     fn consistency() {
         // MODULUS - 1

--- a/src/gadgets/ecc.rs
+++ b/src/gadgets/ecc.rs
@@ -379,14 +379,19 @@ impl<C: CurveAffine<Base = F>, F: PrimeFieldBits, const T: usize> EccChip<C, F, 
 mod tests {
     use std::num::NonZeroUsize;
 
-    use super::*;
-    use crate::util::fe_to_fe_safe;
-    use crate::{create_and_verify_proof, run_mock_prover_test};
     use ff::Field;
-    use halo2_proofs::circuit::{Layouter, SimpleFloorPlanner};
-    use halo2_proofs::plonk::{Circuit, Column, ConstraintSystem, Instance};
+    use halo2_proofs::{
+        circuit::{Layouter, SimpleFloorPlanner},
+        plonk::{Circuit, Column, ConstraintSystem, Instance},
+    };
     use halo2curves::pasta::{pallas, EqAffine, Fp, Fq};
     use rand_core::OsRng;
+    use tracing_test::traced_test;
+
+    use crate::{create_and_verify_proof, run_mock_prover_test, util::fe_to_fe_safe};
+
+    use super::*;
+
     #[derive(Clone, Debug)]
     struct Point<C: CurveAffine> {
         x: C::Base,
@@ -590,6 +595,7 @@ mod tests {
         }
     }
 
+    #[traced_test]
     #[test]
     #[ignore = "cause it takes a few minutes to run"]
     fn test_ecc_op() {

--- a/src/gadgets/nonnative/bn/big_uint.rs
+++ b/src/gadgets/nonnative/bn/big_uint.rs
@@ -303,10 +303,11 @@ mod tests {
 
     use ff::Field;
     use halo2curves::pasta::Fp;
-    use test_log::test;
+    use tracing_test::traced_test;
 
     use super::*;
 
+    #[traced_test]
     #[test]
     fn from_u64() {
         for input in [0, 256, u64::MAX / 2, u64::MAX] {
@@ -325,6 +326,7 @@ mod tests {
         }
     }
 
+    #[traced_test]
     #[test]
     fn from_u128() {
         for input in [u128::from(u64::MAX) + 1, u128::MAX / 2, u128::MAX] {
@@ -342,7 +344,7 @@ mod tests {
             assert_eq!(bn.into_bigint(), BigUintRaw::from(input));
         }
     }
-
+    #[traced_test]
     #[test]
     fn from_two_limbs() {
         let input = BigUintRaw::from(u128::MAX) * BigUintRaw::from(u128::MAX);
@@ -366,6 +368,7 @@ mod tests {
         assert_eq!(bn.into_bigint(), input);
     }
 
+    #[traced_test]
     #[test]
     fn limbs_count_err() {
         let input = BigUintRaw::from(u128::MAX) * BigUintRaw::from(u128::MAX);
@@ -378,6 +381,7 @@ mod tests {
         assert_eq!(result_with_bn, Err(Error::TooBigBigint));
     }
 
+    #[traced_test]
     #[test]
     fn limbs_limit_err() {
         let limbs_count = NonZeroUsize::new(50).unwrap();

--- a/src/gadgets/nonnative/bn/big_uint_mul_mod_chip/tests.rs
+++ b/src/gadgets/nonnative/bn/big_uint_mul_mod_chip/tests.rs
@@ -17,6 +17,8 @@ const LIMB_WIDTH: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(Fp::S as u
 const LIMBS_COUNT: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(10) };
 
 mod mult_mod_tests {
+    use tracing_test::traced_test;
+
     use super::*;
 
     #[derive(Clone)]
@@ -152,7 +154,8 @@ mod mult_mod_tests {
         modulus: u128,
     }
 
-    #[test_log::test]
+    #[traced_test]
+    #[test]
     fn test_mult_mod_bn() {
         const K: u32 = 11;
 
@@ -225,6 +228,7 @@ mod mult_mod_tests {
 
 mod components_tests {
     use halo2_proofs::circuit::Value;
+    use tracing_test::traced_test;
 
     use super::*;
 
@@ -540,7 +544,8 @@ mod components_tests {
         .unwrap()
     }
 
-    #[test_log::test]
+    #[traced_test]
+    #[test]
     fn test_mult_mod_bn() {
         let lhs = BigUintRaw::from_u64(u64::MAX).unwrap() * BigUintRaw::from_u64(100).unwrap();
         let rhs = BigUintRaw::from_u64(u64::MAX).unwrap() * BigUintRaw::from_u64(u64::MAX).unwrap();
@@ -571,7 +576,8 @@ mod components_tests {
         );
     }
 
-    #[test_log::test]
+    #[traced_test]
+    #[test]
     fn test_mult_mod_zero() {
         let lhs = BigUintRaw::from_u64(u64::MAX).unwrap() * BigUintRaw::from_u64(100).unwrap();
         let rhs = BigUintRaw::from_u64(0).unwrap();
@@ -604,13 +610,15 @@ mod components_tests {
 }
 
 mod red_mod_tests {
-    use crate::run_mock_prover_test;
     use halo2_proofs::{
         circuit::SimpleFloorPlanner,
         plonk::{Advice, Circuit, Column, Instance},
     };
     use halo2curves::pasta::Fp;
     use num_traits::FromPrimitive;
+    use tracing_test::traced_test;
+
+    use crate::run_mock_prover_test;
 
     use super::*;
 
@@ -734,7 +742,8 @@ mod red_mod_tests {
         modulus: u128,
     }
 
-    #[test_log::test]
+    #[traced_test]
+    #[test]
     fn test_red_mod_bn() {
         const K: u32 = 11;
 
@@ -795,6 +804,7 @@ mod red_mod_tests {
 
 mod decompose_tests {
     use halo2_proofs::circuit::Value;
+    use tracing_test::traced_test;
 
     use super::*;
 
@@ -903,7 +913,8 @@ mod decompose_tests {
         val: u128,
     }
 
-    #[test_log::test]
+    #[traced_test]
+    #[test]
     fn test_from_assigned_cell() {
         const K: u32 = 11;
         let ts = TestCircuit::<Fp>::default();
@@ -934,6 +945,7 @@ mod decompose_tests {
 
 mod to_le_bits {
     use rand::Rng;
+    use tracing_test::traced_test;
 
     use super::*;
 
@@ -1028,7 +1040,8 @@ mod to_le_bits {
         }
     }
 
-    #[test_log::test]
+    #[traced_test]
+    #[test]
     fn to_le_bits() {
         const K: u32 = 15;
         let ts = TestCircuit::<Fp>::default();

--- a/src/ivc/fold_relaxed_plonk_instance_chip.rs
+++ b/src/ivc/fold_relaxed_plonk_instance_chip.rs
@@ -1026,6 +1026,7 @@ mod tests {
     use halo2_proofs::plonk::ConstraintSystem;
     use halo2curves::{bn256::G1Affine as C1, CurveAffine};
     use rand::{rngs::ThreadRng, Rng};
+    use tracing_test::traced_test;
 
     use crate::{
         commitment::CommitmentKey,
@@ -1130,6 +1131,7 @@ mod tests {
         }
     }
 
+    #[traced_test]
     #[test]
     fn generate_challenge() {
         let mut rnd = rand::thread_rng();
@@ -1204,7 +1206,8 @@ mod tests {
         }
     }
 
-    #[test_log::test]
+    #[traced_test]
+    #[test]
     fn fold_W_test() {
         let Fixture {
             mut ws,
@@ -1280,7 +1283,8 @@ mod tests {
         }
     }
 
-    #[test_log::test]
+    #[traced_test]
+    #[test]
     fn fold_E_test() {
         let Fixture {
             mut ws,
@@ -1366,7 +1370,8 @@ mod tests {
         }
     }
 
-    #[test_log::test]
+    #[traced_test]
+    #[test]
     fn fold_instances_test() {
         let Fixture {
             mut ws,
@@ -1503,7 +1508,8 @@ mod tests {
         }
     }
 
-    #[test_log::test]
+    #[traced_test]
+    #[test]
     fn fold_challenges_test() {
         let Fixture {
             mut ws,
@@ -1639,7 +1645,8 @@ mod tests {
         }
     }
 
-    #[test_log::test]
+    #[traced_test]
+    #[test]
     fn fold_all() {
         const T: usize = 6;
 

--- a/src/ivc/instance_computation.rs
+++ b/src/ivc/instance_computation.rs
@@ -177,6 +177,7 @@ mod tests {
         plonk::ConstraintSystem,
     };
     use halo2curves::{bn256, grumpkin};
+    use tracing_test::traced_test;
 
     type C1 = <bn256::G1 as halo2curves::group::prime::PrimeCurve>::Affine;
     type C2 = <grumpkin::G1 as halo2curves::group::prime::PrimeCurve>::Affine;
@@ -197,7 +198,8 @@ mod tests {
 
     use super::*;
 
-    #[test_log::test]
+    #[traced_test]
+    #[test]
     fn consistency() {
         let random_oracle_constant = Spec::<Base, 10, 9>::new(10, 10);
 

--- a/src/ivc/public_params.rs
+++ b/src/ivc/public_params.rs
@@ -411,10 +411,12 @@ mod pp_test {
 
     use group::Group;
     use halo2curves::{bn256, grumpkin};
+    use tracing_test::traced_test;
 
-    use crate::ivc::step_circuit::{self, trivial};
     use bn256::G1 as C1;
     use grumpkin::G1 as C2;
+
+    use crate::ivc::step_circuit::{self, trivial};
 
     use super::*;
 
@@ -451,6 +453,7 @@ mod pp_test {
         }
     }
 
+    #[traced_test]
     #[test]
     fn digest() {
         type Scalar1 = <C1 as Group>::Scalar;

--- a/src/main_gate.rs
+++ b/src/main_gate.rs
@@ -801,7 +801,9 @@ mod tests {
     use super::*;
     use crate::polynomial::{ColumnIndex, Expression};
     use halo2curves::pasta::Fp;
+    use tracing_test::traced_test;
 
+    #[traced_test]
     #[test]
     fn main_gate_size_change() {
         const T: usize = 10;

--- a/src/nifs/tests.rs
+++ b/src/nifs/tests.rs
@@ -199,8 +199,11 @@ fn smallest_power(n: usize, K: u32) -> usize {
 
 // test with single custom gate without lookup
 mod zero_round_test {
-    use super::*;
+    use tracing_test::traced_test;
+
     use crate::main_gate::{MainGate, MainGateConfig, RegionCtx};
+
+    use super::*;
 
     const T: usize = 3;
 
@@ -259,6 +262,7 @@ mod zero_round_test {
         }
     }
 
+    #[traced_test]
     #[test]
     fn test_nifs() -> Result<(), NIFSError> {
         const K: u32 = 4;

--- a/src/polynomial/expression.rs
+++ b/src/polynomial/expression.rs
@@ -350,9 +350,11 @@ mod tests {
     // use pasta_curves::{Fp, pallas};
     use halo2_proofs::poly::Rotation;
     use halo2curves::pasta::{pallas, Fp};
+    use tracing_test::traced_test;
 
     use super::super::expression::*;
 
+    #[traced_test]
     #[test]
     fn test_expression() {
         let expr1: Expression<Fp> =
@@ -368,6 +370,7 @@ mod tests {
         assert_eq!(format!("{}", expr.expand()), "0x1 + (Z_0^2)");
     }
 
+    #[traced_test]
     #[test]
     fn test_homogeneous() {
         let expr1: Expression<Fp> =

--- a/src/poseidon/poseidon_circuit.rs
+++ b/src/poseidon/poseidon_circuit.rs
@@ -425,6 +425,7 @@ mod tests {
         group::ff::FromUniformBytes,
         pasta::{EqAffine, Fp},
     };
+    use tracing_test::traced_test;
 
     use crate::{
         create_and_verify_proof, main_gate::MainGateConfig, poseidon::Spec, run_mock_prover_test,
@@ -499,6 +500,7 @@ mod tests {
         }
     }
 
+    #[traced_test]
     #[test]
     fn test_poseidon_circuit() {
         println!("-----running Poseidon Circuit-----");

--- a/src/poseidon/poseidon_hash.rs
+++ b/src/poseidon/poseidon_hash.rs
@@ -222,9 +222,12 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use halo2curves::pasta::{EpAffine, Fp, Fq};
+    use tracing_test::traced_test;
 
+    use super::*;
+
+    #[traced_test]
     #[test]
     fn test_poseidon_hash() {
         const T: usize = 3;

--- a/src/poseidon/spec.rs
+++ b/src/poseidon/spec.rs
@@ -134,9 +134,11 @@ impl<F: Serialize + ff::PrimeField, const T: usize, const RATE: usize> Serialize
 #[cfg(test)]
 mod tests {
     use halo2curves::secp256r1::Fp;
+    use tracing_test::traced_test;
 
     use super::*;
 
+    #[traced_test]
     #[test]
     fn just_serialize() {
         let spec = Spec::<Fp, 10, 9>::new(10, 10);

--- a/src/table/tests.rs
+++ b/src/table/tests.rs
@@ -5,6 +5,7 @@ use halo2_proofs::{
 };
 use halo2curves::group::ff::FromUniformBytes;
 use prettytable::{row, Cell, Row, Table};
+use tracing_test::traced_test;
 
 use crate::{
     main_gate::{MainGate, MainGateConfig, RegionCtx},
@@ -68,6 +69,7 @@ impl<F: PrimeField + FromUniformBytes<64>> Circuit<F> for TestCircuit<F> {
     }
 }
 
+#[traced_test]
 #[test]
 fn test_assembly() -> Result<(), Error> {
     use halo2curves::pasta::Fp;

--- a/src/util.rs
+++ b/src/util.rs
@@ -199,6 +199,7 @@ pub(crate) fn concatenate_with_padding<F: PrimeField>(vs: &[Vec<F>], pad_size: u
 #[cfg(test)]
 mod tests {
     use halo2curves::pasta::Fp;
+    use tracing_test::traced_test;
 
     use super::*;
 
@@ -208,6 +209,7 @@ mod tests {
     }
 
     // Test empty input
+    #[traced_test]
     #[test]
     fn concatenate_empty() {
         let input: Vec<Vec<Fp>> = vec![];


### PR DESCRIPTION
**Motivation**
After migration to 'tracing' we should use `tracing_test` for see logs in tests run

**Overview**
- Automatically added `traced_test` to all tests in the project