### PR TITLE
feat(example): arg to write logs into file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ bincode = "1.3"
 clap = { version = "4.5.4", features = ["derive"] }
 criterion = "0.5.1"
 dhat = "0.3.3"
+git2 = "0.19.0"
 maplit = "1.0.2"
 prettytable-rs = "0.10.0"
 tempfile = "3.9.0"

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -141,7 +141,10 @@ impl Args {
             } else {
                 builder.with_writer(file).init();
             }
-            println!("logs will be writed to: {}", log_filename.to_string_lossy());
+            println!(
+                "The logs will be written to the file: {}",
+                log_filename.to_string_lossy()
+            );
         } else if self.json_logs {
             builder.json().init();
         } else {

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -73,7 +73,6 @@ struct Args {
 
 impl Args {
     fn build_log_filename(&self) -> Option<PathBuf> {
-        const LOGS_SUBFOLDER: &str = ".logs";
         if !self.file_logs {
             return None;
         }
@@ -86,35 +85,8 @@ impl Args {
             fold_step_count,
             ..
         } = &self;
-        // Open the repository in the current directory
-        let repo = Repository::discover(".");
 
-        // Get the current branch name
-        let branch_name = repo
-            .as_ref()
-            .ok()
-            .and_then(|repo| {
-                repo.head()
-                    .ok()
-                    .and_then(|head| head.shorthand().map(String::from))
-            })
-            .unwrap_or_else(|| "unknown_branch".to_string());
-
-        let branch_log_dir = match repo {
-            Ok(repo) => repo.workdir().unwrap().join(LOGS_SUBFOLDER),
-            Err(_) => {
-                // `eprintln`, because logger not initialized
-                eprintln!("Can't find git-repo, use current dir");
-                Path::new(".").join(LOGS_SUBFOLDER)
-            }
-        }
-        .join(branch_name);
-
-        fs::create_dir_all(&branch_log_dir).unwrap_or_else(|err| {
-            panic!("Failed to create log directory {branch_log_dir:?}: {err:?}")
-        });
-
-        Some(branch_log_dir.join(format!(
+        Some(build_log_folder().join(format!(
                 "sirius_{primary_circuit}-{primary_repeat_count}_{secondary_circuit}-{secondary_repeat_count}_{fold_step_count}.log"
         )))
     }
@@ -153,6 +125,32 @@ impl Args {
 
         info!("start with args: {self:?}");
     }
+}
+
+pub fn build_log_folder() -> PathBuf {
+    const LOGS_SUBFOLDER: &str = ".logs";
+
+    let Ok(repo) = Repository::discover(".") else {
+        return Path::new(LOGS_SUBFOLDER).to_path_buf();
+    };
+
+    // Get the current branch name
+    let branch_name = repo
+        .head()
+        .ok()
+        .and_then(|head| head.shorthand().map(String::from))
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let branch_log_dir = repo
+        .workdir()
+        .unwrap()
+        .join(LOGS_SUBFOLDER)
+        .join(branch_name);
+
+    fs::create_dir_all(&branch_log_dir)
+        .unwrap_or_else(|err| panic!("Failed to create log directory {branch_log_dir:?}: {err:?}"));
+
+    branch_log_dir
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum, Debug)]

--- a/examples/merkle/kzg.rs
+++ b/examples/merkle/kzg.rs
@@ -144,7 +144,7 @@ pub fn run(repeat_count: usize, clean_cache: bool) {
         OsRng,
         Blake2bWrite<Vec<u8>, C1Affine, Challenge255<_>>,
         _,
-    >(&params, &pk, &[circuit], &[], OsRng, &mut transcript)
+    >(&params, &pk, &[circuit], &[&[]], OsRng, &mut transcript)
     .expect("proof generation should not fail");
     let proof = transcript.finalize();
 

--- a/examples/merkle/main.rs
+++ b/examples/merkle/main.rs
@@ -191,10 +191,13 @@ impl Args {
             panic!("Failed to create log directory {branch_log_dir:?}: {err:?}")
         });
 
-        Some(branch_log_dir.join(format!(
-            "{mode}_merkle-1_trivial-1_{repeat_count}.log",
-            mode = (*mode).unwrap_or_default()
-        )))
+        Some(branch_log_dir.join(match mode {
+            None | Some(ProofSystem::Sirius) => {
+                format!("sirius_merkle-1_trivial-1_{repeat_count}.log")
+            }
+            Some(ProofSystem::Halo2Kzg) => format!("halo2_kzg_merkle_{repeat_count}.log"),
+            Some(ProofSystem::Halo2Ipa) => format!("halo2_ipa_merkle_{repeat_count}.log"),
+        }))
     }
 
     fn init_logger(&self) {


### PR DESCRIPTION
**Motivation**
In all scripts, I redirect logs to files where the file name is the defining file for the run case. To simplify the startup scripts of different scripts I added file creation at the Rust code level

**Overview**
- Made a flag to redirect output to a file
- Used git2 crate to find git-workdir when running from any repository directory
- Made for cli & merkle

