### PR TITLE
fix(util.rs): fix typo in halo2 prover

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -344,7 +344,7 @@ macro_rules! create_and_verify_proof {
         let pk = keygen_pk(&params, vk, &$circuit).expect("keygen_pk should not fail");
 
         // prove
-        let mut transcript = Blake2bWrite::<_, EqAffine, Challenge255<_>>::init(vec![]);
+        let mut transcript = Blake2bWrite::<_, $curve_point, Challenge255<_>>::init(vec![]);
         create_proof::<IPACommitmentScheme<_>, ProverIPA<_>, _, _, _, _>(
             &params,
             &pk,


### PR DESCRIPTION
There is a typo in the halo2 prover which need to be changed.