### PR TITLE
feat(example): add merkle-tree to cli

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,7 +1,8 @@
 [alias]
 poseidon-example = ["run", "--example", "poseidon", "--release", "--", "--json"]
 trivial-example = ["run", "--example", "trivial", "--release", "--", "--json"]
-merkle-example = ["run", "--example", "merkle", "--release", "--", "--json"]
 
-cli-example = ["run", "--example", "cli", "--release", "--"]
 cli-dhat = ["run", "--example", "cli", "--release", "--features", "dhat-heap", "--"]
+cli-example = ["run", "--example", "cli", "--release", "--"]
+
+merkle-example = ["run", "--example", "merkle", "--release", "--", "--json"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,10 @@ harness = false
 name = "poseidon"
 harness = false
 
+[[example]]
+name = "cli"
+path = "examples/cli.rs"
+
 [features]
 # Allows cli-example to check memory usage with dhat
 dhat-heap = []

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -6,13 +6,9 @@ use std::num::NonZeroUsize;
 
 use clap::{Parser, ValueEnum};
 use halo2_proofs::halo2curves;
-
-use merkle::MerkleTreeUpdateCircuit;
-
 use poseidon::poseidon_step_circuit::TestPoseidonCircuit;
 use sirius::{
     ff::{FromUniformBytes, PrimeField, PrimeFieldBits},
-    gadgets::merkle_tree::off_circuit::Tree,
     ivc::{step_circuit::trivial, CircuitPublicParamsInput, PublicParams, StepCircuit, IVC},
     poseidon::ROPair,
 };
@@ -24,6 +20,8 @@ mod poseidon;
 
 #[allow(dead_code)]
 mod merkle;
+
+use merkle::{MerkleTreeUpdateCircuit, Tree};
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]

--- a/examples/merkle/circuit.rs
+++ b/examples/merkle/circuit.rs
@@ -1,0 +1,189 @@
+use std::{collections::VecDeque, iter};
+
+use rand::Rng;
+use sirius::{
+    halo2_proofs::{circuit::*, plonk::*},
+    halo2curves::ff::{FromUniformBytes, PrimeFieldBits},
+    ivc::{StepCircuit, SynthesisError},
+    main_gate::{MainGate, RegionCtx},
+};
+use tracing::info;
+
+const INDEX_LIMIT: u32 = 1 << 31;
+const ARITY: usize = 1;
+
+use super::merkle_tree_gadget::{
+    chip::MerkleTreeUpdateChip,
+    off_circuit::{NodeUpdate, Proof, Tree},
+    *,
+};
+
+type ProofBatch<F> = Box<[Proof<F>]>;
+
+pub struct MerkleTreeUpdateCircuit<F>
+where
+    F: PrimeFieldBits + serde::Serialize + FromUniformBytes<64>,
+{
+    tree: Tree<F>,
+    proofs_batches: VecDeque<ProofBatch<F>>,
+    batch_size: usize,
+}
+
+impl<F> Default for MerkleTreeUpdateCircuit<F>
+where
+    F: PrimeFieldBits + serde::Serialize + FromUniformBytes<64>,
+{
+    fn default() -> Self {
+        Self {
+            tree: Default::default(),
+            proofs_batches: VecDeque::new(),
+            batch_size: 2,
+        }
+    }
+}
+
+impl<F> MerkleTreeUpdateCircuit<F>
+where
+    F: PrimeFieldBits + serde::Serialize + FromUniformBytes<64>,
+{
+    pub fn new(batch_size: usize) -> Self {
+        Self {
+            batch_size,
+            ..Default::default()
+        }
+    }
+    pub fn new_with_random_updates(
+        rng: &mut impl Rng,
+        batch_size: usize,
+        batches_count: usize,
+    ) -> Self {
+        let mut self_ = Self::new(batch_size);
+
+        for _ in 0..=batches_count {
+            self_.random_update_leaves(rng);
+        }
+
+        self_
+    }
+
+    pub fn pop_front_proof_batch(&mut self) -> bool {
+        self.proofs_batches.pop_front().is_some()
+    }
+
+    pub fn front_proof_batch(&self) -> &ProofBatch<F> {
+        self.proofs_batches.front().as_ref().unwrap()
+    }
+
+    pub fn random_update_leaves(&mut self, mut rng: &mut impl Rng) {
+        self.update_leaves(iter::repeat_with(move || {
+            (rng.gen::<u32>() % INDEX_LIMIT, F::random(&mut rng))
+        }));
+    }
+
+    fn update_leaves(&mut self, update: impl Iterator<Item = (u32, F)>) -> (F, F) {
+        assert!(update.size_hint().0 >= self.batch_size);
+        let proofs = update
+            .map(|(index, data)| self.tree.update_leaf(index, data))
+            .take(self.batch_size)
+            .collect::<Box<[_]>>();
+
+        let old = proofs.first().unwrap().root().old;
+        let new = proofs.last().unwrap().root().new;
+
+        self.proofs_batches.push_back(proofs);
+
+        (old, new)
+    }
+}
+
+impl<F> StepCircuit<1, F> for MerkleTreeUpdateCircuit<F>
+where
+    F: PrimeFieldBits + serde::Serialize + FromUniformBytes<64>,
+{
+    type Config = MainGateConfig;
+    fn configure(cs: &mut ConstraintSystem<F>) -> Self::Config {
+        MainGate::configure(cs)
+    }
+
+    fn process_step(
+        &self,
+        _z_i: &[F; ARITY],
+        _k_table_size: u32,
+    ) -> Result<[F; ARITY], SynthesisError> {
+        Ok([self.front_proof_batch().last().as_ref().unwrap().root().new])
+    }
+
+    fn synthesize_step(
+        &self,
+        config: Self::Config,
+        layouter: &mut impl Layouter<F>,
+        z_i: &[AssignedCell<F, F>; 1],
+    ) -> Result<[AssignedCell<F, F>; 1], SynthesisError> {
+        layouter
+            .assign_region(
+                || "",
+                |region| {
+                    let mut region = RegionCtx::new(region, 0);
+
+                    let mut prev = z_i[0].clone();
+                    for proof in self.front_proof_batch().iter() {
+                        let NodeUpdate { old, new, .. } = MerkleTreeUpdateChip::new(proof.clone())
+                            .prove_next_update(&mut region, config.clone())?;
+
+                        region.constrain_equal(prev.cell(), old.cell())?;
+                        prev = new;
+                    }
+                    info!("offset = {}", region.offset);
+
+                    Ok([prev])
+                },
+            )
+            .map_err(SynthesisError::Halo2)
+    }
+}
+
+impl<F> Circuit<F> for MerkleTreeUpdateCircuit<F>
+where
+    F: PrimeFieldBits + serde::Serialize + FromUniformBytes<64>,
+{
+    type Config = <Self as StepCircuit<1, F>>::Config;
+    type FloorPlanner = SimpleFloorPlanner;
+
+    fn without_witnesses(&self) -> Self {
+        todo!()
+    }
+
+    fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+        <Self as StepCircuit<1, F>>::configure(meta)
+    }
+
+    fn synthesize(
+        &self,
+        config: Self::Config,
+        mut layouter: impl Layouter<F>,
+    ) -> Result<(), Error> {
+        layouter.assign_region(
+            || "",
+            |region| {
+                let mut region = RegionCtx::new(region, 0);
+
+                region.next();
+
+                let mut prev = Option::<AssignedCell<F, F>>::None;
+                for proof in self.front_proof_batch().iter() {
+                    let NodeUpdate { old, new, .. } = MerkleTreeUpdateChip::new(proof.clone())
+                        .prove_next_update(&mut region, config.clone())?;
+
+                    if let Some(prev) = prev {
+                        region.constrain_equal(prev.cell(), old.cell())?;
+                    }
+                    prev = Some(new);
+                }
+
+                Ok([prev])
+            },
+        )?;
+
+        Ok(())
+    }
+}

--- a/examples/merkle/main.rs
+++ b/examples/merkle/main.rs
@@ -1,21 +1,14 @@
-use std::{collections::VecDeque, env, io, iter, num::NonZeroUsize, path::Path};
+use std::{env, io, num::NonZeroUsize, path::Path};
 
 use bn256::G1 as C1;
 use grumpkin::G1 as C2;
-use rand::Rng;
 use sirius::{
     commitment::CommitmentKey,
-    halo2_proofs::{circuit::*, plonk::*},
-    halo2curves::{
-        bn256,
-        ff::{Field, FromUniformBytes, PrimeFieldBits},
-        grumpkin, CurveAffine, CurveExt,
-    },
-    ivc::{step_circuit, CircuitPublicParamsInput, PublicParams, StepCircuit, SynthesisError, IVC},
-    main_gate::{MainGate, RegionCtx},
+    halo2curves::{bn256, ff::Field, grumpkin, CurveAffine, CurveExt},
+    ivc::{step_circuit, CircuitPublicParamsInput, PublicParams, IVC},
     poseidon::ROPair,
 };
-use tracing::{info, info_span};
+use tracing::info_span;
 
 type C1Affine = <C1 as sirius::halo2curves::group::prime::PrimeCurve>::Affine;
 type C2Affine = <C2 as sirius::halo2curves::group::prime::PrimeCurve>::Affine;
@@ -31,7 +24,6 @@ const LIMBS_COUNT_LIMIT: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(10)
 
 const COMMITMENT_KEY_SIZE: usize = 23;
 
-const INDEX_LIMIT: u32 = 1 << 31;
 const ARITY: usize = 1;
 
 const CIRCUIT_TABLE_SIZE1: usize = 17;
@@ -39,181 +31,11 @@ const CIRCUIT_TABLE_SIZE2: usize = 17;
 
 mod merkle_tree_gadget;
 
-use merkle_tree_gadget::{
-    chip::MerkleTreeUpdateChip,
-    off_circuit::{NodeUpdate, Proof, Tree},
-    *,
-};
+use merkle_tree_gadget::{off_circuit::Tree, *};
 use tracing_subscriber::{filter::LevelFilter, fmt::format::FmtSpan, EnvFilter};
 
-type ProofBatch<F> = Box<[Proof<F>]>;
-pub struct MerkleTreeUpdateCircuit<F>
-where
-    F: PrimeFieldBits + serde::Serialize + FromUniformBytes<64>,
-{
-    tree: Tree<F>,
-    proofs_batches: VecDeque<ProofBatch<F>>,
-    batch_size: usize,
-}
-
-impl<F> Default for MerkleTreeUpdateCircuit<F>
-where
-    F: PrimeFieldBits + serde::Serialize + FromUniformBytes<64>,
-{
-    fn default() -> Self {
-        Self {
-            tree: Default::default(),
-            proofs_batches: VecDeque::new(),
-            batch_size: 2,
-        }
-    }
-}
-
-impl<F> MerkleTreeUpdateCircuit<F>
-where
-    F: PrimeFieldBits + serde::Serialize + FromUniformBytes<64>,
-{
-    pub fn new(batch_size: usize) -> Self {
-        Self {
-            batch_size,
-            ..Default::default()
-        }
-    }
-    pub fn new_with_random_updates(
-        rng: &mut impl Rng,
-        batch_size: usize,
-        batches_count: usize,
-    ) -> Self {
-        let mut self_ = Self::new(batch_size);
-
-        for _ in 0..=batches_count {
-            self_.random_update_leaves(rng);
-        }
-
-        self_
-    }
-
-    pub fn pop_front_proof_batch(&mut self) -> bool {
-        self.proofs_batches.pop_front().is_some()
-    }
-
-    pub fn front_proof_batch(&self) -> &ProofBatch<F> {
-        self.proofs_batches.front().as_ref().unwrap()
-    }
-
-    pub fn random_update_leaves(&mut self, mut rng: &mut impl Rng) {
-        self.update_leaves(iter::repeat_with(move || {
-            (rng.gen::<u32>() % INDEX_LIMIT, F::random(&mut rng))
-        }));
-    }
-
-    fn update_leaves(&mut self, update: impl Iterator<Item = (u32, F)>) -> (F, F) {
-        assert!(update.size_hint().0 >= self.batch_size);
-        let proofs = update
-            .map(|(index, data)| self.tree.update_leaf(index, data))
-            .take(self.batch_size)
-            .collect::<Box<[_]>>();
-
-        let old = proofs.first().unwrap().root().old;
-        let new = proofs.last().unwrap().root().new;
-
-        self.proofs_batches.push_back(proofs);
-
-        (old, new)
-    }
-}
-
-impl<F> StepCircuit<1, F> for MerkleTreeUpdateCircuit<F>
-where
-    F: PrimeFieldBits + serde::Serialize + FromUniformBytes<64>,
-{
-    type Config = MainGateConfig;
-    fn configure(cs: &mut ConstraintSystem<F>) -> Self::Config {
-        MainGate::configure(cs)
-    }
-
-    fn process_step(
-        &self,
-        _z_i: &[F; ARITY],
-        _k_table_size: u32,
-    ) -> Result<[F; ARITY], SynthesisError> {
-        Ok([self.front_proof_batch().last().as_ref().unwrap().root().new])
-    }
-
-    fn synthesize_step(
-        &self,
-        config: Self::Config,
-        layouter: &mut impl Layouter<F>,
-        z_i: &[AssignedCell<F, F>; 1],
-    ) -> Result<[AssignedCell<F, F>; 1], SynthesisError> {
-        layouter
-            .assign_region(
-                || "",
-                |region| {
-                    let mut region = RegionCtx::new(region, 0);
-
-                    let mut prev = z_i[0].clone();
-                    for proof in self.front_proof_batch().iter() {
-                        let NodeUpdate { old, new, .. } = MerkleTreeUpdateChip::new(proof.clone())
-                            .prove_next_update(&mut region, config.clone())?;
-
-                        region.constrain_equal(prev.cell(), old.cell())?;
-                        prev = new;
-                    }
-                    info!("offset = {}", region.offset);
-
-                    Ok([prev])
-                },
-            )
-            .map_err(SynthesisError::Halo2)
-    }
-}
-
-impl<F> Circuit<F> for MerkleTreeUpdateCircuit<F>
-where
-    F: PrimeFieldBits + serde::Serialize + FromUniformBytes<64>,
-{
-    type Config = <Self as StepCircuit<1, F>>::Config;
-    type FloorPlanner = SimpleFloorPlanner;
-
-    fn without_witnesses(&self) -> Self {
-        todo!()
-    }
-
-    fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
-        <Self as StepCircuit<1, F>>::configure(meta)
-    }
-
-    fn synthesize(
-        &self,
-        config: Self::Config,
-        mut layouter: impl Layouter<F>,
-    ) -> Result<(), Error> {
-        layouter.assign_region(
-            || "",
-            |region| {
-                let mut region = RegionCtx::new(region, 0);
-
-                region.next();
-
-                let mut prev = Option::<AssignedCell<F, F>>::None;
-                for proof in self.front_proof_batch().iter() {
-                    let NodeUpdate { old, new, .. } = MerkleTreeUpdateChip::new(proof.clone())
-                        .prove_next_update(&mut region, config.clone())?;
-
-                    if let Some(prev) = prev {
-                        region.constrain_equal(prev.cell(), old.cell())?;
-                    }
-                    prev = Some(new);
-                }
-
-                Ok([prev])
-            },
-        )?;
-
-        Ok(())
-    }
-}
+pub mod circuit;
+use circuit::MerkleTreeUpdateCircuit;
 
 fn get_or_create_commitment_key<C: CurveAffine>(
     k: usize,

--- a/examples/merkle/mod.rs
+++ b/examples/merkle/mod.rs
@@ -1,0 +1,5 @@
+pub mod circuit;
+pub mod merkle_tree_gadget;
+
+pub use circuit::MerkleTreeUpdateCircuit;
+pub use merkle_tree_gadget::off_circuit::Tree;


### PR DESCRIPTION
**Motivation**
For easier and faster benchmarking, cli should be improved and merkle-tree circuit should be added there

**Overview**
- added possibility to select any combination of circuits to start within cli
- for merkle added possibility to change circuits in intervals between fold_step

NOTE: there is a nasty big match inside that can be simplified with macros, I'll allocate an issue for that later
