### PR TITLE
refactor(ivc): take out step-circuit's ownership

### DIFF
--- a/benches/poseidon/main.rs
+++ b/benches/poseidon/main.rs
@@ -164,9 +164,9 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         b.iter(|| {
             IVC::fold(
                 &pp,
-                sc1.clone(),
+                &sc1,
                 black_box(primary_z_0),
-                sc2.clone(),
+                &sc2,
                 black_box(secondary_z_0),
                 NonZeroUsize::new(1).unwrap(),
             )
@@ -182,9 +182,9 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         b.iter(|| {
             IVC::fold(
                 &pp,
-                sc1.clone(),
+                &sc1,
                 black_box(primary_z_0),
-                sc2.clone(),
+                &sc2,
                 black_box(secondary_z_0),
                 NonZeroUsize::new(2).unwrap(),
             )

--- a/benches/trivial/main.rs
+++ b/benches/trivial/main.rs
@@ -113,9 +113,9 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         b.iter(|| {
             IVC::fold(
                 &pp,
-                sc1.clone(),
+                &sc1,
                 black_box(primary_z_0),
-                sc2.clone(),
+                &sc2,
                 black_box(secondary_z_0),
                 NonZeroUsize::new(1).unwrap(),
             )
@@ -131,9 +131,9 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         b.iter(|| {
             IVC::fold(
                 &pp,
-                sc1.clone(),
+                &sc1,
                 black_box(primary_z_0),
-                sc2.clone(),
+                &sc2,
                 black_box(secondary_z_0),
                 NonZeroUsize::new(2).unwrap(),
             )

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -137,9 +137,9 @@ fn fold(
     if args.debug_mode {
         IVC::fold_with_debug_mode(
             &pp,
-            primary,
+            &primary,
             primary_input,
-            secondary,
+            &secondary,
             secondary_input,
             args.fold_step_count,
         )
@@ -147,9 +147,9 @@ fn fold(
     } else {
         IVC::fold(
             &pp,
-            primary,
+            &primary,
             primary_input,
-            secondary,
+            &secondary,
             secondary_input,
             args.fold_step_count,
         )

--- a/examples/poseidon.rs
+++ b/examples/poseidon.rs
@@ -253,9 +253,9 @@ fn main() {
 
     IVC::fold(
         &pp,
-        primary,
+        &primary,
         primary_input,
-        secondary,
+        &secondary,
         secondary_input,
         fold_step_count,
     )

--- a/examples/sha256/main.rs
+++ b/examples/sha256/main.rs
@@ -401,9 +401,9 @@ fn main() {
 
     IVC::fold_with_debug_mode(
         &pp,
-        sc1,
+        &sc1,
         array::from_fn(|i| C1Scalar::from_u128(i as u128)),
-        sc2,
+        &sc2,
         array::from_fn(|i| C2Scalar::from_u128(i as u128)),
         NonZeroUsize::new(1).unwrap(),
     )

--- a/examples/trivial/main.rs
+++ b/examples/trivial/main.rs
@@ -116,9 +116,9 @@ fn main() {
     debug!("start ivc");
     IVC::fold_with_debug_mode(
         &pp,
-        sc1,
+        &sc1,
         array::from_fn(|i| C1Scalar::from_u128(i as u128)),
-        sc2,
+        &sc2,
         array::from_fn(|i| C2Scalar::from_u128(i as u128)),
         NonZeroUsize::new(5).unwrap(),
     )


### PR DESCRIPTION
**Motivation**
Our API should allow step-circuit to be changed between rounds of folding. As part of #285, we will change the private input (merkle-tree leaves changing) at each iteration of folding

**Overview**
It's just that now IVC is taking the step circuit from the ref
