### PR TITLE
ci: migrate to cargo-nextest & release in tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,5 +45,5 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: nextest
-        args: run
+        args: run --release
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,11 +35,11 @@ jobs:
         command: clippy
         args: --all-targets --all-features -- -D warnings
 
-   - name: Install cargo-nextest
-        uses: baptiste0928/cargo-install@v1
-        with:
-          crate: cargo-nextest
-          locked: true
+    - name: Install cargo-nextest
+      uses: baptiste0928/cargo-install@v1
+      with:
+        crate: cargo-nextest
+        locked: true
 
     - name: Tests
       uses: actions-rs/cargo@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,9 +35,15 @@ jobs:
         command: clippy
         args: --all-targets --all-features -- -D warnings
 
+   - name: Install cargo-nextest
+        uses: baptiste0928/cargo-install@v1
+        with:
+          crate: cargo-nextest
+          locked: true
+
     - name: Tests
       uses: actions-rs/cargo@v1
       with:
-        command: test
-        args: --all --verbose
+        command: nextest
+        args: run
 


### PR DESCRIPTION
**Motivation**
CI tests are slow, to speed things up a bit it would be good to get information on specific tests and also speed things up a bit

**Overview**
- I use the cargo-nextest plugin, to run tests, it will provide more information in Action
- from 12m to 4m with `cargo test --release`