### PR TITLE
feat(profile): add timer profile for folding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ sha3 = "0.10"
 some-to-err = "0.2.1"
 thiserror = "1.0.48"
 tracing = { version = "0.1.40", features = ["attributes"] }
+ark-std = { version = "0.4.0", features = ["print-trace"], optional = true }
 
 [dev-dependencies]
 prettytable-rs = "0.10.0"
@@ -39,3 +40,7 @@ maplit = "1.0.2"
 version = "1"
 default-features = false # Disable features which are enabled by default
 features = ["prepush-hook", "run-cargo-fmt", "run-cargo-test", "run-cargo-clippy"]
+
+[features]
+default = ["profile"]
+profile = ["dep:ark-std"]

--- a/src/ivc/fold_relaxed_plonk_instance_chip.rs
+++ b/src/ivc/fold_relaxed_plonk_instance_chip.rs
@@ -1279,7 +1279,7 @@ mod tests {
 
             assert_eq!(off_circuit_W, on_circuit_W_cell);
 
-            folded_W = plonk.W_commitments.clone();
+            folded_W.clone_from(&plonk.W_commitments);
         }
     }
 

--- a/src/ivc/incrementally_verifiable_computation.rs
+++ b/src/ivc/incrementally_verifiable_computation.rs
@@ -387,7 +387,7 @@ where
         debug!("start fold step with folding 'secondary' by 'primary'");
 
         #[cfg(feature = "profile")]
-        let timer = start_timer!(||"VanillaFS::prove: secondary_cross_terms");
+        let timer = start_timer!(|| "VanillaFS::prove: secondary_cross_terms");
         debug!("start prove secondary trace");
         let (secondary_new_trace, secondary_cross_term_commits) = nifs::vanilla::VanillaFS::prove(
             pp.secondary.ck(),
@@ -402,7 +402,7 @@ where
 
         // Prepare primary constraint system for folding
         #[cfg(feature = "profile")]
-        let timer = start_timer!(||"process_step: primary");
+        let timer = start_timer!(|| "process_step: primary");
         let primary_z_next = self
             .primary
             .step_circuit
@@ -411,7 +411,7 @@ where
         end_timer!(timer);
 
         #[cfg(feature = "profile")]
-        let timer = start_timer!(||"process primary instance");
+        let timer = start_timer!(|| "process primary instance");
         let primary_instance = [
             util::fe_to_fe(&self.secondary_trace.u.instance[1]).unwrap(),
             RandomOracleComputationInstance::<'_, A1, C2, RP1::OffCircuit> {
@@ -430,7 +430,7 @@ where
         end_timer!(timer);
 
         #[cfg(feature = "profile")]
-        let timer = start_timer!(||"create primary ivc circuit");
+        let timer = start_timer!(|| "create primary ivc circuit");
         let primary_sfc = StepFoldingCircuit::<'_, A1, C2, SC1, RP1::OnCircuit, T> {
             step_circuit: &self.primary.step_circuit,
             input: StepInputs::<'_, A1, C2, RP1::OnCircuit> {
@@ -468,7 +468,7 @@ where
         self.secondary.relaxed_trace = secondary_new_trace;
 
         #[cfg(feature = "profile")]
-        let timer = start_timer!(||"generate primary plonk trace");
+        let timer = start_timer!(|| "generate primary plonk trace");
         let primary_plonk_trace = VanillaFS::generate_plonk_trace(
             pp.primary.ck(),
             &primary_instance,
@@ -480,7 +480,7 @@ where
         end_timer!(timer);
 
         #[cfg(feature = "profile")]
-        let timer = start_timer!(||"VanillaFS::prove: primary_cross_term");
+        let timer = start_timer!(|| "VanillaFS::prove: primary_cross_term");
         debug!("start prove primary trace");
         let (primary_new_trace, primary_cross_term_commits) = nifs::vanilla::VanillaFS::prove(
             pp.primary.ck(),
@@ -500,7 +500,7 @@ where
         debug!("prepare secondary td");
 
         #[cfg(feature = "profile")]
-        let timer = start_timer!(||"process_step: secondary");
+        let timer = start_timer!(|| "process_step: secondary");
         let next_secondary_z_i = self
             .secondary
             .step_circuit
@@ -509,7 +509,7 @@ where
         end_timer!(timer);
 
         #[cfg(feature = "profile")]
-        let timer = start_timer!(||"process secondary instance");
+        let timer = start_timer!(|| "process secondary instance");
         let secondary_instance = [
             util::fe_to_fe(&primary_plonk_trace.u.instance[1]).unwrap(),
             RandomOracleComputationInstance::<'_, A2, C1, RP2::OffCircuit> {
@@ -528,7 +528,7 @@ where
         end_timer!(timer);
 
         #[cfg(feature = "profile")]
-        let timer = start_timer!(||"create secondary ivc circuit");
+        let timer = start_timer!(|| "create secondary ivc circuit");
         let secondary_sfc = StepFoldingCircuit::<'_, A2, C1, SC2, RP2::OnCircuit, T> {
             step_circuit: &self.secondary.step_circuit,
             input: StepInputs::<'_, A2, C1, RP2::OnCircuit> {
@@ -566,7 +566,7 @@ where
         self.primary.relaxed_trace = primary_new_trace;
 
         #[cfg(feature = "profile")]
-        let timer = start_timer!(||"generate secondary plonk trace");
+        let timer = start_timer!(|| "generate secondary plonk trace");
         self.secondary_trace = VanillaFS::generate_plonk_trace(
             pp.secondary.ck(),
             &secondary_instance,

--- a/src/main_gate.rs
+++ b/src/main_gate.rs
@@ -198,7 +198,7 @@ pub enum WrapValue<F: PrimeField> {
 }
 
 impl<F: PrimeField> WrapValue<F> {
-    pub fn from_point<C: CurveAffine>(input: &C) -> Option<(Self, Self)>
+    pub fn from_point<C>(input: &C) -> Option<(Self, Self)>
     where
         C: CurveAffine<Base = F>,
     {
@@ -209,7 +209,7 @@ impl<F: PrimeField> WrapValue<F> {
         ))
     }
 
-    pub fn from_assigned_point<C: CurveAffine>(input: &AssignedPoint<C>) -> [Self; 2]
+    pub fn from_assigned_point<C>(input: &AssignedPoint<C>) -> [Self; 2]
     where
         C: CurveAffine<Base = F>,
     {

--- a/src/nifs/vanilla.rs
+++ b/src/nifs/vanilla.rs
@@ -1,6 +1,6 @@
-use std::marker::PhantomData;
 #[cfg(feature = "profile")]
 use ark_std::{end_timer, start_timer};
+use std::marker::PhantomData;
 
 use super::*;
 use crate::commitment::CommitmentKey;
@@ -100,7 +100,7 @@ impl<C: CurveAffine> VanillaFS<C> {
         let normalized = S.poly.fold_transform(offset, S.num_fold_vars());
         #[cfg(feature = "profile")]
         end_timer!(timer);
-        
+
         let r_index = normalized.num_challenges() - 1;
         let degree = S.poly.degree_for_folding(offset);
         #[cfg(feature = "profile")]

--- a/src/util.rs
+++ b/src/util.rs
@@ -88,10 +88,7 @@ pub fn fe_to_fe_safe<F1: PrimeField, F2: PrimeField>(fe: &F1) -> Option<F2> {
     }
 }
 
-fn invert<F: Field>(
-    poly: &[Assigned<F>],
-    inv_denoms: impl Iterator<Item = F> + ExactSizeIterator,
-) -> Vec<F> {
+fn invert<F: Field>(poly: &[Assigned<F>], inv_denoms: impl ExactSizeIterator<Item = F>) -> Vec<F> {
     assert_eq!(inv_denoms.len(), poly.len());
     poly.iter()
         .zip(inv_denoms)
@@ -268,13 +265,8 @@ mod tests {
     }
 }
 
-pub(crate) fn create_ro<
-    F: PrimeField,
-    const T: usize,
-    const RATE: usize,
-    const R_F: usize,
-    const R_P: usize,
->() -> PoseidonHash<F, T, RATE>
+pub(crate) fn create_ro<F, const T: usize, const RATE: usize, const R_F: usize, const R_P: usize>(
+) -> PoseidonHash<F, T, RATE>
 where
     F: ff::PrimeFieldBits + ff::FromUniformBytes<64>,
 {


### PR DESCRIPTION
**Issue Link / Motivation**
To better understand the performance bottleneck of folding, we need have a timer to profile each step/component.

**Changes Overview**
Added the timer profile. Example looks like:

```
··Start:   Fold 1 step
····Start:   VanillaFS::prove: secondary_cross_terms
······Start:   commit cross term
········Start:   fold transform
········End:     fold transform ....................................................2.001ms
········Start:   cross term evaluation
········End:     cross term evaluation .............................................11.043s
······End:     commit cross term ...................................................11.147s
······Start:   fold instance-witness pair
······End:     fold instance-witness pair ..........................................3.892ms
····End:     VanillaFS::prove: secondary_cross_terms ...............................11.151s
····Start:   process_step: primary
····End:     process_step: primary .................................................398.542µs
····Start:   process primary instance
····End:     process primary instance ..............................................176.583µs
····Start:   create primary ivc circuit
····End:     create primary ivc circuit ............................................1.250µs
····Start:   generate primary plonk trace
····End:     generate primary plonk trace ..........................................149.452ms
····Start:   VanillaFS::prove: primary_cross_term
······Start:   commit cross term
········Start:   fold transform
········End:     fold transform ....................................................1.967ms
········Start:   cross term evaluation
········End:     cross term evaluation .............................................11.060s
······End:     commit cross term ...................................................11.196s
······Start:   fold instance-witness pair
······End:     fold instance-witness pair ..........................................3.596ms
····End:     VanillaFS::prove: primary_cross_term ..................................11.200s
····Start:   process_step: secondary
····End:     process_step: secondary ...............................................429.292µs
····Start:   process secondary instance
····End:     process secondary instance ............................................165.875µs
····Start:   create secondary ivc circuit
····End:     create secondary ivc circuit ..........................................481.403ms
····Start:   generate secondary plonk trace
····End:     generate secondary plonk trace ........................................148.273ms
··End:     Fold 1 step .............................................................23.222s
```
