### PR TITLE
refactor(nifs): API for `is_sat_relaxed`

### DIFF
--- a/src/nifs/mod.rs
+++ b/src/nifs/mod.rs
@@ -73,5 +73,20 @@ pub trait FoldingScheme<C: CurveAffine, const L: usize = 1> {
     ) -> Result<Self::AccumulatorInstance, Self::Error>;
 }
 
+pub trait IsSatAccumulator<C: CurveAffine>: FoldingScheme<C> {
+    type VerifyError;
+
+    fn is_sat_acc(
+        ck: &CommitmentKey<C>,
+        S: &PlonkStructure<C::ScalarExt>,
+        acc: &<Self as FoldingScheme<C>>::Accumulator,
+    ) -> Result<(), Self::VerifyError>;
+
+    fn is_sat_perm(
+        S: &PlonkStructure<C::ScalarExt>,
+        acc: &<Self as FoldingScheme<C>>::Accumulator,
+    ) -> Result<(), Self::VerifyError>;
+}
+
 #[cfg(test)]
 pub(crate) mod tests;


### PR DESCRIPTION
**Motivation**
In #267 we need to implicate a new version of `is_sat_relaxed`, right now we have one version of this function, and there should be at least two, for each of the folding schemes currently available

**Overview**
I introduced a new trait `IsSatAccumulator`, making it so that each `FoldingScheme` allows you to check whether its accumulator satisfied or not

This PR doesn't provide any new code, it's just a refactoring of the API
