### PR TITLE
refactor(nifs): err in `nifs::FoldingScheme`

### DIFF
--- a/src/ivc/incrementally_verifiable_computation.rs
+++ b/src/ivc/incrementally_verifiable_computation.rs
@@ -52,7 +52,7 @@ pub enum Error {
     #[error("TODO")]
     Sps(#[from] sps::Error),
     #[error("TODO")]
-    NIFS(#[from] nifs::Error),
+    NIFS(#[from] nifs::vanilla::Error),
     #[error("TODO")]
     VerifyFailed(Vec<VerificationError>),
 }

--- a/src/ivc/public_params.rs
+++ b/src/ivc/public_params.rs
@@ -33,7 +33,7 @@ pub enum Error {
     #[error("Error while calculate digest of pp")]
     WhileDigest(#[from] io::Error),
     #[error("While calculate intiail plonk relaxed trace of secondary circuit: {0:?}")]
-    WhileGeneratePlonkTrace(#[from] nifs::Error),
+    WhileGeneratePlonkTrace(#[from] nifs::vanilla::Error),
     #[error("While calculate intiail plonk relaxed trace of secondary circuit, error was occured in `process_step`: {0:?}")]
     WhileProcessStep(#[from] ivc::step_circuit::SynthesisError),
 }

--- a/src/nifs/protogalaxy/mod.rs
+++ b/src/nifs/protogalaxy/mod.rs
@@ -10,6 +10,7 @@ use crate::{
     ff::PrimeField,
     plonk::{PlonkStructure, PlonkTrace, RelaxedPlonkInstance},
     polynomial::univariate::UnivariatePoly,
+    sps,
 };
 
 mod accumulator;
@@ -76,7 +77,16 @@ pub struct ProtoGalaxyProof<F: PrimeField> {
     pub poly_K: UnivariatePoly<F>,
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error(transparent)]
+    Sps(#[from] sps::Error),
+    #[error(transparent)]
+    Poly(#[from] poly::Error),
+}
+
 impl<C: CurveAffine, const L: usize> FoldingScheme<C, L> for ProtoGalaxy<C> {
+    type Error = Error;
     type ProverParam = ProtoGalaxyProverParam<C>;
     type VerifierParam = C;
     type Accumulator = Accumulator<C>;

--- a/src/nifs/tests.rs
+++ b/src/nifs/tests.rs
@@ -25,7 +25,7 @@ use crate::{
 #[derive(thiserror::Error, Debug)]
 enum Error<C: CurveAffine> {
     #[error(transparent)]
-    Nifs(#[from] nifs::Error),
+    Nifs(#[from] nifs::vanilla::Error),
     #[error(transparent)]
     Plonk(#[from] plonk::Error),
     #[error("while verify: {errors:?}")]

--- a/src/nifs/vanilla.rs
+++ b/src/nifs/vanilla.rs
@@ -146,7 +146,22 @@ impl<C: CurveAffine> VanillaFS<C> {
     }
 }
 
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    #[error("parameter not setup")]
+    ParamNotSetup,
+    #[error(transparent)]
+    Eval(#[from] EvalError),
+    #[error(transparent)]
+    Sps(#[from] SpsError),
+    #[error(transparent)]
+    Plonk(#[from] Halo2Error),
+    #[error(transparent)]
+    Commitment(#[from] commitment::Error),
+}
+
 impl<C: CurveAffine> FoldingScheme<C> for VanillaFS<C> {
+    type Error = Error;
     type ProverParam = VanillaFSProverParam<C>;
     type VerifierParam = C;
     type Accumulator = RelaxedPlonkTrace<C>;


### PR DESCRIPTION
**Motivation**
The errors will be different for vanila & protogalaxy, so a slightly different design of `trait FoldingScheme` methods is needed Part of #266

**Overview**
Old generic error type moved to `nifs::vanila` module
