### PR TITLE
feat: migrate to halo2-scroll

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ rev = "807f8f555313f726ca03bdf941f798098f488ba4"
 
 [dependencies.halo2_proofs]
 git = "https://github.com/snarkify/halo2"
-branch = "snarkify/dev.alpha.2"
+branch = "snarkify/dev.scroll"
 
 [dev-dependencies]
 bincode = "1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,6 @@ bincode = "1.3"
 bitter = "0.7.0"
 count-to-non-zero = "0.3.0"
 digest = "0.10"
-ff = "0.13"
-group = "0.13"
 itertools = "0.13.0"
 num-bigint = "0.4.3"
 num-traits = "0.2.16"
@@ -43,13 +41,9 @@ tracing = { version = "0.1.40", features = ["attributes"] }
 git = "https://github.com/privacy-scaling-explorations/poseidon"
 rev = "807f8f555313f726ca03bdf941f798098f488ba4"
 
-[dependencies.halo2curves]
-git = "https://github.com/privacy-scaling-explorations/halo2curves"
-features = ["derive_serde"]
-
 [dependencies.halo2_proofs]
 git = "https://github.com/snarkify/halo2"
-branch = "snarkify/dev"
+branch = "snarkify/dev.alpha.2"
 
 [dev-dependencies]
 bincode = "1.3"

--- a/benches/poseidon/main.rs
+++ b/benches/poseidon/main.rs
@@ -1,21 +1,18 @@
 use std::{array, io, marker::PhantomData, num::NonZeroUsize, path::Path};
 
-use criterion::{black_box, criterion_group, Criterion};
-use ff::{Field, FromUniformBytes, PrimeFieldBits};
-
-use halo2curves::{bn256, grumpkin, CurveAffine, CurveExt};
-
-use metadata::LevelFilter;
-
 use bn256::G1 as C1;
+use criterion::{black_box, criterion_group, Criterion};
 use grumpkin::G1 as C2;
-
-use halo2_proofs::{
-    circuit::{AssignedCell, Layouter},
-    plonk::ConstraintSystem,
-};
+use metadata::LevelFilter;
 use sirius::{
     commitment::CommitmentKey,
+    ff::{Field, FromUniformBytes, PrimeFieldBits},
+    group::{prime::PrimeCurve, Group},
+    halo2_proofs::{
+        circuit::{AssignedCell, Layouter},
+        plonk::ConstraintSystem,
+    },
+    halo2curves::{bn256, grumpkin, CurveAffine, CurveExt},
     ivc::{step_circuit, CircuitPublicParamsInput, PublicParams, StepCircuit, SynthesisError, IVC},
     main_gate::{MainGate, MainGateConfig, RegionCtx, WrapValue},
     poseidon::{self, poseidon_circuit::PoseidonChip, ROPair, Spec},
@@ -87,11 +84,11 @@ type RandomOracleConstant<F> = <RandomOracle as ROPair<F>>::Args;
 const LIMB_WIDTH: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(32) };
 const LIMBS_COUNT: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(10) };
 
-type C1Affine = <C1 as halo2curves::group::prime::PrimeCurve>::Affine;
-type C2Affine = <C2 as halo2curves::group::prime::PrimeCurve>::Affine;
+type C1Affine = <C1 as PrimeCurve>::Affine;
+type C2Affine = <C2 as PrimeCurve>::Affine;
 
-type C1Scalar = <C1 as halo2curves::group::Group>::Scalar;
-type C2Scalar = <C2 as halo2curves::group::Group>::Scalar;
+type C1Scalar = <C1 as Group>::Scalar;
+type C2Scalar = <C2 as Group>::Scalar;
 
 const FOLDER: &str = ".cache/examples";
 

--- a/benches/trivial/main.rs
+++ b/benches/trivial/main.rs
@@ -2,17 +2,15 @@
 
 use std::{array, io, num::NonZeroUsize, path::Path};
 
-use criterion::{black_box, criterion_group, Criterion};
-use ff::Field;
-
-use halo2curves::{bn256, grumpkin, CurveAffine, CurveExt};
-
 use bn256::G1 as C1;
+use criterion::{black_box, criterion_group, Criterion};
 use grumpkin::G1 as C2;
-
 use metadata::LevelFilter;
 use sirius::{
     commitment::CommitmentKey,
+    ff::Field,
+    group::{prime::PrimeCurve, Group},
+    halo2curves::{bn256, grumpkin, CurveAffine, CurveExt},
     ivc::{step_circuit, CircuitPublicParamsInput, PublicParams, IVC},
     poseidon::{self, ROPair},
 };
@@ -36,11 +34,11 @@ type RandomOracleConstant<F> = <RandomOracle as ROPair<F>>::Args;
 const LIMB_WIDTH: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(32) };
 const LIMBS_COUNT_LIMIT: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(10) };
 
-type C1Affine = <C1 as halo2curves::group::prime::PrimeCurve>::Affine;
-type C2Affine = <C2 as halo2curves::group::prime::PrimeCurve>::Affine;
+type C1Affine = <C1 as PrimeCurve>::Affine;
+type C2Affine = <C2 as PrimeCurve>::Affine;
 
-type C1Scalar = <C1 as halo2curves::group::Group>::Scalar;
-type C2Scalar = <C2 as halo2curves::group::Group>::Scalar;
+type C1Scalar = <C1 as Group>::Scalar;
+type C2Scalar = <C2 as Group>::Scalar;
 
 const FOLDER: &str = ".cache/examples";
 

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -9,9 +9,10 @@ use clap::{Parser, ValueEnum};
 #[allow(dead_code)]
 mod poseidon;
 
-use ff::Field;
+use halo2_proofs::arithmetic::Field;
 use poseidon::poseidon_step_circuit::TestPoseidonCircuit;
 use sirius::{
+    group::{prime::PrimeCurve, Group},
     ivc::{step_circuit::trivial, CircuitPublicParamsInput, PublicParams, StepCircuit, IVC},
     poseidon::ROPair,
 };
@@ -63,10 +64,9 @@ enum Circuits {
     Trivial,
 }
 
-use halo2curves::{bn256, grumpkin};
-
 use bn256::G1 as C1;
 use grumpkin::G1 as C2;
+use sirius::halo2curves::{bn256, grumpkin};
 
 const MAIN_GATE_SIZE: usize = 5;
 const RATE: usize = 4;
@@ -74,11 +74,11 @@ const RATE: usize = 4;
 type RandomOracle = sirius::poseidon::PoseidonRO<MAIN_GATE_SIZE, RATE>;
 type RandomOracleConstant<F> = <RandomOracle as ROPair<F>>::Args;
 
-type C1Affine = <C1 as halo2curves::group::prime::PrimeCurve>::Affine;
-type C1Scalar = <C1 as halo2curves::group::Group>::Scalar;
+type C1Affine = <C1 as PrimeCurve>::Affine;
+type C1Scalar = <C1 as Group>::Scalar;
 
-type C2Affine = <C2 as halo2curves::group::prime::PrimeCurve>::Affine;
-type C2Scalar = <C2 as halo2curves::group::Group>::Scalar;
+type C2Affine = <C2 as PrimeCurve>::Affine;
+type C2Scalar = <C2 as Group>::Scalar;
 
 fn fold(
     args: &Args,

--- a/examples/poseidon.rs
+++ b/examples/poseidon.rs
@@ -2,13 +2,12 @@
 pub mod poseidon_step_circuit {
     use std::marker::PhantomData;
 
-    use ff::{FromUniformBytes, PrimeFieldBits};
-
     use halo2_proofs::{
         circuit::{AssignedCell, Layouter},
         plonk::ConstraintSystem,
     };
     use sirius::{
+        ff::{FromUniformBytes, PrimeFieldBits},
         ivc::{StepCircuit, SynthesisError},
         main_gate::{MainGate, MainGateConfig, RegionCtx, WrapValue},
         poseidon::{poseidon_circuit::PoseidonChip, Spec},
@@ -121,17 +120,13 @@ pub mod poseidon_step_circuit {
 
 use std::{array, env, io, num::NonZeroUsize, path::Path};
 
-use ff::PrimeField;
-
-use halo2curves::{bn256, grumpkin, CurveAffine};
-
-use metadata::LevelFilter;
-
 use bn256::G1 as C1;
 use grumpkin::G1 as C2;
-
+use metadata::LevelFilter;
 use sirius::{
     commitment::CommitmentKey,
+    group::{prime::PrimeCurve, Group},
+    halo2curves::{bn256, grumpkin, CurveAffine},
     ivc::{step_circuit, CircuitPublicParamsInput, PublicParams, IVC},
     poseidon::{self, ROPair},
 };
@@ -160,11 +155,11 @@ const LIMB_WIDTH: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(32) };
 /// Inside the IVC, big-uint math is used, these parameters define maximum count of limbs
 const LIMBS_COUNT: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(10) };
 
-type C1Affine = <C1 as halo2curves::group::prime::PrimeCurve>::Affine;
-type C1Scalar = <C1 as halo2curves::group::Group>::Scalar;
+type C1Affine = <C1 as PrimeCurve>::Affine;
+type C1Scalar = <C1 as Group>::Scalar;
 
-type C2Affine = <C2 as halo2curves::group::prime::PrimeCurve>::Affine;
-type C2Scalar = <C2 as halo2curves::group::Group>::Scalar;
+type C2Affine = <C2 as PrimeCurve>::Affine;
+type C2Scalar = <C2 as Group>::Scalar;
 
 /// Either takes the key from [`CACHE_FOLDER`] or generates a new one and puts it in it
 #[instrument]
@@ -247,8 +242,8 @@ fn main() {
     )
     .unwrap();
 
-    let primary_input = array::from_fn(|i| C1Scalar::from_u128(i as u128));
-    let secondary_input = array::from_fn(|i| C2Scalar::from_u128(i as u128));
+    let primary_input = array::from_fn(|i| C1Scalar::from(i as u64));
+    let secondary_input = array::from_fn(|i| C2Scalar::from(i as u64));
     let fold_step_count = NonZeroUsize::new(10).unwrap();
 
     IVC::fold(

--- a/examples/sha256/main.rs
+++ b/examples/sha256/main.rs
@@ -2,19 +2,17 @@
 
 use std::{array, io, iter, marker::PhantomData, num::NonZeroUsize, path::Path};
 
-use ff::PrimeField;
+use bn256::G1 as C1;
+use grumpkin::G1 as C2;
 use halo2_proofs::{
     circuit::{AssignedCell, Layouter, Value},
     plonk::ConstraintSystem,
 };
-
-use halo2curves::{bn256, grumpkin, CurveAffine, CurveExt};
-
-use bn256::G1 as C1;
-use grumpkin::G1 as C2;
-
 use sirius::{
     commitment::CommitmentKey,
+    ff::PrimeField,
+    group::{prime::PrimeCurve, Group},
+    halo2curves::{bn256, grumpkin, CurveAffine, CurveExt},
     ivc::{step_circuit, CircuitPublicParamsInput, PublicParams, StepCircuit, SynthesisError, IVC},
     poseidon::{self, ROPair},
 };
@@ -333,11 +331,11 @@ type RandomOracleConstant<F> = <RandomOracle as ROPair<F>>::Args;
 const LIMB_WIDTH: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(32) };
 const LIMBS_COUNT: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(10) };
 
-type C1Affine = <C1 as halo2curves::group::prime::PrimeCurve>::Affine;
-type C2Affine = <C2 as halo2curves::group::prime::PrimeCurve>::Affine;
+type C1Affine = <C1 as PrimeCurve>::Affine;
+type C2Affine = <C2 as PrimeCurve>::Affine;
 
-type C1Scalar = <C1 as halo2curves::group::Group>::Scalar;
-type C2Scalar = <C2 as halo2curves::group::Group>::Scalar;
+type C1Scalar = <C1 as Group>::Scalar;
+type C2Scalar = <C2 as Group>::Scalar;
 
 const FOLDER: &str = ".cache/examples";
 

--- a/examples/sha256/table16/compression.rs
+++ b/examples/sha256/table16/compression.rs
@@ -1,12 +1,11 @@
-use std::convert::TryInto;
-use std::ops::Range;
+use std::{convert::TryInto, ops::Range};
 
-use ff::PrimeField;
 use halo2_proofs::{
     circuit::{Layouter, Value},
     plonk::{Advice, Column, ConstraintSystem, Error, Selector},
     poly::Rotation,
 };
+use sirius::ff::PrimeField;
 
 use super::{
     util::{i2lebsp, lebs2ip},
@@ -82,7 +81,7 @@ pub trait UpperSigmaVar<
 ///   We align the columns to make it efficient to copy-constrain these forms where they
 ///   are needed.
 #[derive(Clone, Debug)]
-pub struct AbcdVar<F: ff::PrimeField> {
+pub struct AbcdVar<F: PrimeField> {
     a: SpreadVar<F, 2, 4>,
     b: SpreadVar<F, 11, 22>,
     c_lo: SpreadVar<F, 3, 6>,
@@ -951,9 +950,8 @@ impl CompressionConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::super::{
-        super::BLOCK_SIZE, msg_schedule_test_input, BlockWord, Table16Chip, Table16Config, IV,
-    };
+    use std::marker::PhantomData;
+
     use ff::PrimeField;
     use halo2_proofs::{
         circuit::{Layouter, SimpleFloorPlanner},
@@ -962,7 +960,10 @@ mod tests {
     };
     use halo2curves::pasta::{pallas, Fp};
     use sirius::run_mock_prover_test;
-    use std::marker::PhantomData;
+
+    use super::super::{
+        super::BLOCK_SIZE, msg_schedule_test_input, BlockWord, Table16Chip, Table16Config, IV,
+    };
 
     #[traced_test]
     #[test]

--- a/examples/sha256/table16/compression/compression_gates.rs
+++ b/examples/sha256/table16/compression/compression_gates.rs
@@ -1,7 +1,9 @@
-use super::super::{util::*, Gate};
-use ff::PrimeField;
-use halo2_proofs::plonk::{Constraint, Constraints, Expression};
 use std::marker::PhantomData;
+
+use halo2_proofs::plonk::{Constraint, Constraints, Expression};
+use sirius::ff::PrimeField;
+
+use super::super::{util::*, Gate};
 
 pub struct CompressionGate<F: PrimeField>(PhantomData<F>);
 

--- a/examples/sha256/table16/compression/compression_util.rs
+++ b/examples/sha256/table16/compression/compression_util.rs
@@ -1,14 +1,16 @@
+use std::convert::TryInto;
+
+use halo2_proofs::{
+    circuit::{Region, Value},
+    plonk::{Advice, Column, Error},
+};
+use sirius::ff::PrimeField;
+
 use super::{
     AbcdVar, CompressionConfig, EfghVar, RoundWord, RoundWordA, RoundWordDense, RoundWordE,
     RoundWordSpread, State, UpperSigmaVar,
 };
 use crate::table16::{util::*, AssignedBits, SpreadVar, SpreadWord, StateWord, Table16Assignment};
-use ff::PrimeField;
-use halo2_proofs::{
-    circuit::{Region, Value},
-    plonk::{Advice, Column, Error},
-};
-use std::convert::TryInto;
 
 // Test vector 'abc'
 #[cfg(test)]

--- a/examples/sha256/table16/compression/subregion_digest.rs
+++ b/examples/sha256/table16/compression/subregion_digest.rs
@@ -1,16 +1,15 @@
-use ff::PrimeField;
 use halo2_proofs::{
     circuit::{Region, Value},
     plonk::{Advice, Column, Error},
 };
-
-use crate::AssignedCell;
+use sirius::ff::PrimeField;
 
 use super::{
     super::{BlockWord, RoundWordDense},
-    {compression_util::*, CompressionConfig, State},
+    compression_util::*,
+    CompressionConfig, State,
 };
-use crate::DIGEST_SIZE;
+use crate::{AssignedCell, DIGEST_SIZE};
 
 impl CompressionConfig {
     #[allow(clippy::many_single_char_names)]

--- a/examples/sha256/table16/compression/subregion_initial.rs
+++ b/examples/sha256/table16/compression/subregion_initial.rs
@@ -1,10 +1,13 @@
-use super::super::{RoundWord, StateWord, STATE};
-use super::{compression_util::*, CompressionConfig, State};
-
-use ff::PrimeField;
 use halo2_proofs::{
     circuit::{Region, Value},
     plonk::Error,
+};
+use sirius::ff::PrimeField;
+
+use super::{
+    super::{RoundWord, StateWord, STATE},
+    compression_util::*,
+    CompressionConfig, State,
 };
 
 impl CompressionConfig {

--- a/examples/sha256/table16/compression/subregion_main.rs
+++ b/examples/sha256/table16/compression/subregion_main.rs
@@ -1,10 +1,15 @@
-use super::super::{AssignedBits, RoundWord, RoundWordA, RoundWordE, StateWord, ROUND_CONSTANTS};
-use super::{compression_util::*, CompressionConfig, State};
 use halo2_proofs::{circuit::Region, plonk::Error};
+use sirius::ff::PrimeField;
+
+use super::{
+    super::{AssignedBits, RoundWord, RoundWordA, RoundWordE, StateWord, ROUND_CONSTANTS},
+    compression_util::*,
+    CompressionConfig, State,
+};
 
 impl CompressionConfig {
     #[allow(clippy::many_single_char_names)]
-    pub fn assign_round<F: ff::PrimeField>(
+    pub fn assign_round<F: PrimeField>(
         &self,
         region: &mut Region<'_, F>,
         round_idx: MainRoundIdx,

--- a/examples/sha256/table16/gates.rs
+++ b/examples/sha256/table16/gates.rs
@@ -1,5 +1,5 @@
-use ff::PrimeField;
 use halo2_proofs::{arithmetic::Field, plonk::Expression};
+use sirius::ff::PrimeField;
 
 pub struct Gate<F: Field>(pub Expression<F>);
 

--- a/examples/sha256/table16/message_schedule.rs
+++ b/examples/sha256/table16/message_schedule.rs
@@ -1,14 +1,14 @@
 use std::convert::TryInto;
 
-use crate::BlockWord;
-
-use super::{super::BLOCK_SIZE, AssignedBits, SpreadInputs, Table16Assignment, ROUNDS};
-use ff::PrimeField;
 use halo2_proofs::{
     circuit::Layouter,
     plonk::{Advice, Column, ConstraintSystem, Error, Selector},
     poly::Rotation,
 };
+use sirius::ff::PrimeField;
+
+use super::{super::BLOCK_SIZE, AssignedBits, SpreadInputs, Table16Assignment, ROUNDS};
+use crate::BlockWord;
 
 mod schedule_gates;
 mod schedule_util;
@@ -17,10 +17,9 @@ mod subregion2;
 mod subregion3;
 
 use schedule_gates::ScheduleGate;
-use schedule_util::*;
-
 #[cfg(test)]
 pub use schedule_util::msg_schedule_test_input;
+use schedule_util::*;
 
 #[derive(Clone, Debug)]
 pub(super) struct MessageWord<F: PrimeField>(pub AssignedBits<F, 32>);
@@ -395,10 +394,8 @@ impl MessageScheduleConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::super::{
-        super::BLOCK_SIZE, util::lebs2ip, BlockWord, SpreadTableChip, Table16Chip, Table16Config,
-    };
-    use super::schedule_util::*;
+    use std::marker::PhantomData;
+
     use ff::PrimeField;
     use halo2_proofs::{
         circuit::{Layouter, SimpleFloorPlanner},
@@ -407,7 +404,14 @@ mod tests {
     };
     use halo2curves::pasta::pallas;
     use sirius::run_mock_prover_test;
-    use std::marker::PhantomData;
+
+    use super::{
+        super::{
+            super::BLOCK_SIZE, util::lebs2ip, BlockWord, SpreadTableChip, Table16Chip,
+            Table16Config,
+        },
+        schedule_util::*,
+    };
 
     #[traced_test]
     #[test]

--- a/examples/sha256/table16/message_schedule/schedule_gates.rs
+++ b/examples/sha256/table16/message_schedule/schedule_gates.rs
@@ -1,7 +1,9 @@
-use super::super::Gate;
-use ff::PrimeField;
-use halo2_proofs::plonk::Expression;
 use std::marker::PhantomData;
+
+use halo2_proofs::plonk::Expression;
+use sirius::ff::PrimeField;
+
+use super::super::Gate;
 
 pub struct ScheduleGate<F: PrimeField>(PhantomData<F>);
 

--- a/examples/sha256/table16/message_schedule/schedule_util.rs
+++ b/examples/sha256/table16/message_schedule/schedule_util.rs
@@ -4,6 +4,7 @@ use halo2_proofs::{
     circuit::{Region, Value},
     plonk::Error,
 };
+use sirius::ff::PrimeField;
 
 #[cfg(test)]
 use super::super::{super::BLOCK_SIZE, BlockWord, ROUNDS};
@@ -147,7 +148,7 @@ pub const MSG_SCHEDULE_TEST_OUTPUT: [u32; ROUNDS] = [
 impl MessageScheduleConfig {
     // Assign a word and its hi and lo halves
     #[allow(clippy::type_complexity)]
-    pub fn assign_word_and_halves<F: ff::PrimeField>(
+    pub fn assign_word_and_halves<F: PrimeField>(
         &self,
         region: &mut Region<'_, F>,
         word: Value<u32>,

--- a/examples/sha256/table16/message_schedule/subregion1.rs
+++ b/examples/sha256/table16/message_schedule/subregion1.rs
@@ -1,11 +1,16 @@
-use super::super::{util::*, AssignedBits, BlockWord, SpreadVar, SpreadWord, Table16Assignment};
-use super::{schedule_util::*, MessageScheduleConfig};
-use ff::PrimeField;
+use std::convert::TryInto;
+
 use halo2_proofs::{
     circuit::{Region, Value},
     plonk::Error,
 };
-use std::convert::TryInto;
+use sirius::ff::PrimeField;
+
+use super::{
+    super::{util::*, AssignedBits, BlockWord, SpreadVar, SpreadWord, Table16Assignment},
+    schedule_util::*,
+    MessageScheduleConfig,
+};
 
 // A word in subregion 1
 // (3, 4, 11, 14)-bit chunks

--- a/examples/sha256/table16/message_schedule/subregion2.rs
+++ b/examples/sha256/table16/message_schedule/subregion2.rs
@@ -1,11 +1,16 @@
-use super::super::{util::*, AssignedBits, Bits, SpreadVar, SpreadWord, Table16Assignment};
-use super::{schedule_util::*, MessageScheduleConfig, MessageWord};
-use ff::PrimeField;
+use std::convert::TryInto;
+
 use halo2_proofs::{
     circuit::{Region, Value},
     plonk::Error,
 };
-use std::convert::TryInto;
+use sirius::ff::PrimeField;
+
+use super::{
+    super::{util::*, AssignedBits, Bits, SpreadVar, SpreadWord, Table16Assignment},
+    schedule_util::*,
+    MessageScheduleConfig, MessageWord,
+};
 
 /// A word in subregion 2
 /// (3, 4, 3, 7, 1, 1, 13)-bit chunks

--- a/examples/sha256/table16/message_schedule/subregion3.rs
+++ b/examples/sha256/table16/message_schedule/subregion3.rs
@@ -1,11 +1,16 @@
-use super::super::{util::*, AssignedBits, Bits, SpreadVar, SpreadWord, Table16Assignment};
-use super::{schedule_util::*, MessageScheduleConfig, MessageWord};
-use ff::PrimeField;
+use std::convert::TryInto;
+
 use halo2_proofs::{
     circuit::{Region, Value},
     plonk::Error,
 };
-use std::convert::TryInto;
+use sirius::ff::PrimeField;
+
+use super::{
+    super::{util::*, AssignedBits, Bits, SpreadVar, SpreadWord, Table16Assignment},
+    schedule_util::*,
+    MessageScheduleConfig, MessageWord,
+};
 
 // A word in subregion 3
 // (10, 7, 2, 13)-bit chunks

--- a/examples/sha256/table16/mod.rs
+++ b/examples/sha256/table16/mod.rs
@@ -2,11 +2,11 @@ use std::convert::TryInto;
 use std::marker::PhantomData;
 
 use super::sha256::Sha256Instructions;
-use ff::PrimeField;
 use halo2_proofs::{
     circuit::{AssignedCell, Chip, Layouter, Region, Value},
     plonk::{Advice, Any, Assigned, Column, ConstraintSystem, Error},
 };
+use sirius::ff::PrimeField;
 
 mod compression;
 mod gates;

--- a/examples/sha256/table16/spread_table.rs
+++ b/examples/sha256/table16/spread_table.rs
@@ -1,14 +1,14 @@
-use std::convert::TryInto;
+use std::{convert::TryInto, marker::PhantomData};
 
-use super::{util::*, AssignedBits};
-use ff::PrimeField;
 use halo2_proofs::{
     arithmetic::Field,
     circuit::{Chip, Layouter, Region, Value},
     plonk::{Advice, Column, ConstraintSystem, Error, TableColumn},
     poly::Rotation,
 };
-use std::marker::PhantomData;
+use sirius::ff::PrimeField;
+
+use super::{util::*, AssignedBits};
 
 const BITS_7: usize = 1 << 7;
 const BITS_10: usize = 1 << 10;
@@ -287,18 +287,19 @@ impl SpreadTableConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::{get_tag, SpreadTableChip, SpreadTableConfig};
-    use ff::PrimeField;
-    use rand::Rng;
     use std::marker::PhantomData;
 
+    use ff::PrimeField;
     use halo2_proofs::{
         circuit::{Layouter, SimpleFloorPlanner, Value},
         dev::MockProver,
         plonk::{Advice, Circuit, Column, ConstraintSystem, Error},
     };
     use halo2curves::pasta::Fp;
+    use rand::Rng;
     use sirius::run_mock_prover_test;
+
+    use super::{get_tag, SpreadTableChip, SpreadTableConfig};
 
     #[traced_test]
     #[test]

--- a/examples/trivial/main.rs
+++ b/examples/trivial/main.rs
@@ -2,20 +2,18 @@
 
 use std::{array, env, io, num::NonZeroUsize, path::Path};
 
-use ff::PrimeField;
-use halo2curves::{bn256, grumpkin, CurveAffine, CurveExt};
-use metadata::LevelFilter;
-use tracing::*;
-use tracing_subscriber::{fmt::format::FmtSpan, EnvFilter};
-
 use bn256::G1 as C1;
 use grumpkin::G1 as C2;
-
+use metadata::LevelFilter;
 use sirius::{
     commitment::CommitmentKey,
+    group::{prime::PrimeCurve, Group},
+    halo2curves::{bn256, grumpkin, CurveAffine, CurveExt},
     ivc::{step_circuit, CircuitPublicParamsInput, PublicParams, IVC},
     poseidon::{self, ROPair},
 };
+use tracing::*;
+use tracing_subscriber::{fmt::format::FmtSpan, EnvFilter};
 
 const ARITY: usize = BLOCK_SIZE / 2;
 const BLOCK_SIZE: usize = 16;
@@ -33,11 +31,11 @@ type RandomOracleConstant<F> = <RandomOracle as ROPair<F>>::Args;
 const LIMB_WIDTH: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(32) };
 const LIMBS_COUNT_LIMIT: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(10) };
 
-type C1Affine = <C1 as halo2curves::group::prime::PrimeCurve>::Affine;
-type C2Affine = <C2 as halo2curves::group::prime::PrimeCurve>::Affine;
+type C1Affine = <C1 as PrimeCurve>::Affine;
+type C2Affine = <C2 as PrimeCurve>::Affine;
 
-type C1Scalar = <C1 as halo2curves::group::Group>::Scalar;
-type C2Scalar = <C2 as halo2curves::group::Group>::Scalar;
+type C1Scalar = <C1 as Group>::Scalar;
+type C2Scalar = <C2 as Group>::Scalar;
 
 const FOLDER: &str = ".cache/examples";
 
@@ -117,9 +115,9 @@ fn main() {
     IVC::fold_with_debug_mode(
         &pp,
         &sc1,
-        array::from_fn(|i| C1Scalar::from_u128(i as u128)),
+        array::from_fn(|i| C1Scalar::from(i as u64)),
         &sc2,
-        array::from_fn(|i| C2Scalar::from_u128(i as u128)),
+        array::from_fn(|i| C2Scalar::from(i as u64)),
         NonZeroUsize::new(5).unwrap(),
     )
     .unwrap();

--- a/src/commitment.rs
+++ b/src/commitment.rs
@@ -8,7 +8,6 @@ use std::{
 };
 
 use digest::{ExtendableOutput, Update};
-use group::Curve;
 use halo2_proofs::arithmetic::{best_multiexp, CurveAffine, CurveExt};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -16,7 +15,7 @@ use sha3::Shake256;
 use some_to_err::*;
 use tracing::*;
 
-use crate::util::parallelize;
+use crate::{group::Curve, util::parallelize};
 
 #[derive(Debug, PartialEq, Eq, thiserror::Error)]
 pub enum Error {
@@ -170,11 +169,11 @@ impl<C: CurveAffine> CommitmentKey<C> {
 
 #[cfg(test)]
 mod file_tests {
-    use halo2curves::bn256::G1Affine;
     use tempfile::tempdir;
     use tracing_test::traced_test;
 
     use super::*;
+    use crate::halo2curves::bn256::G1Affine;
 
     #[traced_test]
     #[test]

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -2,17 +2,17 @@ use std::{io, iter, num::NonZeroUsize};
 
 use bincode::Options;
 use bitter::{BitReader, LittleEndianReader};
+pub use digest::Digest;
 use digest::{typenum::U32, OutputSizeUser};
-use ff::{Field, PrimeField};
-use halo2curves::CurveAffine;
 use serde::Serialize;
+pub use sha3::Sha3_256 as DefaultHasher;
 use tracing::*;
 
-pub use digest::Digest;
-
-pub use sha3::Sha3_256 as DefaultHasher;
-
-use crate::constants::NUM_HASH_BITS;
+use crate::{
+    constants::NUM_HASH_BITS,
+    ff::{Field, PrimeField},
+    halo2curves::CurveAffine,
+};
 
 pub trait DigestToBits: Digest {
     #[instrument(skip_all)]
@@ -86,12 +86,14 @@ pub fn into_curve_from_bits<C: CurveAffine>(input: &[u8], bits_count: NonZeroUsi
 mod tests {
     use std::num::NonZeroUsize;
 
-    use ff::PrimeField;
-    use halo2curves::bn256::{Fr, G1Affine};
     use serde::*;
     use tracing_test::traced_test;
 
     use super::{into_curve_from_bits, DigestToCurve};
+    use crate::{
+        ff::PrimeField,
+        halo2curves::bn256::{Fr, G1Affine},
+    };
 
     #[traced_test]
     #[test]

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -1,8 +1,10 @@
-use ff::{Field, PrimeField};
-use group::{ff::WithSmallOrderMulGroup, GroupOpsOwned, ScalarMulOwned};
-pub use halo2curves::{CurveAffine, CurveExt};
-
-use crate::{polynomial::univariate::UnivariatePoly, util};
+pub use crate::halo2curves::{CurveAffine, CurveExt};
+use crate::{
+    ff::{Field, PrimeField},
+    group::{ff::WithSmallOrderMulGroup, GroupOpsOwned, ScalarMulOwned},
+    polynomial::univariate::UnivariatePoly,
+    util,
+};
 
 /// Given FFT domain size k, return the omega in case of fft
 /// or return the omega_inv in case if ifft
@@ -227,11 +229,11 @@ fn distribute_powers_zeta<F: PrimeField>(
 mod tests {
     use std::array;
 
-    use halo2curves::bn256::Fr;
     use itertools::Itertools;
     use rand_core::OsRng;
 
     use super::*;
+    use crate::halo2curves::bn256::Fr;
 
     #[test]
     fn fft_simple_input_test() {

--- a/src/gadgets/ecc.rs
+++ b/src/gadgets/ecc.rs
@@ -25,8 +25,8 @@ impl<C: CurveAffine> AssignedPoint<C> {
     }
 
     pub fn coordinates_values(&self) -> Option<(C::Base, C::Base)> {
-        let x = *self.x.value().copied().unwrap();
-        let y = *self.y.value().copied().unwrap();
+        let x = self.x.value().copied().unwrap();
+        let y = self.y.value().copied().unwrap();
 
         Some((x?, y?))
     }

--- a/src/gadgets/ecc.rs
+++ b/src/gadgets/ecc.rs
@@ -1,12 +1,16 @@
-use crate::main_gate::{AssignedValue, MainGate, MainGateConfig, RegionCtx};
-use ff::PrimeFieldBits;
+use std::cmp;
+
 use halo2_proofs::{
     arithmetic::CurveAffine,
     circuit::{Chip, Value},
     plonk::Error,
 };
-use std::cmp;
 use tracing::*;
+
+use crate::{
+    ff::PrimeFieldBits,
+    main_gate::{AssignedValue, MainGate, MainGateConfig, RegionCtx},
+};
 
 // assume point is not infinity
 #[derive(Clone, Debug)]
@@ -379,18 +383,21 @@ impl<C: CurveAffine<Base = F>, F: PrimeFieldBits, const T: usize> EccChip<C, F, 
 mod tests {
     use std::num::NonZeroUsize;
 
-    use ff::Field;
     use halo2_proofs::{
         circuit::{Layouter, SimpleFloorPlanner},
         plonk::{Circuit, Column, ConstraintSystem, Instance},
     };
-    use halo2curves::pasta::{pallas, EqAffine, Fp, Fq};
     use rand_core::OsRng;
     use tracing_test::traced_test;
 
-    use crate::{create_and_verify_proof, run_mock_prover_test, util::fe_to_fe_safe};
-
     use super::*;
+    use crate::{
+        create_and_verify_proof,
+        ff::Field,
+        halo2curves::pasta::{pallas, EqAffine, Fp, Fq},
+        run_mock_prover_test,
+        util::fe_to_fe_safe,
+    };
 
     #[derive(Clone, Debug)]
     struct Point<C: CurveAffine> {

--- a/src/gadgets/nonnative/bn/big_uint.rs
+++ b/src/gadgets/nonnative/bn/big_uint.rs
@@ -132,7 +132,7 @@ impl<F: PrimeField> BigUint<F> {
 
         let limbs = input
             .iter()
-            .map(|cell| *cell.value().map(|v| *v).unwrap())
+            .map(|cell| cell.value().map(|v| *v).unwrap())
             .map(|fv| {
                 if let Some(fv) = fv {
                     let repr_len = fv.to_repr().as_ref().len();

--- a/src/gadgets/nonnative/bn/big_uint.rs
+++ b/src/gadgets/nonnative/bn/big_uint.rs
@@ -1,6 +1,5 @@
 use std::{io, iter, num::NonZeroUsize, ops::Not};
 
-use ff::PrimeField;
 use halo2_proofs::{
     circuit::{AssignedCell, Value},
     plonk::{Advice, Column},
@@ -9,7 +8,7 @@ use num_bigint::BigUint as BigUintRaw;
 use num_traits::{identities::One, Zero};
 use tracing::*;
 
-use crate::{error::Halo2PlonkError, main_gate::RegionCtx};
+use crate::{error::Halo2PlonkError, ff::PrimeField, main_gate::RegionCtx};
 
 // A big natural number with limbs in field `F`
 //
@@ -70,7 +69,7 @@ pub enum Error {
     LimbNotFound { limb_index: usize },
 }
 
-impl<F: ff::PrimeField> BigUint<F> {
+impl<F: PrimeField> BigUint<F> {
     pub fn from_limbs(
         mut limbs_input: impl Iterator<Item = F>,
         limb_width: NonZeroUsize,
@@ -267,7 +266,7 @@ impl<F: ff::PrimeField> BigUint<F> {
     }
 }
 
-pub fn nat_to_f<Scalar: ff::PrimeField>(n: &num_bigint::BigUint) -> Option<Scalar> {
+pub fn nat_to_f<Scalar: PrimeField>(n: &num_bigint::BigUint) -> Option<Scalar> {
     Scalar::from_str_vartime(&format!("{n}"))
 }
 
@@ -301,11 +300,10 @@ fn get_max_word_mask_bits(limb_width: usize) -> usize {
 mod tests {
     use std::mem;
 
-    use ff::Field;
-    use halo2curves::pasta::Fp;
     use tracing_test::traced_test;
 
     use super::*;
+    use crate::{ff::Field, halo2curves::pasta::Fp};
 
     #[traced_test]
     #[test]

--- a/src/gadgets/nonnative/bn/big_uint_mul_mod_chip/mod.rs
+++ b/src/gadgets/nonnative/bn/big_uint_mul_mod_chip/mod.rs
@@ -1,24 +1,22 @@
 use std::{
     cmp, fmt, iter,
     num::NonZeroUsize,
-    ops::{Add, Div, Mul, Sub},
-    ops::{Deref, Not},
+    ops::{Add, Deref, Div, Mul, Not, Sub},
 };
 
 use bitter::{BitReader, LittleEndianReader};
-use ff::PrimeField;
 use halo2_proofs::circuit::{AssignedCell, Chip, Value};
 use itertools::{EitherOrBoth, Itertools};
 use num_bigint::BigUint as BigUintRaw;
 use num_traits::{One, ToPrimitive, Zero};
 use tracing::*;
 
+use super::big_uint::{self, BigUint};
 use crate::{
+    ff::{PrimeField, PrimeFieldBits},
     main_gate::{AssignAdviceFrom, MainGate, MainGateConfig, RegionCtx},
     util,
 };
-
-use super::big_uint::{self, BigUint};
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -47,13 +45,13 @@ pub const MAIN_GATE_T: usize = 4;
 
 /// Multiplication of two large natural numbers by mod
 #[derive(Debug)]
-pub struct BigUintMulModChip<F: ff::PrimeField> {
+pub struct BigUintMulModChip<F: PrimeField> {
     main_gate: MainGate<F, MAIN_GATE_T>,
     limb_width: NonZeroUsize,
     limbs_count: NonZeroUsize,
 }
 
-impl<F: ff::PrimeField> BigUintMulModChip<F> {
+impl<F: PrimeField> BigUintMulModChip<F> {
     pub fn new(
         config: <Self as Chip<F>>::Config,
         limb_width: NonZeroUsize,
@@ -947,12 +945,12 @@ impl<F: ff::PrimeField> BigUintMulModChip<F> {
 }
 
 #[derive(Debug, Clone)]
-pub struct OverflowingBigUint<F: ff::PrimeField> {
+pub struct OverflowingBigUint<F: PrimeField> {
     pub cells: Vec<AssignedCell<F, F>>,
     pub max_word: F,
 }
 
-impl<F: ff::PrimeField> OverflowingBigUint<F> {
+impl<F: PrimeField> OverflowingBigUint<F> {
     pub fn new(cells: Vec<AssignedCell<F, F>>, limb_width: NonZeroUsize) -> Self {
         let max_word_without_overflow: F =
             big_uint::nat_to_f(&big_uint::get_big_int_with_n_ones(limb_width.get()))
@@ -965,7 +963,7 @@ impl<F: ff::PrimeField> OverflowingBigUint<F> {
     }
 }
 
-impl<F: ff::PrimeField> Deref for OverflowingBigUint<F> {
+impl<F: PrimeField> Deref for OverflowingBigUint<F> {
     type Target = [AssignedCell<F, F>];
     fn deref(&self) -> &Self::Target {
         self.cells.as_slice()
@@ -973,12 +971,12 @@ impl<F: ff::PrimeField> Deref for OverflowingBigUint<F> {
 }
 
 #[derive(Debug, Clone)]
-struct GroupedBigUint<F: ff::PrimeField> {
+struct GroupedBigUint<F: PrimeField> {
     cells: Vec<AssignedCell<F, F>>,
     max_word: F,
     limb_width: NonZeroUsize,
 }
-impl<F: ff::PrimeField> Deref for GroupedBigUint<F> {
+impl<F: PrimeField> Deref for GroupedBigUint<F> {
     type Target = [AssignedCell<F, F>];
     fn deref(&self) -> &Self::Target {
         self.cells.as_slice()
@@ -1010,13 +1008,15 @@ pub struct SumContext<F: PrimeField> {
     pub res: OverflowingBigUint<F>,
 }
 
-impl<F: ff::PrimeField> BigUintMulModChip<F> {
+impl<F: PrimeField> BigUintMulModChip<F> {
     /// Converts a single assigned cell to a list of limbs, according to the limb width and count limit.
     ///
     /// This function assigns to the region context, evaluated `AssignedCells` representing the limbs of the
     /// original `AssignedCell` in the `BigUint` representation.
     ///
     /// # Arguments
+    /// * `ctx`: Mutable reference to the `RegionCtx` provides the constraint system and metadata.
+    /// * `input`: A reference to the `AssignedCell` representing the input value.
     /// * `ctx`: Mutable reference to the `RegionCtx` provides the constraint system and metadata.
     /// * `input`: A reference to the `AssignedCell` representing the input value.
     ///
@@ -1369,7 +1369,7 @@ impl<F: ff::PrimeField> BigUintMulModChip<F> {
     }
 }
 
-impl<F: ff::PrimeFieldBits> BigUintMulModChip<F> {
+impl<F: PrimeFieldBits> BigUintMulModChip<F> {
     /// Converts a big uint number in assigned limbs form to bits, where each limb occupies transmitted bits.
     ///
     /// Use [`MainGate::le_num_to_bits`] per each limb and concat all results
@@ -1391,7 +1391,7 @@ impl<F: ff::PrimeFieldBits> BigUintMulModChip<F> {
     }
 }
 
-impl<F: ff::PrimeField> Chip<F> for BigUintMulModChip<F> {
+impl<F: PrimeField> Chip<F> for BigUintMulModChip<F> {
     type Config = MainGateConfig<MAIN_GATE_T>;
     type Loaded = ();
 

--- a/src/gadgets/nonnative/bn/big_uint_mul_mod_chip/mod.rs
+++ b/src/gadgets/nonnative/bn/big_uint_mul_mod_chip/mod.rs
@@ -328,7 +328,7 @@ impl<F: PrimeField> BigUintMulModChip<F> {
             "Production cells: {:?}",
             production_cells
                 .iter()
-                .filter_map(|c| *c.value().unwrap())
+                .filter_map(|c| c.value().unwrap())
                 .collect::<Box<[_]>>()
         );
 
@@ -1117,7 +1117,7 @@ impl<F: PrimeField> BigUintMulModChip<F> {
 
                 debug!(
                     "Previos partial sum: {:?}",
-                    prev_partial_sum.as_ref().and_then(|c| *c.value().unwrap())
+                    prev_partial_sum.as_ref().and_then(|c| c.value().unwrap())
                 );
                 debug!("Previos shifted partial sum: {:?}", shifted_prev.unwrap());
 

--- a/src/gadgets/nonnative/bn/big_uint_mul_mod_chip/tests.rs
+++ b/src/gadgets/nonnative/bn/big_uint_mul_mod_chip/tests.rs
@@ -1,17 +1,18 @@
 use std::{marker::PhantomData, mem};
 
-use ff::Field;
 use halo2_proofs::{
     circuit::SimpleFloorPlanner,
     plonk::{Advice, Circuit, Column, Instance},
 };
-use halo2curves::pasta::Fp;
 use num_traits::FromPrimitive;
 use tracing::*;
 
-use crate::run_mock_prover_test;
-
 use super::*;
+use crate::{
+    ff::{PrimeField, PrimeFieldBits},
+    halo2curves::pasta::Fp,
+    run_mock_prover_test,
+};
 
 const LIMB_WIDTH: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(Fp::S as usize) };
 const LIMBS_COUNT: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(10) };
@@ -35,11 +36,11 @@ mod mult_mod_tests {
     }
 
     #[derive(Debug)]
-    struct TestCircuit<F: ff::PrimeField + ff::PrimeFieldBits> {
+    struct TestCircuit<F: PrimeField + PrimeFieldBits> {
         modulus: BigUint<F>,
     }
 
-    impl<F: ff::PrimeField + ff::PrimeFieldBits> Circuit<F> for TestCircuit<F> {
+    impl<F: PrimeField + PrimeFieldBits> Circuit<F> for TestCircuit<F> {
         type Config = Config;
         type FloorPlanner = SimpleFloorPlanner;
 
@@ -246,14 +247,14 @@ mod components_tests {
     }
 
     #[derive(Debug, Default)]
-    struct TestCircuit<F: ff::PrimeField + ff::PrimeFieldBits> {
+    struct TestCircuit<F: PrimeField + PrimeFieldBits> {
         _p: PhantomData<F>,
     }
 
     const LIMB_WIDTH: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(Fp::S as usize) };
     const LIMBS_COUNT: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(10) };
 
-    impl<F: ff::PrimeField + ff::PrimeFieldBits> Circuit<F> for TestCircuit<F> {
+    impl<F: PrimeField + PrimeFieldBits> Circuit<F> for TestCircuit<F> {
         type Config = Config;
         type FloorPlanner = SimpleFloorPlanner;
 
@@ -614,13 +615,11 @@ mod red_mod_tests {
         circuit::SimpleFloorPlanner,
         plonk::{Advice, Circuit, Column, Instance},
     };
-    use halo2curves::pasta::Fp;
     use num_traits::FromPrimitive;
     use tracing_test::traced_test;
 
-    use crate::run_mock_prover_test;
-
     use super::*;
+    use crate::{halo2curves::pasta::Fp, run_mock_prover_test};
 
     #[derive(Clone)]
     struct Config {
@@ -637,11 +636,11 @@ mod red_mod_tests {
     const LIMBS_COUNT: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(10) };
 
     #[derive(Debug)]
-    struct TestCircuit<F: ff::PrimeField + ff::PrimeFieldBits> {
+    struct TestCircuit<F: PrimeField + PrimeFieldBits> {
         modulus: BigUint<F>,
     }
 
-    impl<F: ff::PrimeField + ff::PrimeFieldBits> Circuit<F> for TestCircuit<F> {
+    impl<F: PrimeField + PrimeFieldBits> Circuit<F> for TestCircuit<F> {
         type Config = Config;
         type FloorPlanner = SimpleFloorPlanner;
 
@@ -803,7 +802,7 @@ mod red_mod_tests {
 }
 
 mod decompose_tests {
-    use halo2_proofs::circuit::Value;
+    use halo2_proofs::{arithmetic::Field, circuit::Value};
     use tracing_test::traced_test;
 
     use super::*;
@@ -821,9 +820,9 @@ mod decompose_tests {
     const LIMBS_COUNT: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(5) };
 
     #[derive(Debug, Default)]
-    struct TestCircuit<F: ff::PrimeField + ff::PrimeFieldBits>(PhantomData<F>);
+    struct TestCircuit<F: PrimeField + PrimeFieldBits>(PhantomData<F>);
 
-    impl<F: ff::PrimeField + ff::PrimeFieldBits> Circuit<F> for TestCircuit<F> {
+    impl<F: PrimeField + PrimeFieldBits> Circuit<F> for TestCircuit<F> {
         type Config = Config;
         type FloorPlanner = SimpleFloorPlanner;
 
@@ -944,6 +943,7 @@ mod decompose_tests {
 }
 
 mod to_le_bits {
+    use halo2_proofs::arithmetic::Field;
     use rand::Rng;
     use tracing_test::traced_test;
 
@@ -957,11 +957,11 @@ mod to_le_bits {
     }
 
     #[derive(Debug, Default)]
-    struct TestCircuit<F: ff::PrimeField + ff::PrimeFieldBits> {
+    struct TestCircuit<F: PrimeField + PrimeFieldBits> {
         _m: PhantomData<F>,
     }
 
-    impl<F: ff::PrimeField + ff::PrimeFieldBits> Circuit<F> for TestCircuit<F> {
+    impl<F: PrimeField + PrimeFieldBits> Circuit<F> for TestCircuit<F> {
         type Config = Config;
         type FloorPlanner = SimpleFloorPlanner;
 

--- a/src/gadgets/util.rs
+++ b/src/gadgets/util.rs
@@ -1,8 +1,11 @@
-use crate::main_gate::{AssignedValue, MainGate, RegionCtx};
-use ff::PrimeField;
 use halo2_proofs::{
     circuit::{Chip, Value},
     plonk::Error,
+};
+
+use crate::{
+    ff::PrimeField,
+    main_gate::{AssignedValue, MainGate, RegionCtx},
 };
 
 impl<F: PrimeField, const T: usize> MainGate<F, T> {

--- a/src/ivc/incrementally_verifiable_computation.rs
+++ b/src/ivc/incrementally_verifiable_computation.rs
@@ -1,15 +1,15 @@
 use std::{io, marker::PhantomData, num::NonZeroUsize};
 
-use ff::{Field, FromUniformBytes, PrimeField, PrimeFieldBits};
-use group::prime::PrimeCurveAffine;
 use halo2_proofs::dev::MockProver;
-use halo2curves::CurveAffine;
 use serde::Serialize;
 use tracing::*;
 
 use super::instance_computation::RandomOracleComputationInstance;
 pub use super::step_circuit::{self, StepCircuit, SynthesisError};
 use crate::{
+    ff::{Field, FromUniformBytes, PrimeField, PrimeFieldBits},
+    group::prime::PrimeCurveAffine,
+    halo2curves::CurveAffine,
     ivc::{
         public_params::PublicParams,
         step_folding_circuit::{StepFoldingCircuit, StepInputs},

--- a/src/ivc/instance_computation.rs
+++ b/src/ivc/instance_computation.rs
@@ -1,20 +1,19 @@
 /// Module name acronym `instance_computation` -> `icomp`
 use std::num::NonZeroUsize;
 
-use ff::{FromUniformBytes, PrimeField, PrimeFieldBits};
-use halo2curves::CurveAffine;
 use serde::Serialize;
 
+use super::fold_relaxed_plonk_instance_chip::AssignedRelaxedPlonkInstance;
 use crate::{
     constants::NUM_CHALLENGE_BITS,
+    ff::{FromUniformBytes, PrimeField, PrimeFieldBits},
     gadgets::{ecc::AssignedPoint, nonnative::bn::big_uint::BigUint},
+    halo2curves::CurveAffine,
     main_gate::{AssignedValue, MainGate, MainGateConfig, RegionCtx, WrapValue},
     plonk::RelaxedPlonkInstance,
     poseidon::{AbsorbInRO, ROCircuitTrait, ROTrait},
     util,
 };
-
-use super::fold_relaxed_plonk_instance_chip::AssignedRelaxedPlonkInstance;
 
 pub(crate) struct AssignedRandomOracleComputationInstance<
     'l,
@@ -171,21 +170,26 @@ where
 mod tests {
     use std::num::NonZeroUsize;
 
-    use ff::Field;
     use halo2_proofs::{
         circuit::{floor_planner::single_pass::SingleChipLayouter, Layouter},
+        halo2curves::group::prime::PrimeCurve,
         plonk::ConstraintSystem,
     };
-    use halo2curves::{bn256, grumpkin};
     use tracing_test::traced_test;
 
-    type C1 = <bn256::G1 as halo2curves::group::prime::PrimeCurve>::Affine;
-    type C2 = <grumpkin::G1 as halo2curves::group::prime::PrimeCurve>::Affine;
+    use crate::{
+        ff::Field,
+        halo2curves::{bn256, grumpkin},
+    };
+
+    type C1 = <bn256::G1 as PrimeCurve>::Affine;
+    type C2 = <grumpkin::G1 as PrimeCurve>::Affine;
     type Base = <C1 as CurveAffine>::Base;
     type Scalar = <C1 as CurveAffine>::ScalarExt;
 
     const K_TABLE_SIZE: usize = 15;
 
+    use super::*;
     use crate::{
         commitment::CommitmentKey,
         ivc::fold_relaxed_plonk_instance_chip::{
@@ -195,8 +199,6 @@ mod tests {
         poseidon::{poseidon_circuit::PoseidonChip, PoseidonHash, Spec},
         table::WitnessCollector,
     };
-
-    use super::*;
 
     #[traced_test]
     #[test]

--- a/src/ivc/public_params.rs
+++ b/src/ivc/public_params.rs
@@ -1,16 +1,17 @@
 use std::{fmt, io, marker::PhantomData, num::NonZeroUsize, ops::Deref};
 
-use ff::{Field, FromUniformBytes, PrimeFieldBits};
-use group::prime::PrimeCurveAffine;
 use halo2_proofs::plonk;
-use halo2curves::CurveAffine;
 use serde::Serialize;
 use tracing::*;
 
+use super::{step_folding_circuit::StepParams, StepCircuit};
 use crate::{
     commitment::CommitmentKey,
     constants::NUM_HASH_BITS,
     digest::{self, into_curve_from_bits, DigestToBits, DigestToCurve},
+    ff::{Field, FromUniformBytes, PrimeFieldBits},
+    group::prime::PrimeCurveAffine,
+    halo2curves::CurveAffine,
     ivc::{
         self,
         instance_computation::RandomOracleComputationInstance,
@@ -24,8 +25,6 @@ use crate::{
     table::CircuitRunner,
     util,
 };
-
-use super::{step_folding_circuit::StepParams, StepCircuit};
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -418,19 +417,19 @@ where
 mod pp_test {
     use std::{fs, path::Path};
 
-    use group::Group;
-    use halo2curves::{bn256, grumpkin};
-    use tracing_test::traced_test;
-
     use bn256::G1 as C1;
     use grumpkin::G1 as C2;
-
-    use crate::ivc::step_circuit::{self, trivial};
+    use tracing_test::traced_test;
 
     use super::*;
+    use crate::{
+        group::{prime::PrimeCurve, Group},
+        halo2curves::{bn256, grumpkin},
+        ivc::step_circuit::{self, trivial},
+    };
 
-    type C1Affine = <C1 as halo2curves::group::prime::PrimeCurve>::Affine;
-    type C2Affine = <C2 as halo2curves::group::prime::PrimeCurve>::Affine;
+    type C1Affine = <C1 as PrimeCurve>::Affine;
+    type C2Affine = <C2 as PrimeCurve>::Affine;
 
     const LIMB_WIDTH: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(32) };
     const LIMBS_COUNT_LIMIT: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(10) };

--- a/src/ivc/step_circuit.rs
+++ b/src/ivc/step_circuit.rs
@@ -1,13 +1,11 @@
-use ff::PrimeField;
 use halo2_proofs::{
     circuit::{floor_planner::single_pass::SingleChipLayouter, AssignedCell, Layouter, Value},
     plonk::ConstraintSystem,
 };
 use tracing::*;
 
-use crate::{main_gate::RegionCtx, table::WitnessCollector};
-
 use super::fold_relaxed_plonk_instance_chip;
+use crate::{ff::PrimeField, main_gate::RegionCtx, table::WitnessCollector};
 
 #[derive(Debug, thiserror::Error)]
 pub enum SynthesisError {
@@ -132,13 +130,13 @@ pub trait StepCircuit<const ARITY: usize, F: PrimeField> {
 pub mod trivial {
     use std::marker::PhantomData;
 
-    use ff::PrimeField;
     use halo2_proofs::{
         circuit::{AssignedCell, Layouter},
         plonk::ConstraintSystem,
     };
 
     use super::{StepCircuit, SynthesisError};
+    use crate::ff::PrimeField;
 
     /// A trivial step circuit that simply returns the input
     #[derive(Clone, Debug, Default, PartialEq, Eq)]

--- a/src/ivc/step_folding_circuit.rs
+++ b/src/ivc/step_folding_circuit.rs
@@ -1,17 +1,18 @@
 /// Module name acronym `StepFoldingCircuit` -> `sfc`
 use std::{fmt, num::NonZeroUsize};
 
-use ff::{Field, FromUniformBytes, PrimeField, PrimeFieldBits};
 use halo2_proofs::{
     circuit::{floor_planner, Layouter, Value},
     plonk::{Circuit, Column, ConstraintSystem, Instance},
 };
-use halo2curves::CurveAffine;
 use itertools::Itertools;
 use serde::Serialize;
 use tracing::*;
 
+use super::instance_computation::AssignedRandomOracleComputationInstance;
 use crate::{
+    ff::{Field, FromUniformBytes, PrimeField, PrimeFieldBits},
+    halo2curves::CurveAffine,
     ivc::{
         fold_relaxed_plonk_instance_chip::{
             AssignedRelaxedPlonkInstance, FoldRelaxedPlonkInstanceChip, FoldResult,
@@ -23,8 +24,6 @@ use crate::{
     poseidon::ROCircuitTrait,
     table::ConstraintSystemMetainfo,
 };
-
-use super::instance_computation::AssignedRandomOracleComputationInstance;
 
 #[derive(Serialize)]
 #[serde(bound(serialize = "RO::Args: Serialize"))]
@@ -79,7 +78,7 @@ where
 #[derive(Clone)]
 pub(crate) struct StepInputs<'link, const ARITY: usize, C, RO>
 where
-    C::Base: ff::PrimeFieldBits + ff::FromUniformBytes<64>,
+    C::Base: PrimeFieldBits + FromUniformBytes<64>,
     C: CurveAffine,
     RO: ROCircuitTrait<C::Base>,
 {
@@ -103,7 +102,7 @@ where
 
 impl<'link, const ARITY: usize, C, RO> StepInputs<'link, ARITY, C, RO>
 where
-    C::Base: ff::PrimeFieldBits + ff::FromUniformBytes<64>,
+    C::Base: PrimeFieldBits + FromUniformBytes<64>,
     C: CurveAffine,
     RO: ROCircuitTrait<C::Base>,
 {
@@ -187,8 +186,8 @@ where
 pub(crate) struct StepFoldingCircuit<'link, const ARITY: usize, C, SC, RO, const T: usize>
 where
     C: CurveAffine,
-    C::Base: ff::PrimeFieldBits + ff::FromUniformBytes<64>,
-    C::Scalar: ff::PrimeFieldBits + ff::FromUniformBytes<64>,
+    C::Base: PrimeFieldBits + FromUniformBytes<64>,
+    C::Scalar: PrimeFieldBits + FromUniformBytes<64>,
     SC: StepCircuit<ARITY, C::Base> + Sized,
     RO: ROCircuitTrait<C::Base>,
 {
@@ -200,8 +199,8 @@ impl<'link, const ARITY: usize, C, SC, RO, const T: usize> Circuit<C::Base>
     for StepFoldingCircuit<'link, ARITY, C, SC, RO, T>
 where
     C: CurveAffine,
-    C::Base: ff::PrimeFieldBits + ff::FromUniformBytes<64>,
-    C::Scalar: ff::PrimeFieldBits + ff::FromUniformBytes<64>,
+    C::Base: PrimeFieldBits + FromUniformBytes<64>,
+    C::Scalar: PrimeFieldBits + FromUniformBytes<64>,
     SC: StepCircuit<ARITY, C::Base> + Sized,
     RO: ROCircuitTrait<C::Base, Config = MainGateConfig<T>>,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,3 +19,8 @@ pub mod table;
 pub mod util;
 
 pub mod error;
+
+pub use halo2_proofs::{
+    self, halo2curves,
+    halo2curves::{ff, group},
+};

--- a/src/main_gate.rs
+++ b/src/main_gate.rs
@@ -1,16 +1,16 @@
 use std::{array, iter, marker::PhantomData, num::NonZeroUsize};
 
-use ff::{PrimeField, PrimeFieldBits};
 use halo2_proofs::{
     circuit::{AssignedCell, Cell, Chip, Region, Value},
     plonk::{Advice, Column, ConstraintSystem, Error, Expression, Fixed, Instance},
     poly::Rotation,
 };
-use halo2curves::{Coordinates, CurveAffine};
 use itertools::Itertools;
 
 use crate::{
+    ff::{PrimeField, PrimeFieldBits},
     gadgets::ecc::AssignedPoint,
+    halo2curves::{Coordinates, CurveAffine},
     util::{self, normalize_trailing_zeros},
 };
 
@@ -798,13 +798,14 @@ impl<F: PrimeFieldBits, const T: usize> MainGate<F, T> {
 
 #[cfg(test)]
 mod tests {
+    use tracing_test::traced_test;
+
     use super::*;
     use crate::{
+        halo2curves::pasta::Fp,
         plonk::CompressedGates,
         polynomial::{expression::QueryIndexContext, Expression},
     };
-    use halo2curves::pasta::Fp;
-    use tracing_test::traced_test;
 
     #[traced_test]
     #[test]

--- a/src/main_gate.rs
+++ b/src/main_gate.rs
@@ -824,7 +824,7 @@ mod tests {
         const RATE: usize = 2;
         let mut cs = ConstraintSystem::<Fp>::default();
         let _: MainGateConfig<T> = MainGate::configure(&mut cs);
-        let num_selector = cs.num_selectors(); // is zero for current main_gate design
+        let num_selector = cs.num_selectors; // is zero for current main_gate design
         let num_fixed = cs.num_fixed_columns();
         let num_instance = cs.num_instance_columns();
         let num_advice = cs.num_advice_columns();
@@ -844,7 +844,7 @@ mod tests {
             QueryIndexContext {
                 num_fixed,
                 num_advice,
-                num_selectors: cs.num_selectors(),
+                num_selectors: cs.num_selectors,
                 num_challenges: cs.num_challenges(),
                 num_lookups: 0,
             },

--- a/src/nifs/protogalaxy/mod.rs
+++ b/src/nifs/protogalaxy/mod.rs
@@ -1,11 +1,11 @@
 use std::marker::PhantomData;
 
-use ff::PrimeField;
 use halo2_proofs::arithmetic::CurveAffine;
 
 use super::*;
 use crate::{
     commitment::CommitmentKey,
+    ff::PrimeField,
     plonk::{PlonkStructure, PlonkTrace, RelaxedPlonkInstance, RelaxedPlonkTrace},
 };
 

--- a/src/nifs/protogalaxy/poly/folded_trace.rs
+++ b/src/nifs/protogalaxy/poly/folded_trace.rs
@@ -1,9 +1,9 @@
 use std::iter;
 
-use ff::PrimeField;
 use rayon::prelude::*;
 
 use crate::{
+    ff::PrimeField,
     plonk::{GetChallenges, GetWitness, PlonkWitness},
     polynomial::lagrange,
     util::MultiCartesianProduct,

--- a/src/nifs/protogalaxy/poly/mod.rs
+++ b/src/nifs/protogalaxy/poly/mod.rs
@@ -3,14 +3,14 @@ use std::{
     num::{NonZeroU32, NonZeroUsize},
 };
 
-use ff::PrimeField;
-use group::ff::WithSmallOrderMulGroup;
 use itertools::*;
 use num_traits::Zero;
 use tracing::*;
 
 use crate::{
+    ff::PrimeField,
     fft::{self, coset_fft, coset_ifft},
+    group::ff::WithSmallOrderMulGroup,
     plonk::{self, eval, GetChallenges, GetWitness, PlonkStructure},
     polynomial::{expression::QueryIndexContext, lagrange, univariate::UnivariatePoly},
     util::TryMultiProduct,
@@ -369,12 +369,12 @@ pub(crate) fn compute_K<F: WithSmallOrderMulGroup<3>>(
 mod test {
     use std::iter;
 
-    use ff::Field as _Field;
-    use halo2curves::{bn256, CurveAffine};
     use tracing_test::traced_test;
 
     use crate::{
         commitment::CommitmentKey,
+        ff::Field as _Field,
+        halo2curves::{bn256, CurveAffine},
         nifs::protogalaxy::poly::PolyChallenges,
         plonk::{test_eval_witness::poseidon_circuit, PlonkStructure, PlonkTrace},
         polynomial::univariate::UnivariatePoly,
@@ -395,10 +395,10 @@ mod test {
     const R_F1: usize = 4;
     const R_P1: usize = 3;
     pub type PoseidonSpec =
-        Spec<<Curve as halo2curves::CurveAffine>::Base, POSEIDON_PERMUTATION_WIDTH, POSEIDON_RATE>;
+        Spec<<Curve as CurveAffine>::Base, POSEIDON_PERMUTATION_WIDTH, POSEIDON_RATE>;
 
     type RO = <PoseidonRO<POSEIDON_PERMUTATION_WIDTH, POSEIDON_RATE> as random_oracle::ROPair<
-        <Curve as halo2curves::CurveAffine>::Base,
+        <Curve as CurveAffine>::Base,
     >>::OffCircuit;
 
     fn poseidon_trace() -> (PlonkStructure<Field>, PlonkTrace<Curve>) {

--- a/src/nifs/tests.rs
+++ b/src/nifs/tests.rs
@@ -83,7 +83,7 @@ where
     let td1 = CircuitRunner::new(K, circuit1, public_inputs1.clone());
     let num_lookup = td1.cs.lookups().len();
     let p1 = smallest_power(td1.cs.num_advice_columns() + 5 * num_lookup, K);
-    let p2 = smallest_power(td1.cs.num_selectors() + td1.cs.num_fixed_columns(), K);
+    let p2 = smallest_power(td1.cs.num_selectors + td1.cs.num_fixed_columns(), K);
     let ck = CommitmentKey::<C>::setup(p1.max(p2), b"prepare_trace");
 
     let S = td1.try_collect_plonk_structure()?;

--- a/src/nifs/tests.rs
+++ b/src/nifs/tests.rs
@@ -1,19 +1,19 @@
 use std::marker::PhantomData;
 
-use ff::{PrimeField, PrimeFieldBits};
 use halo2_proofs::{
     circuit::{AssignedCell, Layouter, SimpleFloorPlanner, Value},
     plonk::{self, Advice, Circuit, Column, ConstraintSystem, Instance, Selector},
     poly::Rotation,
 };
-use halo2curves::{
-    bn256::{Fr, G1Affine},
-    group::ff::FromUniformBytes,
-};
 use some_to_err::*;
 
 use super::*;
 use crate::{
+    ff::{PrimeField, PrimeFieldBits},
+    halo2curves::{
+        bn256::{Fr, G1Affine},
+        group::ff::FromUniformBytes,
+    },
     nifs::{self, vanilla::VanillaFS},
     plonk::{
         PlonkStructure, PlonkTrace, RelaxedPlonkInstance, RelaxedPlonkTrace, RelaxedPlonkWitness,

--- a/src/nifs/vanilla.rs
+++ b/src/nifs/vanilla.rs
@@ -1,6 +1,5 @@
 use std::marker::PhantomData;
 
-use ff::Field;
 use halo2_proofs::arithmetic::CurveAffine;
 use tracing::*;
 
@@ -9,6 +8,7 @@ use crate::{
     commitment::CommitmentKey,
     concat_vec,
     constants::NUM_CHALLENGE_BITS,
+    ff::Field,
     plonk::{
         eval::{GetDataForEval, PlonkEvalDomain},
         PlonkInstance, PlonkStructure, PlonkTrace, PlonkWitness, RelaxedPlonkInstance,

--- a/src/plonk/eval.rs
+++ b/src/plonk/eval.rs
@@ -1,5 +1,4 @@
-use crate::polynomial::ColumnIndex;
-use ff::PrimeField;
+use crate::{ff::PrimeField, polynomial::ColumnIndex};
 
 #[derive(Debug, thiserror::Error, PartialEq, Eq, Clone)]
 pub enum Error {

--- a/src/plonk/lookup.rs
+++ b/src/plonk/lookup.rs
@@ -41,13 +41,13 @@ use std::{
     collections::{HashMap, HashSet},
 };
 
-use crate::ff::PrimeField;
 use halo2_proofs::{plonk::ConstraintSystem, poly::Rotation};
 use rayon::prelude::*;
 use serde::Serialize;
 use tracing::*;
 
 use crate::{
+    ff::PrimeField,
     plonk::{
         eval::{Error, LookupEvalDomain},
         util::compress_halo2_expression,
@@ -100,15 +100,20 @@ impl<F: PrimeField> Arguments<F> {
             .map(|arg| {
                 (
                     compress_halo2_expression(
-                        arg.input_expressions(),
-                        cs.num_selectors(),
+                        arg.input_expressions()
+                            .iter()
+                            .flatten()
+                            .cloned()
+                            .collect::<Vec<_>>()
+                            .as_slice(),
+                        cs.num_selectors,
                         cs.num_fixed_columns(),
                         // compress vector table items with r1 (challenge_index = 0)
                         0,
                     ),
                     compress_halo2_expression(
                         arg.table_expressions(),
-                        cs.num_selectors(),
+                        cs.num_selectors,
                         cs.num_fixed_columns(),
                         // compress vector lookups with r1 (challenge_index = 0)
                         0,
@@ -134,7 +139,7 @@ impl<F: PrimeField> Arguments<F> {
     /// L_i(x1,...,xa) - l_i which evaluates to zero on every row
     /// T_i(y1,...,yb) - t_i which evaluates to zero on every row
     pub fn vanishing_lookup_polys(&self, cs: &ConstraintSystem<F>) -> Vec<Expression<F>> {
-        let lookup_offset = cs.num_selectors() + cs.num_fixed_columns() + cs.num_advice_columns();
+        let lookup_offset = cs.num_selectors + cs.num_fixed_columns() + cs.num_advice_columns();
         let expression_of_l = |lookup_index: usize| -> Expression<F> {
             Expression::Polynomial(Query {
                 index: lookup_offset + lookup_index * 5,
@@ -177,7 +182,7 @@ impl<F: PrimeField> Arguments<F> {
     ) -> (Expression<F>, Expression<F>) {
         let r = Expression::Challenge(challenge_index);
         // starting index of lookup variables (l_i, t_i, m_i, h_i, g_i)
-        let lookup_offset = cs.num_selectors() + cs.num_fixed_columns() + cs.num_advice_columns();
+        let lookup_offset = cs.num_selectors + cs.num_fixed_columns() + cs.num_advice_columns();
         // Please see (#34)[https://github.com/snarkify/sirius/issues/34] for details on notations.
         let [l, t, m, h, g] = array::from_fn(|idx| {
             Expression::Polynomial(Query {

--- a/src/plonk/lookup.rs
+++ b/src/plonk/lookup.rs
@@ -41,7 +41,7 @@ use std::{
     collections::{HashMap, HashSet},
 };
 
-use ff::PrimeField;
+use crate::ff::PrimeField;
 use halo2_proofs::{plonk::ConstraintSystem, poly::Rotation};
 use rayon::prelude::*;
 use serde::Serialize;

--- a/src/plonk/mod.rs
+++ b/src/plonk/mod.rs
@@ -17,7 +17,6 @@
 use std::{iter, num::NonZeroUsize, time::Instant};
 
 use count_to_non_zero::*;
-use ff::{Field, PrimeField};
 use halo2_proofs::arithmetic::{best_multiexp, CurveAffine};
 use itertools::Itertools;
 use rayon::prelude::*;
@@ -29,6 +28,7 @@ use crate::{
     commitment::CommitmentKey,
     concat_vec,
     constants::NUM_CHALLENGE_BITS,
+    ff::{Field, PrimeField},
     plonk::{
         self,
         eval::{Error as EvalError, GetDataForEval, PlonkEvalDomain},
@@ -984,13 +984,13 @@ pub(crate) mod test_eval_witness {
     pub mod poseidon_circuit {
         use std::{array, marker::PhantomData};
 
-        use ff::{FromUniformBytes, PrimeFieldBits};
         use halo2_proofs::{
             circuit::{Layouter, SimpleFloorPlanner, Value},
             plonk::{Circuit, ConstraintSystem},
         };
 
         use crate::{
+            ff::{FromUniformBytes, PrimeFieldBits},
             main_gate::{MainGate, MainGateConfig, RegionCtx, WrapValue},
             poseidon::{poseidon_circuit::PoseidonChip, Spec},
         };
@@ -1061,11 +1061,10 @@ pub(crate) mod test_eval_witness {
         }
     }
 
-    use ff::Field as _Field;
-    use halo2curves::{bn256, CurveAffine};
-
     use crate::{
         commitment::CommitmentKey,
+        ff::Field as _Field,
+        halo2curves::{bn256, CurveAffine},
         plonk::PlonkTrace,
         poseidon::{
             random_oracle::{self, ROTrait},
@@ -1084,10 +1083,10 @@ pub(crate) mod test_eval_witness {
     const R_F1: usize = 4;
     const R_P1: usize = 3;
     pub type PoseidonSpec =
-        Spec<<Curve as halo2curves::CurveAffine>::Base, POSEIDON_PERMUTATION_WIDTH, POSEIDON_RATE>;
+        Spec<<Curve as CurveAffine>::Base, POSEIDON_PERMUTATION_WIDTH, POSEIDON_RATE>;
 
     type RO = <PoseidonRO<POSEIDON_PERMUTATION_WIDTH, POSEIDON_RATE> as random_oracle::ROPair<
-        <Curve as halo2curves::CurveAffine>::Base,
+        <Curve as CurveAffine>::Base,
     >>::OffCircuit;
 
     #[test]

--- a/src/plonk/util.rs
+++ b/src/plonk/util.rs
@@ -1,10 +1,10 @@
 use std::collections::HashSet;
 
-use ff::PrimeField;
 use halo2_proofs::plonk::{Any, Column, ConstraintSystem, Expression as PE};
 use tracing::*;
 
 use crate::{
+    ff::PrimeField,
     plonk::permutation::Assembly,
     polynomial::{sparse::SparseMatrix, Expression},
 };

--- a/src/polynomial/expression.rs
+++ b/src/polynomial/expression.rs
@@ -6,11 +6,10 @@ use std::{
     ops::{self, Add, Mul, Neg, Sub},
 };
 
-use ff::PrimeField;
 use halo2_proofs::{plonk::Expression as PE, poly::Rotation};
 use serde::Serialize;
 
-use crate::{plonk::PlonkStructure, util::trim_leading_zeros};
+use crate::{ff::PrimeField, plonk::PlonkStructure, util::trim_leading_zeros};
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
 pub enum ColumnIndex {
     Challenge { column_index: usize },
@@ -517,14 +516,16 @@ pub fn challenge_in_degree<F: PrimeField>(
 mod tests {
     use std::array;
 
-    use ff::PrimeField;
     // use pasta_curves::{Fp, pallas};
     use halo2_proofs::poly::Rotation;
-    use halo2curves::pasta::{pallas, Fp};
     use tracing::*;
     use tracing_test::traced_test;
 
     use super::super::expression::*;
+    use crate::{
+        ff::PrimeField,
+        halo2curves::pasta::{pallas, Fp},
+    };
 
     #[traced_test]
     #[test]

--- a/src/polynomial/graph_evaluator.rs
+++ b/src/polynomial/graph_evaluator.rs
@@ -1,3 +1,7 @@
+use halo2_proofs::poly::Rotation;
+use tracing::*;
+
+use super::Expression;
 /// This module provides an efficient and flexible way to evaluate expressions that represent
 /// can be represented as a graph of calculations.
 ///
@@ -40,13 +44,8 @@
 ///
 /// It is an adaptation for our needs of the [code from
 /// halo2](https://github.com/privacy-scaling-explorations/halo2/blob/main/halo2_backend/src/plonk/evaluation.rs#L200)
-use ff::PrimeField;
-use halo2_proofs::poly::Rotation;
-use tracing::*;
-
+use crate::ff::PrimeField;
 use crate::plonk::eval::{Error as EvalError, GetDataForEval};
-
-use super::Expression;
 
 /// Return the index in the polynomial of size `isize` after rotation `rot`.
 fn get_rotation_idx(idx: usize, rot: i32, num_row: usize) -> usize {
@@ -393,16 +392,16 @@ impl<F: PrimeField> GraphEvaluator<F> {
 mod tests {
     use std::array;
 
-    use ff::Field;
-    use halo2curves::bn256;
+    use halo2_proofs::halo2curves::CurveAffine;
     use tracing_test::traced_test;
 
+    use super::*;
     use crate::{
+        ff::Field,
+        halo2curves::bn256,
         plonk::eval::{Error as EvalError, GetDataForEval},
         polynomial::Query,
     };
-
-    use super::*;
 
     #[derive(Default)]
     struct Mock<F: PrimeField> {
@@ -443,7 +442,7 @@ mod tests {
         }
     }
 
-    type Scalar = <bn256::G1Affine as halo2curves::CurveAffine>::ScalarExt;
+    type Scalar = <bn256::G1Affine as CurveAffine>::ScalarExt;
 
     #[traced_test]
     #[test]

--- a/src/polynomial/grouped_poly.rs
+++ b/src/polynomial/grouped_poly.rs
@@ -5,14 +5,15 @@ use std::{
     time::Instant,
 };
 
-use ff::PrimeField;
 use itertools::*;
 use serde::Serialize;
 use tracing::*;
 
-use crate::polynomial::{Query, QueryType};
-
 use super::{expression::QueryIndexContext, Expression};
+use crate::{
+    ff::PrimeField,
+    polynomial::{Query, QueryType},
+};
 
 /// Polynome grouped by degrees
 ///
@@ -284,12 +285,11 @@ impl<F: PrimeField> Neg for GroupedPoly<F> {
 mod test {
     use std::array;
 
-    use ff::Field;
     use halo2_proofs::poly::Rotation;
-    use halo2curves::pasta::Fq;
     use maplit::hashmap as map;
 
     use super::*;
+    use crate::{ff::Field, halo2curves::pasta::Fq};
 
     #[test]
     fn simple_add() {

--- a/src/polynomial/lagrange.rs
+++ b/src/polynomial/lagrange.rs
@@ -1,8 +1,6 @@
 use std::iter;
 
-use ff::PrimeField;
-
-use crate::fft;
+use crate::{ff::PrimeField, fft};
 
 /// Returns an iterator over elements of a cyclic subgroup of a specified order in a given prime
 /// field:
@@ -86,11 +84,11 @@ pub fn eval_vanish_polynomial<F: PrimeField>(log_n: u32, point: F) -> F {
 
 #[cfg(test)]
 mod tests {
-    use ff::Field;
     use halo2_proofs::halo2curves::bn256::Fr;
     use tracing_test::traced_test;
 
     use super::*;
+    use crate::ff::Field;
 
     #[traced_test]
     #[test]

--- a/src/polynomial/sparse.rs
+++ b/src/polynomial/sparse.rs
@@ -1,4 +1,4 @@
-use ff::PrimeField;
+use crate::ff::PrimeField;
 
 // represent a sparse matrix M = {(i, j, v)}, i.e. M[i,j] = v
 // the size of matrix is N*N with N = num_io + num_advice_columns * num_rows

--- a/src/polynomial/univariate.rs
+++ b/src/polynomial/univariate.rs
@@ -1,6 +1,6 @@
 use std::iter;
 
-use ff::Field;
+use crate::ff::Field;
 
 /// Represents a univariate polynomial
 ///
@@ -44,9 +44,8 @@ impl<F: Field> UnivariatePoly<F> {
 mod tests {
     use std::iter;
 
-    use halo2curves::bn256::Fr;
-
     use super::UnivariatePoly;
+    use crate::halo2curves::bn256::Fr;
 
     // Helper to create an `Fr` iterator from a `u64` iterator
     trait ToF<I: Into<Fr>>: Sized + IntoIterator<Item = I> {

--- a/src/poseidon/mod.rs
+++ b/src/poseidon/mod.rs
@@ -3,16 +3,17 @@ pub mod poseidon_hash;
 pub mod random_oracle;
 mod spec;
 
+use halo2_proofs::halo2curves::ff::{FromUniformBytes, PrimeField, PrimeFieldBits};
 pub use poseidon_hash::PoseidonHash;
 pub use random_oracle::*;
 pub use spec::Spec;
 
 pub struct PoseidonRO<const T: usize, const RATE: usize>;
 
-impl<const T: usize, const RATE: usize, F: serde::Serialize + ff::PrimeField> ROPair<F>
+impl<const T: usize, const RATE: usize, F: serde::Serialize + PrimeField> ROPair<F>
     for PoseidonRO<T, RATE>
 where
-    F: ff::PrimeFieldBits + ff::FromUniformBytes<64>,
+    F: PrimeFieldBits + FromUniformBytes<64>,
 {
     type Args = Spec<F, T, RATE>;
     type Config = crate::main_gate::MainGateConfig<T>;

--- a/src/poseidon/poseidon_circuit.rs
+++ b/src/poseidon/poseidon_circuit.rs
@@ -43,11 +43,14 @@ impl<F: PrimeFieldBits + FromUniformBytes<64>, const T: usize, const RATE: usize
         self.update(&point)
     }
 
-    fn inspect(&mut self, scan: impl FnOnce(&[F])) -> &mut Self {
+    fn inspect(&mut self, scan: impl FnOnce(&[F])) -> &mut Self
+    where
+        F: Sized,
+    {
         if let Some(buf) = self
             .buf
             .iter()
-            .map(|b| *b.value().unwrap())
+            .map(|b| b.value().unwrap())
             .collect::<Option<Vec<_>>>()
         {
             scan(&buf)
@@ -380,7 +383,7 @@ impl<F: PrimeField + PrimeFieldBits, const T: usize, const RATE: usize> Poseidon
         let buf = self.buf.clone();
         if let Some(buf) = buf
             .iter()
-            .map(|val| *val.value().unwrap())
+            .map(|val| val.value().unwrap())
             .collect::<Option<Vec<F>>>()
         {
             debug!("On circuit input of hash: {buf:?}",);

--- a/src/poseidon/poseidon_circuit.rs
+++ b/src/poseidon/poseidon_circuit.rs
@@ -1,6 +1,5 @@
 use std::{convert::TryInto, num::NonZeroUsize};
 
-use ff::{FromUniformBytes, PrimeField, PrimeFieldBits};
 use halo2_proofs::{
     circuit::{AssignedCell, Chip, Value},
     plonk::Error,
@@ -8,12 +7,12 @@ use halo2_proofs::{
 use poseidon::{self};
 use tracing::*;
 
+use super::{ROCircuitTrait, Spec};
 use crate::{
     constants::MAX_BITS,
+    ff::{FromUniformBytes, PrimeField, PrimeFieldBits},
     main_gate::{AssignedBit, AssignedValue, MainGate, MainGateConfig, RegionCtx, WrapValue},
 };
-
-use super::{ROCircuitTrait, Spec};
 
 pub struct PoseidonChip<F: PrimeFieldBits, const T: usize, const RATE: usize> {
     main_gate: MainGate<F, T>,
@@ -421,17 +420,19 @@ mod tests {
         circuit::{Layouter, SimpleFloorPlanner},
         plonk::{Circuit, Column, ConstraintSystem, Instance},
     };
-    use halo2curves::{
-        group::ff::FromUniformBytes,
-        pasta::{EqAffine, Fp},
-    };
     use tracing_test::traced_test;
 
-    use crate::{
-        create_and_verify_proof, main_gate::MainGateConfig, poseidon::Spec, run_mock_prover_test,
-    };
-
     use super::*;
+    use crate::{
+        create_and_verify_proof,
+        halo2curves::{
+            group::ff::FromUniformBytes,
+            pasta::{EqAffine, Fp},
+        },
+        main_gate::MainGateConfig,
+        poseidon::Spec,
+        run_mock_prover_test,
+    };
 
     const T: usize = 3;
     const RATE: usize = 2;

--- a/src/poseidon/poseidon_hash.rs
+++ b/src/poseidon/poseidon_hash.rs
@@ -1,15 +1,15 @@
-use std::num::NonZeroUsize;
-use std::{iter, mem};
+use std::{iter, mem, num::NonZeroUsize};
 
-use halo2_proofs::arithmetic::CurveAffine;
-use halo2curves::group::ff::{FromUniformBytes, PrimeField};
+use halo2_proofs::{arithmetic::CurveAffine, halo2curves::ff::PrimeFieldBits};
 use poseidon::{self, SparseMDSMatrix};
 use tracing::*;
 
-use crate::poseidon::{ROConstantsTrait, ROTrait};
-use crate::util::{bits_to_fe_le, fe_to_bits_le};
-
 use super::Spec;
+use crate::{
+    halo2curves::group::ff::{FromUniformBytes, PrimeField},
+    poseidon::{ROConstantsTrait, ROTrait},
+    util::{bits_to_fe_le, fe_to_bits_le},
+};
 
 // adapted from: https://github.com/privacy-scaling-explorations/snark-verifier
 
@@ -107,7 +107,7 @@ where
 
 impl<F: PrimeField, const T: usize, const RATE: usize> ROTrait<F> for PoseidonHash<F, T, RATE>
 where
-    F: ff::PrimeFieldBits + ff::FromUniformBytes<64>,
+    F: PrimeFieldBits + FromUniformBytes<64>,
 {
     type Constants = Spec<F, T, RATE>;
 
@@ -154,7 +154,7 @@ where
 #[derive(Clone, Debug)]
 pub struct PoseidonHash<F: PrimeField, const T: usize, const RATE: usize>
 where
-    F: ff::PrimeFieldBits + ff::FromUniformBytes<64>,
+    F: PrimeFieldBits + FromUniformBytes<64>,
 {
     spec: Spec<F, T, RATE>,
     state: State<F, T, RATE>,
@@ -163,7 +163,7 @@ where
 
 impl<F: PrimeField, const T: usize, const RATE: usize> PoseidonHash<F, T, RATE>
 where
-    F: ff::PrimeFieldBits + ff::FromUniformBytes<64>,
+    F: PrimeFieldBits + FromUniformBytes<64>,
 {
     fn update(&mut self, elements: &[F]) {
         self.buf.extend_from_slice(elements);
@@ -223,10 +223,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use halo2curves::pasta::{EpAffine, Fp, Fq};
     use tracing_test::traced_test;
 
     use super::*;
+    use crate::halo2curves::pasta::{EpAffine, Fp, Fq};
 
     #[traced_test]
     #[test]

--- a/src/poseidon/random_oracle.rs
+++ b/src/poseidon/random_oracle.rs
@@ -1,9 +1,11 @@
 use std::{fmt, num::NonZeroUsize};
 
-use ff::{FromUniformBytes, PrimeField, PrimeFieldBits};
 use halo2_proofs::{arithmetic::CurveAffine, plonk::Error};
 
-use crate::main_gate::{AssignedBit, RegionCtx, WrapValue};
+use crate::{
+    ff::{FromUniformBytes, PrimeField, PrimeFieldBits},
+    main_gate::{AssignedBit, RegionCtx, WrapValue},
+};
 
 /// A helper trait to obsorb different objects into RO
 pub trait AbsorbInRO<F: PrimeField, RO: ROTrait<F>> {
@@ -110,7 +112,7 @@ pub trait ROCircuitTrait<F: PrimeFieldBits + FromUniformBytes<64>> {
 /// allowing the use of a single generic.
 pub trait ROPair<F: PrimeField>
 where
-    F: ff::PrimeFieldBits + ff::FromUniformBytes<64>,
+    F: PrimeFieldBits + FromUniformBytes<64>,
 {
     /// Argument for creating on-circuit & off-circuit versions of oracles
     type Args: fmt::Debug + serde::Serialize + Clone;

--- a/src/poseidon/spec.rs
+++ b/src/poseidon/spec.rs
@@ -1,14 +1,13 @@
 use std::ops;
 
-use ff::FromUniformBytes;
 use serde::Serialize;
 
-#[derive(Clone, Debug)]
-pub struct Spec<F: ff::PrimeField, const T: usize, const RATE: usize>(
-    pub poseidon::Spec<F, T, RATE>,
-);
+use crate::ff::{FromUniformBytes, PrimeField};
 
-impl<F: ff::PrimeField, const T: usize, const RATE: usize> Spec<F, T, RATE>
+#[derive(Clone, Debug)]
+pub struct Spec<F: PrimeField, const T: usize, const RATE: usize>(pub poseidon::Spec<F, T, RATE>);
+
+impl<F: PrimeField, const T: usize, const RATE: usize> Spec<F, T, RATE>
 where
     F: FromUniformBytes<64>,
 {
@@ -17,16 +16,14 @@ where
     }
 }
 
-impl<F: ff::PrimeField, const T: usize, const RATE: usize> ops::Deref for Spec<F, T, RATE> {
+impl<F: PrimeField, const T: usize, const RATE: usize> ops::Deref for Spec<F, T, RATE> {
     type Target = poseidon::Spec<F, T, RATE>;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl<F: Serialize + ff::PrimeField, const T: usize, const RATE: usize> Serialize
-    for Spec<F, T, RATE>
-{
+impl<F: Serialize + PrimeField, const T: usize, const RATE: usize> Serialize for Spec<F, T, RATE> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::ser::Serializer,
@@ -133,15 +130,15 @@ impl<F: Serialize + ff::PrimeField, const T: usize, const RATE: usize> Serialize
 
 #[cfg(test)]
 mod tests {
-    use halo2curves::secp256r1::Fp;
     use tracing_test::traced_test;
 
     use super::*;
+    use crate::halo2curves::bn256::Fr;
 
     #[traced_test]
     #[test]
     fn just_serialize() {
-        let spec = Spec::<Fp, 10, 9>::new(10, 10);
+        let spec = Spec::<Fr, 10, 9>::new(10, 10);
         bincode::serialize(&spec).unwrap();
     }
 }

--- a/src/table/circuit_data.rs
+++ b/src/table/circuit_data.rs
@@ -1,4 +1,3 @@
-use ff::PrimeField;
 use halo2_proofs::{
     circuit::Value,
     plonk::{
@@ -7,7 +6,7 @@ use halo2_proofs::{
 };
 use tracing::*;
 
-use crate::plonk;
+use crate::{ff::PrimeField, plonk};
 
 pub struct CircuitData<F: PrimeField> {
     pub(crate) k: u32,

--- a/src/table/circuit_data.rs
+++ b/src/table/circuit_data.rs
@@ -134,4 +134,12 @@ impl<F: PrimeField> Assignment<F> for CircuitData<F> {
     fn pop_namespace(&mut self, _: Option<String>) {
         // Do nothing; we don't care about namespaces in this context.
     }
+
+    fn query_advice(&self, _column: Column<Advice>, _row: usize) -> Result<F, Error> {
+        todo!()
+    }
+
+    fn query_fixed(&self, _column: Column<Fixed>, _row: usize) -> Result<F, Error> {
+        todo!()
+    }
 }

--- a/src/table/circuit_runner.rs
+++ b/src/table/circuit_runner.rs
@@ -1,14 +1,13 @@
-use ff::PrimeField;
 use halo2_proofs::plonk::{Circuit, ConstraintSystem, Error, FloorPlanner};
 use tracing::*;
 
+use super::{circuit_data::CircuitData, ConstraintSystemMetainfo, WitnessCollector};
 use crate::{
+    ff::PrimeField,
     plonk::{self, PlonkStructure},
     polynomial::sparse::SparseMatrix,
     util::batch_invert_assigned,
 };
-
-use super::{circuit_data::CircuitData, ConstraintSystemMetainfo, WitnessCollector};
 
 pub type Witness<F> = Vec<Vec<F>>;
 

--- a/src/table/circuit_runner.rs
+++ b/src/table/circuit_runner.rs
@@ -87,7 +87,7 @@ impl<F: PrimeField, CT: Circuit<F>> CircuitRunner<F, CT> {
             k: self.k,
             num_io: self.instance.len(),
             fixed: vec![vec![F::ZERO.into(); nrow]; self.cs.num_fixed_columns()],
-            selector: vec![vec![false; nrow]; self.cs.num_selectors()],
+            selector: vec![vec![false; nrow]; self.cs.num_selectors],
             permutation: plonk::permutation::Assembly::new(nrow, &self.cs.permutation),
         };
 

--- a/src/table/constraint_system_metainfo.rs
+++ b/src/table/constraint_system_metainfo.rs
@@ -1,8 +1,8 @@
-use ff::PrimeField;
 use halo2_proofs::plonk::ConstraintSystem;
 use tracing::*;
 
 use crate::{
+    ff::PrimeField,
     plonk::{lookup, CompressedGates},
     polynomial::{expression::QueryIndexContext, Expression},
 };

--- a/src/table/constraint_system_metainfo.rs
+++ b/src/table/constraint_system_metainfo.rs
@@ -49,9 +49,7 @@ impl<F: PrimeField> ConstraintSystemMetainfo<F> {
             .gates()
             .iter()
             .flat_map(|gate| gate.polynomials().iter())
-            .map(|expr| {
-                Expression::from_halo2_expr(expr, cs.num_selectors(), cs.num_fixed_columns())
-            })
+            .map(|expr| Expression::from_halo2_expr(expr, cs.num_selectors, cs.num_fixed_columns()))
             .chain(lookup_exprs)
             .collect::<Vec<_>>();
 
@@ -84,7 +82,7 @@ impl<F: PrimeField> ConstraintSystemMetainfo<F> {
         // we use r3 to combine all custom gates and lookup expressions
         // find the challenge index of r3
         let mut ctx = QueryIndexContext {
-            num_selectors: cs.num_selectors(),
+            num_selectors: cs.num_selectors,
             num_fixed: cs.num_fixed_columns(),
             num_advice: cs.num_advice_columns(),
             num_lookups,

--- a/src/table/tests.rs
+++ b/src/table/tests.rs
@@ -1,18 +1,17 @@
-use ff::{Field, PrimeField};
 use halo2_proofs::{
     circuit::{Layouter, SimpleFloorPlanner},
     plonk::{Circuit, Column, ConstraintSystem, Error, Instance},
 };
-use halo2curves::group::ff::FromUniformBytes;
 use prettytable::{row, Cell, Row, Table};
 use tracing_test::traced_test;
 
+use super::*;
 use crate::{
+    ff::{Field, PrimeField},
+    halo2curves::group::ff::FromUniformBytes,
     main_gate::{MainGate, MainGateConfig, RegionCtx},
     util::trim_leading_zeros,
 };
-
-use super::*;
 
 const T: usize = 3;
 
@@ -72,7 +71,7 @@ impl<F: PrimeField + FromUniformBytes<64>> Circuit<F> for TestCircuit<F> {
 #[traced_test]
 #[test]
 fn test_assembly() -> Result<(), Error> {
-    use halo2curves::pasta::Fp;
+    use crate::halo2curves::pasta::Fp;
 
     const K: u32 = 4;
     let mut inputs = Vec::new();

--- a/src/table/witness_data.rs
+++ b/src/table/witness_data.rs
@@ -1,4 +1,3 @@
-use crate::ff::PrimeField;
 use halo2_proofs::{
     circuit::Value,
     plonk::{
@@ -6,6 +5,8 @@ use halo2_proofs::{
     },
 };
 use tracing::*;
+
+use crate::ff::PrimeField;
 
 pub struct WitnessCollector<F: PrimeField> {
     pub(crate) instance: Vec<F>,
@@ -126,5 +127,13 @@ impl<F: PrimeField> Assignment<F> for WitnessCollector<F> {
 
     fn pop_namespace(&mut self, _: Option<String>) {
         // Do nothing; we don't care about namespaces in this context.
+    }
+
+    fn query_advice(&self, _column: Column<Advice>, _row: usize) -> Result<F, Error> {
+        todo!()
+    }
+
+    fn query_fixed(&self, _column: Column<Fixed>, _row: usize) -> Result<F, Error> {
+        todo!()
     }
 }

--- a/src/table/witness_data.rs
+++ b/src/table/witness_data.rs
@@ -1,4 +1,4 @@
-use ff::PrimeField;
+use crate::ff::PrimeField;
 use halo2_proofs::{
     circuit::Value,
     plonk::{

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,13 +1,16 @@
 use std::{fmt, iter, num::NonZeroUsize};
 
-use ff::{BatchInvert, Field, PrimeField};
-use halo2_proofs::plonk::Assigned;
+use halo2_proofs::{
+    halo2curves::ff::{FromUniformBytes, PrimeFieldBits},
+    plonk::Assigned,
+};
 use itertools::Itertools;
 use num_bigint::BigUint;
 pub(crate) use rayon::current_num_threads;
 use rayon::prelude::*;
 
 use crate::{
+    ff::{BatchInvert, Field, PrimeField},
     main_gate::AssignedValue,
     poseidon::{PoseidonHash, ROTrait, Spec},
 };
@@ -192,10 +195,10 @@ pub(crate) fn concatenate_with_padding<F: PrimeField>(vs: &[Vec<F>], pad_size: u
 #[allow(clippy::items_after_test_module)]
 #[cfg(test)]
 mod tests {
-    use halo2curves::pasta::Fp;
     use tracing_test::traced_test;
 
     use super::*;
+    use crate::halo2curves::pasta::Fp;
 
     // Helper to easily create an Fp element
     fn fp(num: u64) -> Fp {
@@ -265,7 +268,7 @@ mod tests {
 pub(crate) fn create_ro<F, const T: usize, const RATE: usize, const R_F: usize, const R_P: usize>(
 ) -> PoseidonHash<F, T, RATE>
 where
-    F: ff::PrimeFieldBits + ff::FromUniformBytes<64>,
+    F: PrimeFieldBits + FromUniformBytes<64>,
 {
     let spec = Spec::<F, T, RATE>::new(R_F, R_P);
     PoseidonHash::<F, T, RATE>::new(spec)
@@ -363,7 +366,7 @@ macro_rules! create_and_verify_proof {
     }};
 }
 
-pub(crate) fn get_power_of_two_iter<F: ff::PrimeField>() -> impl Iterator<Item = F> {
+pub(crate) fn get_power_of_two_iter<F: PrimeField>() -> impl Iterator<Item = F> {
     iter::successors(Some(F::ONE), |l| Some(l.double()))
 }
 


### PR DESCRIPTION
**Issue Link / Motivation**
Using one version of halo2curves will allow us to unfreeze #287, halo2-kzg for #285 and fix smaller bugs

**Changes Overview**
- Migrating to halo2curves and reimporting it from the crate root
- Minor edits and fixes related to another version of halo2