### PR TITLE
feat(example): upd examples & add benches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,6 @@ name = "sirius"
 version = "0.1.0"
 edition = "2021"
 
-[[bench]]
-name = "trivial"
-harness = false
-
 [dependencies]
 bincode = "1.3"
 bitter = "0.6.1"
@@ -44,3 +40,11 @@ criterion = "0.5.1"
 version = "1"
 default-features = false # Disable features which are enabled by default
 features = ["prepush-hook", "run-cargo-fmt", "run-cargo-test", "run-cargo-clippy"]
+
+[[bench]]
+name = "trivial"
+harness = false
+
+[[bench]]
+name = "poseidon"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,10 @@ name = "sirius"
 version = "0.1.0"
 edition = "2021"
 
+[[bench]]
+name = "trivial"
+harness = false
+
 [dependencies]
 bincode = "1.3"
 bitter = "0.6.1"
@@ -34,6 +38,7 @@ bincode = "1.3"
 tempfile = "3.9.0"
 tracing-subscriber = { version = "0.3.18", features = ["json"] }
 maplit = "1.0.2"
+criterion = "0.5.1"
 
 [dev-dependencies.cargo-husky]
 version = "1"

--- a/benches/trivial/main.rs
+++ b/benches/trivial/main.rs
@@ -1,8 +1,8 @@
 #![allow(dead_code)]
 
-use std::{array, env, fs, io, num::NonZeroUsize, path::Path};
+use std::{array, io, num::NonZeroUsize, path::Path};
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{black_box, criterion_group, Criterion};
 use ff::PrimeField;
 use halo2_gadgets::sha256::BLOCK_SIZE;
 
@@ -52,8 +52,6 @@ fn get_or_create_commitment_key<C: CurveAffine>(
 }
 
 pub fn criterion_benchmark(c: &mut Criterion) {
-    tracing_subscriber::fmt::init();
-
     let prepare_span = info_span!("prepare").entered();
 
     // C1

--- a/benches/trivial/main.rs
+++ b/benches/trivial/main.rs
@@ -3,7 +3,7 @@
 use std::{array, io, num::NonZeroUsize, path::Path};
 
 use criterion::{black_box, criterion_group, Criterion};
-use ff::PrimeField;
+use ff::Field;
 use halo2_gadgets::sha256::BLOCK_SIZE;
 
 use halo2curves::{bn256, grumpkin, CurveAffine, CurveExt};
@@ -101,20 +101,40 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     prepare_span.exit();
 
-    let mut group = c.benchmark_group("sample-size-example");
-    group.significance_level(0.1).sample_size(10);
+    let mut group = c.benchmark_group("ivc_of_trivial");
+    group.significance_level(0.1).sample_size(15);
 
-    group.bench_function("trivial", move |b| {
+    group.bench_function("fold_1_step", |b| {
+        let mut rnd = rand::thread_rng();
+        let primary_z_0 = array::from_fn(|_| C1Scalar::random(&mut rnd));
+        let secondary_z_0 = array::from_fn(|_| C2Scalar::random(&mut rnd));
+
         b.iter(|| {
-            let _span = info_span!("bench").entered();
-
-            IVC::fold_with_debug_mode(
+            IVC::fold(
                 &pp,
                 sc1.clone(),
-                black_box(array::from_fn(|i| C1Scalar::from_u128(i as u128))),
+                black_box(primary_z_0),
                 sc2.clone(),
-                black_box(array::from_fn(|i| C2Scalar::from_u128(i as u128))),
+                black_box(secondary_z_0),
                 NonZeroUsize::new(1).unwrap(),
+            )
+            .unwrap();
+        })
+    });
+
+    group.bench_function("fold_2_step", |b| {
+        let mut rnd = rand::thread_rng();
+        let primary_z_0 = array::from_fn(|_| C1Scalar::random(&mut rnd));
+        let secondary_z_0 = array::from_fn(|_| C2Scalar::random(&mut rnd));
+
+        b.iter(|| {
+            IVC::fold(
+                &pp,
+                sc1.clone(),
+                black_box(primary_z_0),
+                sc2.clone(),
+                black_box(secondary_z_0),
+                NonZeroUsize::new(2).unwrap(),
             )
             .unwrap();
         })

--- a/examples/sha256/main.rs
+++ b/examples/sha256/main.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use std::{array, fs, io, iter, marker::PhantomData, num::NonZeroUsize, path::Path};
+use std::{array, io, iter, marker::PhantomData, num::NonZeroUsize, path::Path};
 
 use ff::PrimeField;
 use halo2_gadgets::sha256::BLOCK_SIZE;
@@ -339,26 +339,14 @@ type C2Affine = <C2 as halo2curves::group::prime::PrimeCurve>::Affine;
 type C1Scalar = <C1 as halo2curves::group::Group>::Scalar;
 type C2Scalar = <C2 as halo2curves::group::Group>::Scalar;
 
+const FOLDER: &str = ".cache/examples";
+
+#[instrument]
 fn get_or_create_commitment_key<C: CurveAffine>(
     k: usize,
     label: &'static str,
 ) -> io::Result<CommitmentKey<C>> {
-    const FOLDER: &str = ".cache/examples";
-
-    let file_path = Path::new(FOLDER).join(label).join(format!("{k}.bin"));
-
-    if file_path.exists() {
-        debug!("{file_path:?} exists, load key");
-        unsafe { CommitmentKey::load_from_file(&file_path, k) }
-    } else {
-        debug!("{file_path:?} not exists, start generate");
-        let key = CommitmentKey::setup(k, label.as_bytes());
-        fs::create_dir_all(file_path.parent().unwrap())?;
-        unsafe {
-            key.save_to_file(&file_path)?;
-        }
-        Ok(key)
-    }
+    unsafe { CommitmentKey::load_or_setup_cache(Path::new(FOLDER), label, k) }
 }
 
 fn main() {


### PR DESCRIPTION
**Motivation**
I'd like to have an easy way to check how a particular code change affects performance, as well as have reports on averages between runs. 

Such a solution would allow us to track the impact of certain features quite easily. 

Close #33 & MPV milestone 

**Overview**
I just moved the example inside the benches and added a 'criterion' crate (actually the default solution in the Rust ecosystem). The only downside is that due to the huge bench `IVC::fold` we can only run 10 samples, but the spread between runs is very small, so it's not critical.

Let me know if you need more info on cargo-criterion and how to use it, but I was planning to add it to the README under #247 anyway

```
cargo install cargo-criterion; cargo criterion
```

This command allows you to create a full-fledged performance report, but most importantly, if you run the target code first on the original version and then on the new one - it will calculate the performance difference taking into account the average values.

In the future, this crate can also be used to measure the performance of bottle necks
