### PR TITLE
perf(pp): skip serialization and digest of commitment key

### DIFF
--- a/src/ivc/public_params.rs
+++ b/src/ivc/public_params.rs
@@ -47,6 +47,7 @@ where
     RP: ROPair<C::Scalar>,
 {
     S: PlonkStructure<C::Scalar>,
+    #[serde(skip_serializing)]
     ck: &'key CommitmentKey<C>,
     params: StepParams<C::Scalar, RP::OnCircuit>,
 }


### PR DESCRIPTION
**Issue Link / Motivation**

Close #136 

**Changes Overview**
skip serialization of commitment keys.


With table size `k=17` and commitment key of size `2^27`, i.e. each key has 8GB size.

**time profile**
before
```
··Start:  pp_new
····Start:  primary
······Start:  circuit_collect_plonk_struct
······End:    circuit_collect_plonk_struct.................................0.38s
····End:    primary........................................................0.38s
····Start:  secondary
······Start:  process_step
······End:    process_step.................................................0.00s
······Start:  circuit_collect_plonk_struct
······End:    circuit_collect_plonk_struct.................................0.24s
······Start:  circuit_collect_witness
······End:    circuit_collect_witness......................................0.10s
······Start:  generate_plonk_trace
······End:    generate_plonk_trace.........................................0.07s
····End:    secondary......................................................0.43s
····Start:  digest
······Start:  digest_to_bits
······End:    digest_to_bits..............................................59.00s
····End:    digest........................................................59.00s
··End:    pp_new..........................................................59.80s
```

after
```
··Start:  pp_new
····Start:  primary
······Start:  circuit_collect_plonk_struct
········Start:  compressed_gates
········End:    compressed_gates...........................................0.00s
······End:    circuit_collect_plonk_struct.................................0.37s
····End:    primary........................................................0.37s
····Start:  secondary
······Start:  process_step
······End:    process_step.................................................0.00s
······Start:  circuit_collect_plonk_struct
······End:    circuit_collect_plonk_struct.................................0.24s
······Start:  circuit_collect_witness
······End:    circuit_collect_witness......................................0.10s
······Start:  generate_plonk_trace
······End:    generate_plonk_trace.........................................0.08s
····End:    secondary......................................................0.43s
····Start:  digest
······Start:  digest_to_bits
······End:    digest_to_bits...............................................1.69s
····End:    digest.........................................................1.69s
··End:    pp_new...........................................................2.49s
```

**memory profile**

Before:
```
dhat: Total:     46,145,901,258 bytes in 7,481,137 blocks
dhat: At t-gmax: 26,414,849,327 bytes in 15,103 blocks
dhat: At t-end:  503,405 bytes in 810 blocks
```

After
```
dhat: Total:     37,553,398,397 bytes in 7,441,377 blocks
dhat: At t-gmax: 18,205,173,065 bytes in 29,544 blocks
dhat: At t-end:  503,405 bytes in 810 blocks
```



