### PR TITLE
feat(159): `HashMap<usize, _>` -> `Vec<Option<_>>`

### DIFF
--- a/src/polynomial/grouped_poly.rs
+++ b/src/polynomial/grouped_poly.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::HashMap,
-    ops::{Add, Mul, Sub},
-};
+use std::ops::{Add, Mul, Sub};
 
 use ff::PrimeField;
 use itertools::*;
@@ -26,8 +23,8 @@ impl<F> Default for GroupedPoly<F> {
     }
 }
 
-impl<F: PrimeField> From<HashMap<usize, Expression<F>>> for GroupedPoly<F> {
-    fn from(value: HashMap<usize, Expression<F>>) -> Self {
+impl<IT: IntoIterator<Item = (usize, Expression<F>)>, F: PrimeField> From<IT> for GroupedPoly<F> {
+    fn from(value: IT) -> Self {
         let mut self_ = Self::default();
 
         for (degree, expr) in value.into_iter() {


### PR DESCRIPTION
**Motivation**
The degree is small, so HashMap is redundant here
Part of #159 

**Overview**
Simple enough migration. Also corrected an error in subtraction with this implementation. It is possible to use `vec_option` crate to optimise storage of discriminators, but I will try to use it when there is a benchmark