### PR TITLE
feat(nifs): impl `ProtoGalaxy::is_sat_acc`

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,1 +1,1 @@
-toolchain.channel = "1.80"
+toolchain.channel = "1.80.1"

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -38,6 +38,16 @@ where
 {
 }
 
+fn bitreverse(input: usize, limit: usize) -> usize {
+    assert!(
+        limit <= usize::BITS as usize,
+        "Bit length exceeds `usize` capacity"
+    );
+
+    let mask = (1 << limit) - 1;
+    input.reverse_bits() >> (usize::BITS as usize - limit) & mask
+}
+
 /// Performs a radix-$2$ Fast-Fourier Transformation (FFT) on a vector of size
 /// $n = 2^k$, when provided `log_n` = $k$ and an element of multiplicative
 /// order $n$ called `omega` ($\omega$). The result is that the vector `a`, when
@@ -49,16 +59,6 @@ where
 ///
 /// This will use multithreading if beneficial.
 pub(crate) fn best_fft<Scalar: Field, G: FftGroup<Scalar>>(a: &mut [G], omega: Scalar, log_n: u32) {
-    fn bitreverse(input: usize, limit: usize) -> usize {
-        assert!(
-            limit <= usize::BITS as usize,
-            "Bit length exceeds `usize` capacity"
-        );
-
-        let mask = (1 << limit) - 1;
-        input.reverse_bits() >> (usize::BITS as usize - limit) & mask
-    }
-
     let threads = rayon::current_num_threads();
     let log_threads = threads.ilog2();
     let n = a.len();
@@ -157,15 +157,23 @@ pub(crate) fn recursive_butterfly_arithmetic<Scalar: Field, G: FftGroup<Scalar>>
 /// FFT with input size 1 << log_n
 ///
 /// This is a wrapper around fn [`best_fft`]
-pub fn fft<F: PrimeField>(a: &mut [F], log_n: u32) {
+pub fn fft<F: PrimeField>(a: &mut [F]) {
+    assert!(a.len().is_power_of_two());
+    let log_n = a.len().ilog2();
+
     best_fft(a, get_omega_or_inv(log_n, false), log_n);
 }
 
 /// Inverse fft with input size 1 << log_n
-pub fn ifft<F: PrimeField>(a: &mut [F], log_n: u32) {
+pub fn ifft<F: PrimeField>(a: &mut [F]) {
+    assert!(a.len().is_power_of_two());
+    let log_n = a.len().ilog2();
+
     let omega_inv = get_omega_or_inv(log_n, true);
     let divisor = get_ifft_divisor(log_n);
+
     best_fft(a, omega_inv, log_n);
+
     util::parallelize(a, |(a, _)| {
         for a in a {
             *a *= &divisor;
@@ -176,21 +184,15 @@ pub fn ifft<F: PrimeField>(a: &mut [F], log_n: u32) {
 /// coset FFT
 /// input `a` corresponds to coefficients of a polynoimal
 pub fn coset_fft<F: WithSmallOrderMulGroup<3>>(a: &mut [F]) {
-    assert!(a.len().is_power_of_two());
-    let log_n = a.len().ilog2();
-
     distribute_powers_zeta(a, F::ZETA, F::ZETA.square(), true);
 
-    fft(a, log_n);
+    fft(a);
 }
 
 /// coset IFFT
 /// input `a` corresponds to values of a polynoimal on coset domain zeta*{1,omega,omega^2,...}
 pub fn coset_ifft<F: WithSmallOrderMulGroup<3>>(a: &mut [F]) -> UnivariatePoly<F> {
-    assert!(a.len().is_power_of_two());
-    let log_n = a.len().ilog2();
-
-    ifft(a, log_n);
+    ifft(a);
     distribute_powers_zeta(a, F::ZETA, F::ZETA.square(), false);
     UnivariatePoly(a.to_vec().into_boxed_slice())
 }
@@ -227,7 +229,7 @@ fn distribute_powers_zeta<F: PrimeField>(
 
 #[cfg(test)]
 mod tests {
-    use std::array;
+    use std::{array, iter};
 
     use itertools::Itertools;
     use rand_core::OsRng;
@@ -250,7 +252,7 @@ mod tests {
         .map(|s| Fr::from_str_vartime(s).unwrap());
 
         let mut a: [Fr; 8] = array::from_fn(|idx| Fr::from_u128(idx as u128));
-        fft(&mut a, 3);
+        fft(&mut a);
 
         a.iter().zip_eq(test_vector.iter()).for_each(|(lhs, rhs)| {
             assert_eq!(*lhs, *rhs);
@@ -258,21 +260,36 @@ mod tests {
     }
 
     fn generate_random_input<F: PrimeField>(k: u32) -> Vec<F> {
-        let n = 1 << k;
-        vec![F::random(OsRng); n]
+        iter::repeat_with(|| F::random(OsRng))
+            .take(1 << k)
+            .collect()
     }
 
     #[test]
     fn fft_random_input_test() {
         for k in [4, 5, 6, 7, 8] {
-            let input: Vec<Fr> = generate_random_input(k);
-            let mut a: Vec<Fr> = input.clone();
+            let original = generate_random_input::<Fr>(k);
+            let mut actual = original.clone();
 
-            fft(&mut a, k);
+            fft(&mut actual);
+            ifft(&mut actual);
 
-            ifft(&mut a, k);
+            actual.into_iter().zip_eq(original).for_each(|(ai, bi)| {
+                assert_eq!(ai, bi);
+            });
+        }
+    }
 
-            a.into_iter().zip_eq(input).for_each(|(ai, bi)| {
+    #[test]
+    fn coset_fft_random_input_test() {
+        for k in [4, 5, 6, 7, 8] {
+            let original = generate_random_input::<Fr>(k);
+            let mut actual = original.clone();
+
+            coset_fft(&mut actual);
+            coset_ifft(&mut actual);
+
+            actual.into_iter().zip_eq(original).for_each(|(ai, bi)| {
                 assert_eq!(ai, bi);
             });
         }

--- a/src/gadgets/nonnative/bn/big_uint_mul_mod_chip/tests.rs
+++ b/src/gadgets/nonnative/bn/big_uint_mul_mod_chip/tests.rs
@@ -882,7 +882,6 @@ mod decompose_tests {
                             F::from_u128(u128::MAX),
                             F::from_u128(u128::MAX) * F::from_u128(1_000_000_000),
                         ] {
-                            dbg!(&val);
                             region.next();
 
                             let new_val = region

--- a/src/nifs/protogalaxy/accumulator.rs
+++ b/src/nifs/protogalaxy/accumulator.rs
@@ -3,13 +3,16 @@ use std::iter;
 use crate::{
     ff::Field,
     halo2curves::CurveAffine,
-    plonk::{self, PlonkInstance, PlonkTrace},
+    plonk::{self, PlonkInstance, PlonkTrace, PlonkWitness},
     poseidon::{AbsorbInRO, ROTrait},
     util,
 };
 
 /// Represents an accumulator for folding multiple instances into a single instance,
 /// following the accumulation schemes.
+///
+/// TODO#266 Docs
+#[derive(Clone, Debug)]
 pub struct Accumulator<C: CurveAffine> {
     /// `φ`: Represents the combined state of all instances & witnesses. It is a summary that
     /// captures the essential data and relationships from the instances being merged.
@@ -49,6 +52,7 @@ impl<C: CurveAffine> Accumulator<C> {
 
 /// Represents an accumulator for folding multiple instances into a single instance,
 /// following the accumulation schemes.
+#[derive(Debug, PartialEq, Eq)]
 pub struct AccumulatorInstance<C: CurveAffine> {
     /// `φ`: Represents the combined state of all instances. It is a summary that captures the
     /// essential data and relationships from the instances being merged.
@@ -61,6 +65,17 @@ pub struct AccumulatorInstance<C: CurveAffine> {
     /// `e`: an accumulated value that encapsulates the result of the folding operation. it serves
     /// as a concise representation of the correctness and properties of the folded instances.
     pub(super) e: C::ScalarExt,
+}
+
+impl<C: CurveAffine> AccumulatorInstance<C> {
+    pub fn into_acc(self, w: PlonkWitness<C::Scalar>) -> Accumulator<C> {
+        let Self { ins, betas, e } = self;
+        Accumulator {
+            trace: PlonkTrace { u: ins, w },
+            betas,
+            e,
+        }
+    }
 }
 
 impl<C: CurveAffine> From<Accumulator<C>> for AccumulatorInstance<C> {

--- a/src/nifs/protogalaxy/mod.rs
+++ b/src/nifs/protogalaxy/mod.rs
@@ -333,7 +333,7 @@ impl<C: CurveAffine, const L: usize> FoldingScheme<C, L> for ProtoGalaxy<C, L> {
             .absorb_field_iter(poly_K.iter().map(|v| util::fe_to_fe(v).unwrap()))
             .squeeze::<C>(NUM_CHALLENGE_BITS);
 
-        let lagrange_for_gamma = lagrange::iter_eval_lagrange_poly_for_cyclic_group(gamma, log_n)
+        let polys_L_in_gamma = lagrange::iter_eval_lagrange_poly_for_cyclic_group(gamma, log_n)
             .take(L + 1)
             .collect::<Box<[_]>>();
 
@@ -345,12 +345,12 @@ impl<C: CurveAffine, const L: usize> FoldingScheme<C, L> for ProtoGalaxy<C, L> {
                     u: Self::fold_instance(
                         accumulator.trace.u,
                         incoming.iter().map(|tr| &tr.u),
-                        lagrange_for_gamma.iter().copied(),
+                        polys_L_in_gamma.iter().copied(),
                     ),
                     w: Self::fold_witness(
                         accumulator.trace.w,
                         incoming.iter().map(|tr| &tr.w),
-                        lagrange_for_gamma.iter().copied(),
+                        polys_L_in_gamma.iter().copied(),
                     ),
                 },
             },

--- a/src/nifs/protogalaxy/poly/folded_witness.rs
+++ b/src/nifs/protogalaxy/poly/folded_witness.rs
@@ -1,6 +1,7 @@
 use std::iter;
 
 use rayon::prelude::*;
+use itertools::*;
 
 use crate::{
     ff::PrimeField,
@@ -26,7 +27,7 @@ impl<F: PrimeField> FoldedWitness<F> {
 
         folded_witnesses_collection
             .into_iter()
-            .zip(folded_challenges_collection)
+            .zip_eq(folded_challenges_collection)
             .map(|(witness, challenges)| Self {
                 witness,
                 challenges,

--- a/src/nifs/protogalaxy/poly/folded_witness.rs
+++ b/src/nifs/protogalaxy/poly/folded_witness.rs
@@ -9,12 +9,12 @@ use crate::{
     util::MultiCartesianProduct,
 };
 
-pub(crate) struct FoldedTrace<F: PrimeField> {
+pub(crate) struct FoldedWitness<F: PrimeField> {
     witness: PlonkWitness<F>,
     challenges: Vec<F>,
 }
 
-impl<F: PrimeField> FoldedTrace<F> {
+impl<F: PrimeField> FoldedWitness<F> {
     pub(crate) fn new(
         points_for_fft: &[F],
         accumulator: &(impl Sync + GetChallenges<F> + GetWitness<F>),
@@ -34,12 +34,12 @@ impl<F: PrimeField> FoldedTrace<F> {
             .collect()
     }
 }
-impl<F: PrimeField> GetChallenges<F> for FoldedTrace<F> {
+impl<F: PrimeField> GetChallenges<F> for FoldedWitness<F> {
     fn get_challenges(&self) -> &[F] {
         &self.challenges
     }
 }
-impl<F: PrimeField> GetWitness<F> for FoldedTrace<F> {
+impl<F: PrimeField> GetWitness<F> for FoldedWitness<F> {
     fn get_witness(&self) -> &[Vec<F>] {
         &self.witness.W
     }
@@ -50,7 +50,7 @@ impl<F: PrimeField> GetWitness<F> for FoldedTrace<F> {
 ///
 /// Since the number of rows is large, we do this in one pass, counting the points for each
 /// challenge at each iteration, and laying them out in separate [`PlonkWitness`] at the end.
-fn fold_witnesses<F: PrimeField>(
+pub fn fold_witnesses<F: PrimeField>(
     X_challenges: &[F],
     accumulator: &(impl GetWitness<F> + Sync),
     witnesses: &[impl Sync + GetWitness<F>],

--- a/src/nifs/protogalaxy/poly/folded_witness.rs
+++ b/src/nifs/protogalaxy/poly/folded_witness.rs
@@ -62,7 +62,8 @@ pub fn fold_witnesses<F: PrimeField>(
     let lagrange_poly_by_challenge = X_challenges
         .iter()
         .map(|X| {
-            lagrange::iter_eval_lagrange_poly_for_cyclic_group(*X, lagrange_domain).collect::<Box<[_]>>()
+            lagrange::iter_eval_lagrange_poly_for_cyclic_group(*X, lagrange_domain)
+                .collect::<Box<[_]>>()
         })
         .collect::<Box<[_]>>();
 

--- a/src/nifs/protogalaxy/poly/mod.rs
+++ b/src/nifs/protogalaxy/poly/mod.rs
@@ -1,4 +1,4 @@
-use std::{iter, num::NonZeroUsize};
+use std::{iter, num::NonZeroUsize, ops::Add};
 
 use itertools::*;
 use tracing::*;
@@ -390,8 +390,11 @@ fn compute_K_from_G<F: WithSmallOrderMulGroup<3>>(
     poly_G: UnivariatePoly<F>,
     poly_F_in_alpha: F,
 ) -> UnivariatePoly<F> {
-    let fft_domain_size_K =
-        (poly_G.degree() - ctx.instances_to_fold + 1).next_power_of_two() as u32;
+    let fft_domain_size_K = poly_G
+        .degree()
+        .add(1)
+        .saturating_sub(ctx.instances_to_fold)
+        .next_power_of_two() as u32;
 
     UnivariatePoly::coset_ifft(
         lagrange::iter_cyclic_subgroup::<F>(fft_domain_size_K)
@@ -609,7 +612,7 @@ mod test {
                 .for_each(|row| row.iter_mut().zip(gen.by_ref()).for_each(|(v, r)| *v = r));
             trace
         })
-        .take(2)
+        .take(3)
         .collect::<Box<[_]>>();
 
         let ctx = PolyContext::new(&S, &traces);

--- a/src/plonk/mod.rs
+++ b/src/plonk/mod.rs
@@ -738,11 +738,13 @@ pub(crate) mod test_eval_witness {
         }
 
         #[derive(Debug, Default)]
-        pub struct TestPoseidonCircuit<F: PrimeFieldBits> {
+        pub struct TestPoseidonCircuit<F: PrimeFieldBits, const L: usize = 50> {
             _p: PhantomData<F>,
         }
 
-        impl<F: PrimeFieldBits + FromUniformBytes<64>> Circuit<F> for TestPoseidonCircuit<F> {
+        impl<F: PrimeFieldBits + FromUniformBytes<64>, const L: usize> Circuit<F>
+            for TestPoseidonCircuit<F, L>
+        {
             type Config = TestPoseidonCircuitConfig;
             type FloorPlanner = SimpleFloorPlanner;
 
@@ -765,7 +767,7 @@ pub(crate) mod test_eval_witness {
                 layouter.assign_region(
                     || "poseidon hash",
                     move |region| {
-                        let z_i: [F; 50] = array::from_fn(|i| F::from(i as u64));
+                        let z_i: [F; L] = array::from_fn(|i| F::from(i as u64));
                         let ctx = &mut RegionCtx::new(region, 0);
 
                         let mut pchip = PoseidonChip::new(config.pconfig.clone(), spec.clone());
@@ -818,7 +820,7 @@ pub(crate) mod test_eval_witness {
     fn basic() {
         let runner = CircuitRunner::<Field, _>::new(
             12,
-            poseidon_circuit::TestPoseidonCircuit::default(),
+            poseidon_circuit::TestPoseidonCircuit::<_, 50>::default(),
             vec![],
         );
 

--- a/src/polynomial/lagrange.rs
+++ b/src/polynomial/lagrange.rs
@@ -49,18 +49,18 @@ pub fn iter_cyclic_subgroup<F: PrimeField>(log_n: u32) -> impl Iterator<Item = F
 /// more details
 pub fn iter_eval_lagrange_poly_for_cyclic_group<F: PrimeField>(
     X: F,
-    log_n: u32,
+    lagrange_domain: u32,
 ) -> impl Iterator<Item = F> {
-    let n = 2usize.pow(log_n);
+    let points_count = 2usize.pow(lagrange_domain);
 
-    let inverted_n = F::from_u128(n as u128)
+    let inverted_n = F::from_u128(points_count as u128)
         .invert()
         .expect("safe because it's `2^log_n`");
 
-    iter_cyclic_subgroup::<F>(log_n)
+    iter_cyclic_subgroup::<F>(lagrange_domain)
         .map(move |value| {
             let X_sub_value_inverted = X.sub(value).invert();
-            let X_pow_n_sub_1 = X.pow([n as u64]) - F::ONE;
+            let X_pow_n_sub_1 = X.pow([points_count as u64]) - F::ONE;
 
             // During the calculation, this part of the expression should be reduced to 1, but we
             // get 0/0 here, so we insert an explicit `if`.
@@ -70,7 +70,7 @@ pub fn iter_eval_lagrange_poly_for_cyclic_group<F: PrimeField>(
                 value * inverted_n * (X_pow_n_sub_1 * X_sub_value_inverted.unwrap())
             }
         })
-        .take(n)
+        .take(points_count)
 }
 
 /// This fn calculates vanishing polynomial $Z(X)$ from the formula $G(X)=F(\alpha)L_0(X)+K(X)Z(X)$

--- a/src/polynomial/lagrange.rs
+++ b/src/polynomial/lagrange.rs
@@ -60,7 +60,7 @@ pub fn iter_eval_lagrange_poly_for_cyclic_group<F: PrimeField>(
     iter_cyclic_subgroup::<F>(log_n)
         .map(move |value| {
             let challenge_sub_value_inverted = X.sub(value).invert();
-            let X_pow_n_sub_1 = eval_vanish_polynomial(log_n, X);
+            let X_pow_n_sub_1 = eval_vanish_polynomial(n, X);
 
             // During the calculation, this part of the expression should be reduced to 1, but we
             // get 0/0 here, so we insert an explicit `if`.
@@ -78,8 +78,10 @@ pub fn iter_eval_lagrange_poly_for_cyclic_group<F: PrimeField>(
 /// - `log_n` - logarithm of polynomial degree
 /// - `point` - `x` - eval Lagrange polynomials at this point
 /// # Result - x^n - 1
-pub fn eval_vanish_polynomial<F: PrimeField>(log_n: u32, point: F) -> F {
-    point.pow([1 << log_n as u64]) - F::ONE
+/// X^{2^log_n} - 1
+/// -1 * X^0 + 0 * X^1 + ... + a * X^{2^log_n}
+pub fn eval_vanish_polynomial<F: PrimeField>(degree: usize, point: F) -> F {
+    point.pow([(degree - 1) as u64]) - F::ONE
 }
 
 #[cfg(test)]

--- a/src/polynomial/lagrange.rs
+++ b/src/polynomial/lagrange.rs
@@ -22,7 +22,7 @@ use crate::{ff::PrimeField, fft};
 pub fn iter_cyclic_subgroup<F: PrimeField>(log_n: u32) -> impl Iterator<Item = F> {
     let generator: F = fft::get_omega_or_inv(log_n, false);
 
-    iter::successors(Some(F::ONE), move |val| Some(*val * generator))
+    iter::successors(Some(F::ONE), move |val| Some(*val * generator)).take(1 << log_n)
 }
 
 /// Lazy eval the values of the Lagrange polynomial for a cyclic subgroup of length `n` (`2.pow(log_n)`) at
@@ -59,15 +59,15 @@ pub fn iter_eval_lagrange_poly_for_cyclic_group<F: PrimeField>(
 
     iter_cyclic_subgroup::<F>(log_n)
         .map(move |value| {
-            let challenge_sub_value_inverted = X.sub(value).invert();
-            let X_pow_n_sub_1 = eval_vanish_polynomial(n, X);
+            let X_sub_value_inverted = X.sub(value).invert();
+            let X_pow_n_sub_1 = X.pow([n as u64]) - F::ONE;
 
             // During the calculation, this part of the expression should be reduced to 1, but we
             // get 0/0 here, so we insert an explicit `if`.
-            if X_pow_n_sub_1.is_zero_vartime() && challenge_sub_value_inverted.is_none().into() {
+            if X_pow_n_sub_1.is_zero_vartime() && X_sub_value_inverted.is_none().into() {
                 F::ONE
             } else {
-                value * inverted_n * (X_pow_n_sub_1 * challenge_sub_value_inverted.unwrap())
+                value * inverted_n * (X_pow_n_sub_1 * X_sub_value_inverted.unwrap())
             }
         })
         .take(n)
@@ -81,7 +81,7 @@ pub fn iter_eval_lagrange_poly_for_cyclic_group<F: PrimeField>(
 /// X^{2^log_n} - 1
 /// -1 * X^0 + 0 * X^1 + ... + a * X^{2^log_n}
 pub fn eval_vanish_polynomial<F: PrimeField>(degree: usize, point: F) -> F {
-    point.pow([(degree - 1) as u64]) - F::ONE
+    point.pow([degree as u64]) - F::ONE
 }
 
 #[cfg(test)]

--- a/src/polynomial/univariate.rs
+++ b/src/polynomial/univariate.rs
@@ -20,6 +20,14 @@ impl<F: Field> UnivariatePoly<F> {
     pub fn iter(&self) -> impl Iterator<Item = &F> {
         self.0.iter()
     }
+    pub fn degree(&self) -> usize {
+        self.0
+            .iter()
+            .enumerate()
+            .rev()
+            .find_map(|(i, coeff)| F::ZERO.ne(coeff).then_some(i))
+            .unwrap_or_default()
+    }
 }
 
 impl<F: Field> IntoIterator for UnivariatePoly<F> {


### PR DESCRIPTION
**Motivation**
Part of #267

**Overview**
Unfortunately, it was not possible to reuse parts of the code from `protogalaxy::poly`, so there is a slight DRY violation, however, the code there is optimized for simultaneous eval, whereas here it is a much simpler case.

- [ ] test(nifs): `protogalaxy::is_sat_{acc, perm}`