### PR TITLE
fix(ivc): correct init secondary trace

### DIFF
--- a/src/ivc/incrementally_verifiable_computation.rs
+++ b/src/ivc/incrementally_verifiable_computation.rs
@@ -195,7 +195,7 @@ where
     {
         debug!("start creation of IVC");
         // For use as first version of `U` in primary circuit synthesize
-        let secondary_pre_round_plonk_trace = pp.secondary.S().dry_run_sps_protocol();
+        let secondary_pre_round_plonk_trace = pp.secondary_initial_plonk_trace();
 
         let primary_z_output = primary.process_step(&primary_z_0, pp.primary.k_table_size())?;
         debug!("primary z output calculated off-circuit");
@@ -229,7 +229,7 @@ where
                 z_0: primary_z_0,
                 z_i: primary_z_0,
                 U: secondary_relaxed_trace.U.clone(),
-                u: secondary_pre_round_plonk_trace.u,
+                u: secondary_pre_round_plonk_trace.u.clone(),
                 cross_term_commits: vec![
                     C2::identity();
                     pp.secondary.S().get_degree_for_folding().saturating_sub(1)

--- a/src/ivc/step_folding_circuit.rs
+++ b/src/ivc/step_folding_circuit.rs
@@ -76,6 +76,7 @@ where
     }
 }
 
+#[derive(Clone)]
 pub(crate) struct StepInputs<'link, const ARITY: usize, C, RO>
 where
     C::Base: ff::PrimeFieldBits + ff::FromUniformBytes<64>,


### PR DESCRIPTION
**Motivation**
Our initial plonk trace was incorrect and poisoned the entire relaxed trace for the secondary circuit.

Close #192

**Overview**
Now when creating public parameters, we not only calculate `S` (`PlonkStructure`), but also calculate the correct trace for the secondary input to use as the initial trace

The fact that the trace is computed on incorrect `u` & `U` (null traces do not converge) is immaterial, since internal traces are not used, only their folding traces are used.
