### PR TITLE
refactor(plonk): `&Vec<_> -> &[_]` in `PlonkEvalDomain`

### DIFF
--- a/src/nifs/vanilla.rs
+++ b/src/nifs/vanilla.rs
@@ -84,7 +84,7 @@ impl<C: CurveAffine> VanillaFS<C> {
         let data = PlonkEvalDomain {
             num_advice: S.num_advice_columns,
             num_lookup: S.num_lookups(),
-            challenges: concat_vec!(&U1.challenges, &[U1.u], &U2.challenges, &[U2.to_relax().u]),
+            challenges: &concat_vec!(&U1.challenges, &[U1.u], &U2.challenges, &[U2.to_relax().u]),
             selectors: &S.selectors,
             fixed: &S.fixed_columns,
             W1s: &W1.W,

--- a/src/plonk/eval.rs
+++ b/src/plonk/eval.rs
@@ -95,13 +95,13 @@ pub struct PlonkEvalDomain<'a, F: PrimeField> {
     pub(crate) num_advice: usize,
     pub(crate) num_lookup: usize,
     // concatenation of challenges from two RelaxedPlonkInstance
-    pub(crate) challenges: Vec<F>,
-    pub(crate) selectors: &'a Vec<Vec<bool>>,
-    pub(crate) fixed: &'a Vec<Vec<F>>,
+    pub(crate) challenges: &'a [F],
+    pub(crate) selectors: &'a [Vec<bool>],
+    pub(crate) fixed: &'a [Vec<F>],
     // [`RelaxedPlonkWitness::W`] for first instance
-    pub(crate) W1s: &'a Vec<Vec<F>>,
+    pub(crate) W1s: &'a [Vec<F>],
     // [`RelaxedPlonkWitness::W`] for second instance
-    pub(crate) W2s: &'a Vec<Vec<F>>,
+    pub(crate) W2s: &'a [Vec<F>],
 }
 
 impl<'a, F: PrimeField> GetDataForEval<F> for LookupEvalDomain<'a, F> {
@@ -144,11 +144,11 @@ impl<'a, F: PrimeField> GetDataForEval<F> for PlonkEvalDomain<'a, F> {
     }
 
     fn get_selectors(&self) -> &impl AsRef<[Vec<bool>]> {
-        self.selectors
+        &self.selectors
     }
 
     fn get_fixed(&self) -> &impl AsRef<[Vec<F>]> {
-        self.fixed
+        &self.fixed
     }
 
     fn eval_advice_var(&self, row: usize, index: usize) -> Result<F, Error> {

--- a/src/plonk/mod.rs
+++ b/src/plonk/mod.rs
@@ -314,11 +314,11 @@ impl<F: PrimeField> PlonkStructure<F> {
         let data = PlonkEvalDomain {
             num_advice: self.num_advice_columns,
             num_lookup: self.num_lookups(),
-            challenges: U.challenges.clone(),
+            challenges: &U.challenges,
             selectors: &self.selectors,
             fixed: &self.fixed_columns,
             W1s: &W.W,
-            W2s: &vec![],
+            W2s: &[],
         };
 
         let total_row = 1 << self.k;
@@ -372,11 +372,11 @@ impl<F: PrimeField> PlonkStructure<F> {
         let data = PlonkEvalDomain {
             num_advice: self.num_advice_columns,
             num_lookup: self.num_lookups(),
-            challenges: concat_vec!(&U.challenges, &[U.u]),
+            challenges: &concat_vec!(&U.challenges, &[U.u]),
             selectors: &self.selectors,
             fixed: &self.fixed_columns,
             W1s: &W.W,
-            W2s: &vec![],
+            W2s: &[],
         };
 
         let evaluator = GraphEvaluator::new(self.custom_gates_lookup_compressed.homogeneous());


### PR DESCRIPTION
**Motivation**
- The antipattern of taking `&Vec` was used. `&[_]` is a more generalized type
- Some fields were copied unnecessarily

Implemented as part of #259

**Overview**
N/A
