### PR TITLE
refactor(nifs): use `PlonkTrace` in sps protocol

### DIFF
--- a/src/nifs/protogalaxy/mod.rs
+++ b/src/nifs/protogalaxy/mod.rs
@@ -52,9 +52,9 @@ impl<C: CurveAffine, const L: usize> FoldingScheme<C, L> for ProtoGalaxy<C> {
         pp: &Self::ProverParam,
         ro_nark: &mut impl ROTrait<C::Base>,
     ) -> Result<PlonkTrace<C>, Error> {
-        let (u, w) =
-            pp.S.run_sps_protocol(ck, instance, witness, ro_nark, pp.S.num_challenges)?;
-        Ok(PlonkTrace { u, w })
+        Ok(pp
+            .S
+            .run_sps_protocol(ck, instance, witness, ro_nark, pp.S.num_challenges)?)
     }
 
     fn prove(

--- a/src/nifs/protogalaxy/poly/mod.rs
+++ b/src/nifs/protogalaxy/poly/mod.rs
@@ -411,7 +411,7 @@ mod test {
         let S = runner.try_collect_plonk_structure().unwrap();
         let witness = runner.try_collect_witness().unwrap();
 
-        let (u, w) = S
+        let PlonkTrace { u, w } = S
             .run_sps_protocol(
                 &CommitmentKey::setup(17, b""),
                 &[],

--- a/src/nifs/vanilla.rs
+++ b/src/nifs/vanilla.rs
@@ -168,9 +168,9 @@ impl<C: CurveAffine> FoldingScheme<C> for VanillaFS<C> {
         pp: &VanillaFSProverParam<C>,
         ro_nark: &mut impl ROTrait<C::Base>,
     ) -> Result<PlonkTrace<C>, Error> {
-        let (u, w) =
-            pp.S.run_sps_protocol(ck, instance, witness, ro_nark, pp.S.num_challenges)?;
-        Ok(PlonkTrace { u, w })
+        Ok(pp
+            .S
+            .run_sps_protocol(ck, instance, witness, ro_nark, pp.S.num_challenges)?)
     }
 
     /// Generates a proof of correct folding using the NIFS protocol.


### PR DESCRIPTION
**Motivation**
Since we already have a type that represents this tuple, we can use it

Part of #266

**Overview**
Just change return type in API