### PR TITLE
feat(poly): impl `QueryIndexContext`

### DIFF
--- a/src/digest.rs
+++ b/src/digest.rs
@@ -2,10 +2,12 @@ use std::{io, iter, num::NonZeroUsize, ops::Deref};
 
 use bincode::Options;
 use bitter::{BitReader, LittleEndianReader};
-use digest::{typenum::U32, Digest, OutputSizeUser};
+use digest::{typenum::U32, OutputSizeUser};
 use ff::{Field, PrimeField};
 use halo2curves::CurveAffine;
 use serde::Serialize;
+
+pub use digest::Digest;
 
 pub use sha3::Sha3_256 as DefaultHasher;
 
@@ -49,7 +51,7 @@ pub trait DigestToCurve: Digest {
 }
 impl DigestToCurve for sha3::Sha3_256 {}
 
-fn into_curve_by_bits<C: CurveAffine>(input: &[u8], bits_count: NonZeroUsize) -> C {
+pub fn into_curve_by_bits<C: CurveAffine>(input: &[u8], bits_count: NonZeroUsize) -> C {
     let mut coeff = C::ScalarExt::ONE;
 
     let mut reader = LittleEndianReader::new(input);

--- a/src/ivc/public_params.rs
+++ b/src/ivc/public_params.rs
@@ -1,6 +1,5 @@
 use std::{fmt, io, marker::PhantomData, num::NonZeroUsize, ops::Deref};
 
-use bincode::Options;
 use ff::{Field, FromUniformBytes, PrimeFieldBits};
 use group::prime::PrimeCurveAffine;
 use halo2_proofs::plonk;
@@ -11,7 +10,7 @@ use tracing::*;
 use crate::{
     commitment::CommitmentKey,
     constants::NUM_HASH_BITS,
-    digest::{self, into_curve_by_bits, Digest, DigestToCurve},
+    digest::{self, into_curve_from_bits, DigestToBits, DigestToCurve},
     ivc::{
         self,
         instance_computation::RandomOracleComputationInstance,
@@ -353,16 +352,10 @@ where
             _p: PhantomData,
         };
 
-        let digest = digest::DefaultHasher::digest(
-            bincode::DefaultOptions::new()
-                .with_little_endian()
-                .with_fixint_encoding()
-                .serialize(&self_)
-                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?,
-        );
+        let digest = digest::DefaultHasher::digest_to_bits(&self_)?;
 
-        self_.digest_1 = into_curve_by_bits(digest.deref(), NUM_HASH_BITS);
-        self_.digest_2 = into_curve_by_bits(digest.deref(), NUM_HASH_BITS);
+        self_.digest_1 = into_curve_from_bits(digest.deref(), NUM_HASH_BITS);
+        self_.digest_2 = into_curve_from_bits(digest.deref(), NUM_HASH_BITS);
 
         Ok(self_)
     }

--- a/src/plonk/mod.rs
+++ b/src/plonk/mod.rs
@@ -78,9 +78,11 @@ pub(crate) struct CompressedGates<F: PrimeField> {
     compressed: Expression<F>,
     /// A homogeneous version of the `compressed` expression, achieved by adding another challenge
     /// if necessary
+    #[serde(skip_serializing)]
     homogeneous: HomogeneousExpression<F>,
     /// A degree-grouped version of the `homogeneous` expression, adds another expression, but
     /// implicitly
+    #[serde(skip_serializing)]
     grouped: GroupedPoly<F>,
 }
 

--- a/src/plonk/mod.rs
+++ b/src/plonk/mod.rs
@@ -14,7 +14,7 @@
 //!
 //! Additionally, it defines a method is_sat on PlonkStructure to determine if
 //! a given Plonk instance and witness satisfy the circuit constraints.
-use std::{iter, num::NonZeroUsize};
+use std::{iter, num::NonZeroUsize, time::Instant};
 
 use count_to_non_zero::*;
 use itertools::Itertools;
@@ -35,7 +35,7 @@ use crate::{
         eval::{Error as EvalError, Eval, PlonkEvalDomain},
     },
     polynomial::{
-        expression::HomogeneousExpression,
+        expression::{HomogeneousExpression, QueryIndexContext},
         grouped_poly::GroupedPoly,
         sparse::{matrix_multiply, SparseMatrix},
         Expression, MultiPolynomial,
@@ -85,30 +85,33 @@ pub(crate) struct CompressedGates<F: PrimeField> {
 }
 
 impl<F: PrimeField> CompressedGates<F> {
-    pub fn new(
-        original_expressions: &[Expression<F>],
-        num_selectors: usize,
-        num_fixed: usize,
-        num_of_fold_vars: usize,
-        num_challenges: usize,
-    ) -> Self {
-        debug!("input num_challenges: {num_challenges}");
-        let compressed = plonk::util::compress_expression(original_expressions, num_challenges);
+    #[instrument(name = "compressing", skip_all)]
+    pub fn new(original_expressions: &[Expression<F>], ctx: &mut QueryIndexContext) -> Self {
+        let timer = Instant::now();
+        debug!("input num_challenges: {}", ctx.num_challenges);
+        let compressed = plonk::util::compress_expression(original_expressions, ctx.num_challenges);
+        info!(
+            "custom gates compressed in {} ns",
+            timer.elapsed().as_nanos()
+        );
+        ctx.num_challenges = compressed.num_challenges();
 
-        let homogeneous =
-            compressed.homogeneous(num_selectors, num_fixed, compressed.num_challenges());
+        let homogeneous = compressed.homogeneous(ctx);
+        info!(
+            "compressed made homogeneous in {} ns",
+            timer.elapsed().as_nanos()
+        );
+        ctx.num_challenges = homogeneous.num_challenges();
 
-        let num_challenges = homogeneous.num_challenges();
+        let grouped = GroupedPoly::new(&homogeneous, ctx);
+        info!(
+            "homogeneous made grouped in {} ns",
+            timer.elapsed().as_nanos()
+        );
 
         Self {
             compressed,
-            grouped: GroupedPoly::new(
-                &homogeneous,
-                num_selectors,
-                num_fixed,
-                num_of_fold_vars,
-                num_challenges,
-            ),
+            grouped,
             homogeneous,
         }
     }

--- a/src/polynomial/expression.rs
+++ b/src/polynomial/expression.rs
@@ -528,6 +528,7 @@ impl_expression_ops!(Add, add, Sum, Expression<F>, std::convert::identity);
 impl_expression_ops!(Sub, sub, Sum, Expression<F>, Neg::neg);
 impl_expression_ops!(Mul, mul, Product, Expression<F>, std::convert::identity);
 
+/// Multiply `Expression::Challenge(new_challenge_index)` by the `degree` time
 fn challenge_in_degree<F: PrimeField>(new_challenge_index: usize, degree: usize) -> Expression<F> {
     let challenge = Expression::Challenge(new_challenge_index);
     let mut result = challenge.clone();

--- a/src/polynomial/expression.rs
+++ b/src/polynomial/expression.rs
@@ -38,6 +38,29 @@ impl Ord for ColumnIndex {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Default)]
+pub struct QueryIndexContext {
+    pub num_selectors: usize,
+    pub num_fixed: usize,
+    pub num_advice: usize,
+    pub num_challenges: usize,
+    pub num_lookups: usize,
+}
+
+impl QueryIndexContext {
+    pub fn num_fold_vars(self) -> usize {
+        self.num_advice + self.num_lookups * 5
+    }
+
+    pub fn shift_advice_index(self, advice_poly_index: usize) -> usize {
+        advice_poly_index + self.num_fold_vars()
+    }
+
+    pub fn shift_lookup_index(self, lookup_poly_index: usize) -> usize {
+        lookup_poly_index + self.num_fold_vars()
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Serialize)]
 pub struct Query {
     pub index: usize,
@@ -45,9 +68,28 @@ pub struct Query {
     pub rotation: Rotation,
 }
 
+pub enum QueryType {
+    Selector,
+    Fixed,
+    Advice,
+    Lookup,
+}
+
 impl Query {
-    pub fn is_advice(&self, num_selectors: usize, num_fixed: usize) -> bool {
-        self.index >= num_selectors + num_fixed
+    pub fn subtype(&self, ctx: &QueryIndexContext) -> QueryType {
+        if self.index < ctx.num_selectors {
+            QueryType::Selector
+        } else if self.index < ctx.num_selectors + ctx.num_fixed {
+            QueryType::Fixed
+        } else if self.index < ctx.num_selectors + ctx.num_fixed + ctx.num_advice {
+            QueryType::Advice
+        } else if self.index
+            < ctx.num_selectors + ctx.num_fixed + ctx.num_advice + (5 * ctx.num_lookups)
+        {
+            QueryType::Lookup
+        } else {
+            unreachable!("unknown index {} in {ctx:?}", self.index)
+        }
     }
 }
 
@@ -360,103 +402,86 @@ impl<F: PrimeField> Expression<F> {
     /// ```math
     /// $$a\cdot b+c\rightarrow a\cdot b+c\cdot u$$
     ///```
-    pub fn homogeneous(
-        &self,
-        num_selector: usize,
-        num_fixed: usize,
-        num_challenges: usize,
-    ) -> HomogeneousExpression<F> {
+    pub fn homogeneous(&self, ctx: &QueryIndexContext) -> HomogeneousExpression<F> {
         use Expression::*;
-        let new_challenge_index = num_challenges.saturating_sub(1);
+        let new_challenge_index = ctx.num_challenges;
 
-        fn multiply_by_challenge<F: PrimeField>(
-            expr: Expression<F>,
-            new_challenge_index: usize,
-            degree: usize,
-        ) -> Expression<F> {
-            match degree.checked_sub(1) {
-                Some(degree_sub_1) => multiply_by_challenge(
-                    Expression::Challenge(new_challenge_index) * expr,
-                    new_challenge_index,
-                    degree_sub_1,
-                ),
-                None => expr,
+        match self {
+            Constant(constant) => HomogeneousExpression {
+                expr: Constant(*constant),
+                degree: 0,
+            },
+            Polynomial(polynomial) => HomogeneousExpression {
+                expr: Polynomial(*polynomial),
+                degree: match polynomial.subtype(ctx) {
+                    QueryType::Advice | QueryType::Lookup => 1,
+                    _other => 0,
+                },
+            },
+            Expression::Challenge(challenge) => (Challenge(*challenge), 1).into(),
+            Expression::Negated(expr) => {
+                let HomogeneousExpression { expr, degree } = expr.homogeneous(ctx);
+                (Expression::Negated(Box::new(expr)), degree).into()
             }
-        }
-
-        self.evaluate(
-            &|constant| -> HomogeneousExpression<F> { (Constant(constant), 0).into() },
-            &|polynomial: Query| {
-                (
-                    Polynomial(polynomial),
-                    if polynomial.is_advice(num_selector, num_fixed) {
-                        1
-                    } else {
-                        0
+            Expression::Sum(lhs, rhs) => {
+                let (
+                    HomogeneousExpression {
+                        expr: lhs,
+                        degree: lhs_degree,
                     },
-                )
-                    .into()
-            },
-            &|challenge| (Challenge(challenge), 1).into(),
-            &|expr| {
-                let HomogeneousExpression { expr, degree } =
-                    expr.homogeneous(num_selector, num_fixed, num_challenges);
-                (-expr, degree).into()
-            },
-            &|lhs, rhs| {
-                let HomogeneousExpression {
-                    expr: lhs,
-                    degree: lhs_degree,
-                } = lhs.homogeneous(num_selector, num_fixed, num_challenges);
-                let HomogeneousExpression {
-                    expr: rhs,
-                    degree: rhs_degree,
-                } = rhs.homogeneous(num_selector, num_fixed, num_challenges);
+                    HomogeneousExpression {
+                        expr: rhs,
+                        degree: rhs_degree,
+                    },
+                ) = (lhs.homogeneous(ctx), rhs.homogeneous(ctx));
 
                 match lhs_degree.cmp(&rhs_degree) {
                     Ordering::Greater => (
-                        lhs + multiply_by_challenge(
-                            rhs,
-                            new_challenge_index,
-                            lhs_degree - rhs_degree,
-                        ),
+                        lhs + (rhs
+                            * challenge_in_degree(
+                                new_challenge_index,
+                                lhs_degree.checked_sub(rhs_degree).unwrap(),
+                            )),
                         lhs_degree,
                     ),
                     Ordering::Less => (
-                        multiply_by_challenge(lhs, new_challenge_index, rhs_degree - lhs_degree)
-                            + rhs,
+                        (lhs * challenge_in_degree(
+                            new_challenge_index,
+                            rhs_degree.checked_sub(lhs_degree).unwrap(),
+                        )) + rhs,
                         rhs_degree,
                     ),
                     Ordering::Equal => (lhs + rhs, lhs_degree),
                 }
                 .into()
-            },
-            &|lhs, rhs| {
-                let HomogeneousExpression {
-                    expr: lhs,
-                    degree: lhs_degree,
-                } = lhs.homogeneous(num_selector, num_fixed, num_challenges);
-                let HomogeneousExpression {
-                    expr: rhs,
-                    degree: rhs_degree,
-                } = rhs.homogeneous(num_selector, num_fixed, num_challenges);
+            }
+            Expression::Product(lhs, rhs) => {
+                let (
+                    HomogeneousExpression {
+                        expr: lhs,
+                        degree: lhs_degree,
+                    },
+                    HomogeneousExpression {
+                        expr: rhs,
+                        degree: rhs_degree,
+                    },
+                ) = (lhs.homogeneous(ctx), rhs.homogeneous(ctx));
 
                 (lhs * rhs, lhs_degree + rhs_degree).into()
-            },
-            &|expr, constant| {
-                let HomogeneousExpression { expr, degree } =
-                    expr.homogeneous(num_selector, num_fixed, num_challenges);
+            }
+            Expression::Scaled(expr, constant) => {
+                let HomogeneousExpression { expr, degree } = expr.homogeneous(ctx);
 
-                (Scaled(Box::new(expr), constant), degree).into()
-            },
-        )
+                (Scaled(Box::new(expr), *constant), degree).into()
+            }
+        }
     }
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Default)]
 pub struct HomogeneousExpression<F: PrimeField> {
     pub expr: Expression<F>,
-    degree: usize,
+    pub degree: usize,
 }
 
 impl<F: PrimeField> ops::Deref for HomogeneousExpression<F> {
@@ -502,6 +527,17 @@ macro_rules! impl_expression_ops {
 impl_expression_ops!(Add, add, Sum, Expression<F>, std::convert::identity);
 impl_expression_ops!(Sub, sub, Sum, Expression<F>, Neg::neg);
 impl_expression_ops!(Mul, mul, Product, Expression<F>, std::convert::identity);
+
+fn challenge_in_degree<F: PrimeField>(new_challenge_index: usize, degree: usize) -> Expression<F> {
+    let challenge = Expression::Challenge(new_challenge_index);
+    let mut result = challenge.clone();
+
+    for _ in 2..=degree {
+        result = result * challenge.clone();
+    }
+
+    result
+}
 
 #[cfg(test)]
 mod tests {
@@ -559,24 +595,27 @@ mod tests {
     fn test_homogeneous_simple() {
         use Expression::*;
 
-        let expr1 = Polynomial(Query {
-            index: 0,
-            rotation: Rotation(0),
-        }) + Constant(pallas::Base::from(1));
-
-        let expr2 = Polynomial(Query {
-            index: 0,
-            rotation: Rotation(0),
-        }) * Polynomial(Query {
-            index: 1,
-            rotation: Rotation(0),
+        let [a, b] = array::from_fn(|index| {
+            Expression::<pallas::Base>::Polynomial(Query {
+                index,
+                rotation: Rotation(0),
+            })
         });
 
-        let expr3 = expr1.clone() - expr2.clone();
+        let expr1 = a.clone() + Constant(pallas::Base::from(1));
+        let expr2 = a * b;
+
+        let expr3 = expr1.clone() + expr2.clone();
         debug!("from {expr3}");
         assert_eq!(
-            format!("{}", expr3.homogeneous(0, 0, 0).expr),
-            "r_0 * (Z_0 + r_0 * 0x1) - Z_0 * Z_1"
+            expr3
+                .homogeneous(&QueryIndexContext {
+                    num_advice: 2,
+                    ..Default::default()
+                })
+                .expr
+                .to_string(),
+            "(Z_0 + 0x1 * r_0) * r_0 + Z_0 * Z_1"
         );
     }
 
@@ -597,11 +636,16 @@ mod tests {
 
         debug!("from {expr}");
 
-        let homogeneous = expr.homogeneous(0, 0, 0).expr;
+        let homogeneous = expr
+            .homogeneous(&QueryIndexContext {
+                num_advice: 5,
+                ..Default::default()
+            })
+            .expr;
 
         assert_eq!(
-            format!("{}", homogeneous),
-            "r_0 * r_0 * (r_0 * (r_0 * Z_0 + Z_0 * Z_1) + Z_0 * Z_1 * Z_2) + Z_0 * Z_1 * Z_2 * Z_3 * Z_4"
+            homogeneous.to_string(),
+            "((Z_0 * r_0 + Z_0 * Z_1) * r_0 + Z_0 * Z_1 * Z_2) * r_0 * r_0 + Z_0 * Z_1 * Z_2 * Z_3 * Z_4"
         );
     }
 }

--- a/src/polynomial/mod.rs
+++ b/src/polynomial/mod.rs
@@ -5,6 +5,6 @@ pub mod monomial;
 pub mod multi_polynomial;
 pub mod sparse;
 
-pub use expression::{ColumnIndex, Expression, Query};
+pub use expression::{ColumnIndex, Expression, Query, QueryType};
 pub use monomial::Monomial;
 pub use multi_polynomial::MultiPolynomial;


### PR DESCRIPTION
**Motivation**
To understand which `Expression` is the `Advice` or `Lookup`
representation of a column and which is any other type (Selector, Fixed)
we have to flip the whole context to calculate the relative index and
define the `Polynomial` subtype. We need to move towards making these
rules localized in the code and not requiring to remember them while
working with indexes

Part of #159 

**Overview**
- Introduced a new type that defines all `num_of`
- Subtype `QueryType` introduced
- The `Expression::homogeneous` function no longer uses `evaluate`, due to the overhead of using closure
- Lookup polynomials are now taken into account in `Expression::homogeneous` function
- Removed recursion for calculating `Challenge` in degree within `homogeneous` fn
- Removed an unnecessary `clone` call within `GroupedPoly::mul` for `rhs`
- Optimized `resize` call in `GroupedPoly::mul`
