### PR TITLE
fix: compatibility with zkevm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_arrays = "0.1.0"
 sha3 = "0.10"
 some-to-err = "0.2.1"
-thiserror = "1.0.0"
-tracing = { version = "0.1.37", features = ["attributes"] }
+thiserror = "1"
+tracing = { version = "0.1", features = ["attributes"] }
 
 [dependencies.poseidon]
 git = "https://github.com/privacy-scaling-explorations/poseidon"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_arrays = "0.1.0"
 sha3 = "0.10"
 some-to-err = "0.2.1"
-thiserror = "1.0.48"
-tracing = { version = "0.1.40", features = ["attributes"] }
+thiserror = "1.0.0"
+tracing = { version = "0.1.37", features = ["attributes"] }
 
 [dependencies.poseidon]
 git = "https://github.com/privacy-scaling-explorations/poseidon"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ rev = "807f8f555313f726ca03bdf941f798098f488ba4"
 
 [dependencies.halo2_proofs]
 git = "https://github.com/snarkify/halo2"
-branch = "snarkify/dev.scroll"
+branch = "snarkify/dev.scroll.alpha.1"
 
 [dev-dependencies]
 bincode = "1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ rev = "807f8f555313f726ca03bdf941f798098f488ba4"
 
 [dependencies.halo2_proofs]
 git = "https://github.com/snarkify/halo2"
-branch = "snarkify/dev.scroll.alpha.1"
+branch = "snarkify/dev.scroll.alpha.2"
 
 [dev-dependencies]
 bincode = "1.3"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,1 +1,1 @@
-toolchain.channel = "nightly-2024-05-01"
+toolchain.channel = "1.80"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,1 +1,1 @@
-toolchain.channel = "1.80"
+toolchain.channel = "nightly-2024-05-01"

--- a/src/ivc/step_circuit.rs
+++ b/src/ivc/step_circuit.rs
@@ -10,7 +10,7 @@ use crate::{ff::PrimeField, main_gate::RegionCtx, table::WitnessCollector};
 #[derive(Debug, thiserror::Error)]
 pub enum SynthesisError {
     #[error(transparent)]
-    Halo2(halo2_proofs::plonk::Error),
+    Halo2(#[from] halo2_proofs::plonk::Error),
     #[error(transparent)]
     FoldError(#[from] fold_relaxed_plonk_instance_chip::Error),
 }


### PR DESCRIPTION
**Motivation**
As part of https://github.com/snarkify/sirius/milestone/4

**Overview**
Make less strict deps of some crates & impl `From<Halo2Error>` for `sirius::SynthesisError~
