### PR TITLE
refactor(nifs): mv `Relaxed*` into 'nifs::vanilla'

### DIFF
--- a/src/ivc/incrementally_verifiable_computation.rs
+++ b/src/ivc/incrementally_verifiable_computation.rs
@@ -15,8 +15,12 @@ use crate::{
         step_folding_circuit::{StepFoldingCircuit, StepInputs},
     },
     main_gate::MainGateConfig,
-    nifs::{self, vanilla::VanillaFS, FoldingScheme, IsSatAccumulator},
-    plonk::{self, PlonkTrace, RelaxedPlonkTrace},
+    nifs::{
+        self,
+        vanilla::{accumulator::RelaxedPlonkTrace, VanillaFS},
+        FoldingScheme, IsSatAccumulator,
+    },
+    plonk::{self, PlonkTrace},
     poseidon::{random_oracle::ROTrait, ROPair},
     sps,
     table::CircuitRunner,
@@ -200,8 +204,10 @@ where
         debug!("primary z output calculated off-circuit");
 
         // Will be used as input & output `U` of zero-step of IVC
-        let secondary_relaxed_trace =
-            secondary_pre_round_plonk_trace.to_relax(pp.secondary.k_table_size() as usize);
+        let secondary_relaxed_trace = RelaxedPlonkTrace::from_regular(
+            secondary_pre_round_plonk_trace.clone(),
+            pp.secondary.k_table_size() as usize,
+        );
 
         // Prepare primary constraint system for folding
         let primary_instance = {
@@ -268,8 +274,10 @@ where
             &mut RP2::OffCircuit::new(pp.secondary.params().ro_constant().clone()),
         )?;
 
-        let primary_relaxed_trace =
-            primary_plonk_trace.to_relax(pp.primary.k_table_size() as usize);
+        let primary_relaxed_trace = RelaxedPlonkTrace::from_regular(
+            primary_plonk_trace.clone(),
+            pp.primary.k_table_size() as usize,
+        );
 
         primary_span.exit();
         let _secondary_span = info_span!("secondary").entered();

--- a/src/ivc/instance_computation.rs
+++ b/src/ivc/instance_computation.rs
@@ -10,7 +10,7 @@ use crate::{
     gadgets::{ecc::AssignedPoint, nonnative::bn::big_uint::BigUint},
     halo2curves::CurveAffine,
     main_gate::{AssignedValue, MainGate, MainGateConfig, RegionCtx, WrapValue},
-    plonk::RelaxedPlonkInstance,
+    nifs::vanilla::accumulator::RelaxedPlonkInstance,
     poseidon::{AbsorbInRO, ROCircuitTrait, ROTrait},
     util,
 };
@@ -180,6 +180,7 @@ mod tests {
     use crate::{
         ff::Field,
         halo2curves::{bn256, grumpkin},
+        plonk::PlonkInstance,
     };
 
     type C1 = <bn256::G1 as PrimeCurve>::Affine;
@@ -211,10 +212,12 @@ mod tests {
         let z_0 = [Base::from_u128(0x1024); 10];
         let z_i = [Base::from_u128(0x2048); 10];
         let relaxed = RelaxedPlonkInstance {
-            W_commitments: vec![CommitmentKey::<C1>::default_value(); 10],
+            inner: PlonkInstance {
+                W_commitments: vec![CommitmentKey::<C1>::default_value(); 10],
+                instance: vec![Scalar::from_u128(0x67899); 2],
+                challenges: vec![Scalar::from_u128(0x123456); 10],
+            },
             E_commitment: CommitmentKey::<C1>::default_value(),
-            instance: vec![Scalar::from_u128(0x67899); 2],
-            challenges: vec![Scalar::from_u128(0x123456); 10],
             u: Scalar::from_u128(u128::MAX),
         };
 

--- a/src/ivc/step_folding_circuit.rs
+++ b/src/ivc/step_folding_circuit.rs
@@ -20,7 +20,8 @@ use crate::{
         StepCircuit,
     },
     main_gate::{AdviceCyclicAssignor, MainGate, MainGateConfig, RegionCtx},
-    plonk::{PlonkInstance, RelaxedPlonkInstance},
+    nifs::vanilla::accumulator::RelaxedPlonkInstance,
+    plonk::PlonkInstance,
     poseidon::ROCircuitTrait,
     table::ConstraintSystemMetainfo,
 };

--- a/src/nifs/vanilla/accumulator.rs
+++ b/src/nifs/vanilla/accumulator.rs
@@ -1,0 +1,286 @@
+use std::{iter, ops};
+
+use halo2_proofs::arithmetic::{best_multiexp, CurveAffine};
+use itertools::Itertools;
+use rayon::prelude::*;
+use tracing::{debug, instrument, warn};
+
+use crate::{
+    commitment::CommitmentKey,
+    ff::{Field, PrimeField},
+    plonk::{
+        self, GetChallenges, GetWitness, PlonkInstance, PlonkStructure, PlonkTrace, PlonkWitness,
+    },
+    poseidon::{AbsorbInRO, ROTrait},
+    util,
+};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RelaxedPlonkInstance<C: CurveAffine> {
+    pub(crate) inner: PlonkInstance<C>,
+    pub(crate) E_commitment: C,
+    /// homogenous variable u
+    pub(crate) u: C::ScalarExt,
+}
+impl<C: CurveAffine> ops::Deref for RelaxedPlonkInstance<C> {
+    type Target = PlonkInstance<C>;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<C: CurveAffine> From<PlonkInstance<C>> for RelaxedPlonkInstance<C> {
+    fn from(inner: PlonkInstance<C>) -> Self {
+        RelaxedPlonkInstance {
+            inner,
+            E_commitment: C::identity(),
+            u: C::ScalarExt::ONE,
+        }
+    }
+}
+
+impl<C: CurveAffine> From<&PlonkInstance<C>> for RelaxedPlonkInstance<C> {
+    fn from(input: &PlonkInstance<C>) -> Self {
+        Self::from(input.clone())
+    }
+}
+
+impl<C: CurveAffine> RelaxedPlonkInstance<C> {
+    pub fn new(num_io: usize, num_challenges: usize, num_witness: usize) -> Self {
+        Self {
+            inner: PlonkInstance {
+                W_commitments: vec![CommitmentKey::<C>::default_value(); num_witness],
+                instance: vec![C::ScalarExt::ZERO; num_io],
+                challenges: vec![C::ScalarExt::ZERO; num_challenges],
+            },
+            E_commitment: CommitmentKey::<C>::default_value(),
+            u: Self::DEFAULT_u,
+        }
+    }
+
+    // In order not to confuse `U` & `u`, which means different things in Sirius, non upper
+    // case is allowed here.
+    #[allow(non_upper_case_globals)]
+    pub const DEFAULT_u: C::ScalarExt = C::ScalarExt::ONE;
+
+    /// Folds a `RelaxedPlonkInstance` with another `PlonkInstance` while preserving their Plonk relation.
+    ///
+    /// This function combines the current relaxed Plonk instance with a given Plonk instance by
+    /// computing new commitments, instances, and scalar values using provided cross-term
+    /// commitments and random value `r`.
+    ///
+    /// # Arguments
+    /// * `U2`: A `PlonkInstance` used to combine with the current relaxed Plonk instance.
+    /// * `cross_term_commits`: The commitments of the cross terms used to calculate the folded
+    /// value comm_E
+    /// * `r`: A random scalar value used for combining the instances and commitments.
+    ///
+    /// # Returns
+    /// The folded `RelaxedPlonkInstance` after combining the instances and commitments.
+    /// for detail of how fold works, please refer to: [nifs](https://hackmd.io/d7syox5tTeaxkepc9nLvHw?view#31-NIFS)
+    #[instrument(name = "fold_plonk_instance", skip_all)]
+    pub fn fold(&self, U2: &PlonkInstance<C>, cross_term_commits: &[C], r: &C::ScalarExt) -> Self {
+        let W_commitments = self
+            .W_commitments
+            .iter()
+            .zip(U2.W_commitments.clone())
+            .enumerate()
+            .map(|(W_index, (W1, W2))| {
+                let rW = best_multiexp(&[*r], &[W2]).into();
+                let res = *W1 + rW;
+                debug!(
+                    "W1 = {W1:?}; W2 = {W2:?}; rW2[{W_index}] = {rW:?}; rW1 + rW2 * r = {res:?}"
+                );
+                res.into()
+            })
+            .collect::<Vec<C>>();
+
+        let instance = self
+            .instance
+            .par_iter()
+            .zip(&U2.instance)
+            .map(|(a, b)| *a + *r * b)
+            .collect::<Vec<C::ScalarExt>>();
+
+        let challenges = self
+            .challenges
+            .iter()
+            .zip_eq(U2.challenges.iter())
+            .map(|(a, b)| *a + *r * b)
+            .collect::<Vec<C::ScalarExt>>();
+
+        let u = self.u + *r;
+
+        let comm_E = cross_term_commits
+            .iter()
+            .zip(iter::successors(Some(*r), |el| Some(*el * *r))) // r^1, r^2, ...
+            .map(|(tk, power_of_r)| best_multiexp(&[power_of_r], &[*tk]).into())
+            .fold(self.E_commitment, |acc, x| (acc + x).into());
+
+        RelaxedPlonkInstance {
+            inner: PlonkInstance {
+                W_commitments,
+                instance,
+                challenges,
+            },
+            u,
+            E_commitment: comm_E,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct RelaxedPlonkWitness<F: PrimeField> {
+    /// each vector element in W is a vector folded from an old [`RelaxedPlonkWitness.W`] and [`PlonkWitness.W`]
+    pub(crate) inner: PlonkWitness<F>,
+    pub(crate) E: Box<[F]>,
+}
+
+impl<F: PrimeField> ops::Deref for RelaxedPlonkWitness<F> {
+    type Target = PlonkWitness<F>;
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<F: PrimeField> RelaxedPlonkWitness<F> {
+    fn from_regular(inner: PlonkWitness<F>, k_table_size: usize) -> Self {
+        Self {
+            inner,
+            E: vec![F::ZERO; 1 << k_table_size].into_boxed_slice(),
+        }
+    }
+}
+
+// TODO #31 docs
+#[derive(Debug, Clone)]
+pub struct RelaxedPlonkTrace<C: CurveAffine> {
+    pub U: RelaxedPlonkInstance<C>,
+    pub W: RelaxedPlonkWitness<C::Scalar>,
+}
+
+impl<C: CurveAffine> RelaxedPlonkTrace<C> {
+    pub fn from_regular(tr: PlonkTrace<C>, k_table_size: usize) -> RelaxedPlonkTrace<C> {
+        RelaxedPlonkTrace {
+            U: RelaxedPlonkInstance::from(tr.u),
+            W: RelaxedPlonkWitness::from_regular(tr.w, k_table_size),
+        }
+    }
+}
+
+pub type RelaxedPlonkTraceArgs = plonk::PlonkTraceArgs;
+
+impl<C: CurveAffine> RelaxedPlonkTrace<C> {
+    pub fn new(args: RelaxedPlonkTraceArgs) -> Self {
+        Self {
+            U: RelaxedPlonkInstance::new(args.num_io, args.num_challenges, args.num_witness),
+            W: RelaxedPlonkWitness::new(args.k_table_size, &args.round_sizes),
+        }
+    }
+}
+
+impl<C: CurveAffine> From<&PlonkStructure<C::ScalarExt>> for RelaxedPlonkTrace<C> {
+    fn from(value: &PlonkStructure<C::ScalarExt>) -> Self {
+        Self::new(RelaxedPlonkTraceArgs::from(value))
+    }
+}
+
+impl<F: PrimeField> GetWitness<F> for RelaxedPlonkWitness<F> {
+    fn get_witness(&self) -> &[Vec<F>] {
+        &self.W
+    }
+}
+
+impl<C: CurveAffine> GetWitness<C::ScalarExt> for RelaxedPlonkTrace<C> {
+    fn get_witness(&self) -> &[Vec<C::ScalarExt>] {
+        self.W.get_witness()
+    }
+}
+
+impl<C: CurveAffine> GetChallenges<C::ScalarExt> for RelaxedPlonkInstance<C> {
+    fn get_challenges(&self) -> &[C::ScalarExt] {
+        &self.challenges
+    }
+}
+
+impl<C: CurveAffine> GetChallenges<C::ScalarExt> for RelaxedPlonkTrace<C> {
+    fn get_challenges(&self) -> &[C::ScalarExt] {
+        self.U.get_challenges()
+    }
+}
+
+impl<C: CurveAffine, RO: ROTrait<C::Base>> AbsorbInRO<C::Base, RO> for RelaxedPlonkInstance<C> {
+    fn absorb_into(&self, ro: &mut RO) {
+        ro.absorb_point_iter(self.W_commitments.iter())
+            .absorb_point(&self.E_commitment)
+            .absorb_field_iter(
+                self.instance
+                    .iter()
+                    .map(|inst| util::fe_to_fe(inst).unwrap()),
+            )
+            .absorb_field_iter(
+                self.challenges
+                    .iter()
+                    .map(|cha| util::fe_to_fe(cha).unwrap()),
+            )
+            .absorb_field(util::fe_to_fe(&self.u).unwrap());
+    }
+}
+
+impl<F: PrimeField> RelaxedPlonkWitness<F> {
+    /// round_sizes: specify the size of witness vector for each round
+    /// in special soundness protocol.
+    /// In current version, we have either one round (without lookup)
+    /// or two rounds (with lookup)
+    pub fn new(k_table_size: usize, round_sizes: &[usize]) -> Self {
+        Self {
+            inner: PlonkWitness {
+                W: round_sizes.iter().map(|sz| vec![F::ZERO; *sz]).collect(),
+            },
+            E: iter::repeat(F::ZERO).take(1 << k_table_size).collect(),
+        }
+    }
+
+    #[instrument(name = "fold_witness", skip_all)]
+    pub fn fold(&self, W2: &PlonkWitness<F>, cross_terms: &[Box<[F]>], r: &F) -> Self {
+        debug!("start W: {} len", self.W.len());
+        let W = self
+            .W
+            .iter()
+            .zip_eq(W2.W.iter())
+            .map(|(vec1, vec2)| {
+                vec1.par_iter()
+                    .zip_eq(vec2.par_iter())
+                    .map(|(w1, w2)| *w1 + *r * *w2)
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+
+        debug!(
+            "start E {} len & cross term {} len",
+            self.E.len(),
+            cross_terms.len()
+        );
+
+        // r^1, r^2, ...
+        let powers_or_r = iter::successors(Some(*r), |el| Some(*el * r))
+            .take(cross_terms.len())
+            .collect::<Box<[_]>>();
+        let E = self
+            .E
+            .par_iter()
+            .enumerate()
+            .map(|(i, ei)| {
+                cross_terms
+                    .iter()
+                    .zip_eq(powers_or_r.iter().copied())
+                    .fold(*ei, |acc, (tk, power_of_r)| acc + power_of_r * tk[i])
+            })
+            .collect();
+
+        RelaxedPlonkWitness {
+            inner: PlonkWitness { W },
+            E,
+        }
+    }
+}

--- a/src/nifs/vanilla/mod.rs
+++ b/src/nifs/vanilla/mod.rs
@@ -12,16 +12,18 @@ use crate::{
     concat_vec,
     constants::NUM_CHALLENGE_BITS,
     ff::Field,
+    nifs::vanilla::accumulator::{RelaxedPlonkInstance, RelaxedPlonkTrace, RelaxedPlonkWitness},
     plonk::{
         self,
         eval::{GetDataForEval, PlonkEvalDomain},
-        PlonkInstance, PlonkStructure, PlonkTrace, PlonkWitness, RelaxedPlonkInstance,
-        RelaxedPlonkTrace, RelaxedPlonkWitness,
+        PlonkInstance, PlonkStructure, PlonkTrace, PlonkWitness,
     },
     polynomial::{graph_evaluator::GraphEvaluator, sparse},
     poseidon::ROTrait,
     sps::SpecialSoundnessVerifier,
 };
+
+pub mod accumulator;
 
 /// Represent intermediate polynomial terms that arise when folding
 /// two polynomial relations into one.
@@ -90,7 +92,12 @@ impl<C: CurveAffine> VanillaFS<C> {
         let data = PlonkEvalDomain {
             num_advice: S.num_advice_columns,
             num_lookup: S.num_lookups(),
-            challenges: &concat_vec!(&U1.challenges, &[U1.u], &U2.challenges, &[U2.to_relax().u]),
+            challenges: &concat_vec!(
+                &U1.challenges,
+                &[U1.u],
+                &U2.challenges,
+                &[RelaxedPlonkInstance::<C>::DEFAULT_u]
+            ),
             selectors: &S.selectors,
             fixed: &S.fixed_columns,
             W1s: &W1.W,

--- a/src/nifs/vanilla/tests.rs
+++ b/src/nifs/vanilla/tests.rs
@@ -9,10 +9,15 @@ use crate::{
         bn256::{Fr, G1Affine},
         group::ff::FromUniformBytes,
     },
-    nifs::{self, tests::setup_smallest_commitment_key, vanilla::VanillaFS},
-    plonk::{
-        PlonkStructure, PlonkTrace, RelaxedPlonkInstance, RelaxedPlonkTrace, RelaxedPlonkWitness,
+    nifs::{
+        self,
+        tests::setup_smallest_commitment_key,
+        vanilla::{
+            accumulator::{RelaxedPlonkInstance, RelaxedPlonkTrace, RelaxedPlonkWitness},
+            VanillaFS,
+        },
     },
+    plonk::{PlonkStructure, PlonkTrace},
     table::CircuitRunner,
     util::create_ro,
 };
@@ -92,11 +97,11 @@ where
 
     let pair1 =
         VanillaFS::generate_plonk_trace(&ck, &public_inputs1, &W1, &pp, &mut ro_nark_prepare)?;
-    let pair1_relaxed = pair1.to_relax(S.k);
+    let pair1_relaxed = RelaxedPlonkTrace::from_regular(pair1.clone(), S.k);
 
     let pair2 =
         VanillaFS::generate_plonk_trace(&ck, &public_inputs2, &W2, &pp, &mut ro_nark_prepare)?;
-    let pair2_relaxed = pair2.to_relax(S.k);
+    let pair2_relaxed = RelaxedPlonkTrace::from_regular(pair2.clone(), S.k);
 
     let mut errors = Vec::new();
 

--- a/src/plonk/mod.rs
+++ b/src/plonk/mod.rs
@@ -6,18 +6,13 @@
 //! - PlonkStructure: Represents the structure of a Plonk circuit and its associated data.
 //! - PlonkInstance: Represents an instance of a Plonk circuit.
 //! - PlonkWitness: Represents the witness data for a Plonk circuit.
-//! - RelaxedPlonkInstance: Represents an instance of a relaxed Plonk circuit.
-//! - RelaxedPlonkWitness: Represents the witness data for a relaxed Plonk circuit.
-//!
-//! The module also provides implementations of the AbsorbInRO trait for
-//! PlonkStructure, PlonkInstance, and RelaxedPlonkInstance.
 //!
 //! Additionally, it defines a method is_sat on PlonkStructure to determine if
 //! a given Plonk instance and witness satisfy the circuit constraints.
 use std::{iter, num::NonZeroUsize, time::Instant};
 
 use count_to_non_zero::*;
-use halo2_proofs::arithmetic::{best_multiexp, CurveAffine};
+use halo2_proofs::arithmetic::CurveAffine;
 use itertools::Itertools;
 use rayon::prelude::*;
 use serde::Serialize;
@@ -165,7 +160,7 @@ pub struct PlonkStructure<F: PrimeField> {
     pub(crate) lookup_arguments: Option<lookup::Arguments<F>>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PlonkInstance<C: CurveAffine> {
     /// `W_commitments = round_sizes.len()`, see [`PlonkStructure::round_sizes`]
     pub(crate) W_commitments: Vec<C>,
@@ -203,50 +198,25 @@ impl<F: PrimeField> PlonkWitness<F> {
             W: round_sizes.iter().map(|sz| vec![F::ZERO; *sz]).collect(),
         }
     }
-
-    pub fn to_relax(&self, k_table_size: usize) -> RelaxedPlonkWitness<F> {
-        RelaxedPlonkWitness {
-            W: self.W.clone(),
-            E: vec![F::ZERO; 1 << k_table_size].into_boxed_slice(),
-        }
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct RelaxedPlonkInstance<C: CurveAffine> {
-    pub(crate) W_commitments: Vec<C>,
-    pub(crate) E_commitment: C,
-    pub(crate) instance: Vec<C::ScalarExt>,
-    /// contains challenges
-    pub(crate) challenges: Vec<C::ScalarExt>,
-    /// homogenous variable u
-    pub(crate) u: C::ScalarExt,
-}
-
-#[derive(Clone, Debug)]
-pub struct RelaxedPlonkWitness<F: PrimeField> {
-    /// each vector element in W is a vector folded from an old [`RelaxedPlonkWitness.W`] and [`PlonkWitness.W`]
-    pub(crate) W: Vec<Vec<F>>,
-    pub(crate) E: Box<[F]>,
 }
 
 // TODO #31 docs
 #[derive(Debug, Clone)]
-pub struct RelaxedPlonkTrace<C: CurveAffine> {
-    pub U: RelaxedPlonkInstance<C>,
-    pub W: RelaxedPlonkWitness<C::Scalar>,
+pub struct PlonkTrace<C: CurveAffine> {
+    pub u: PlonkInstance<C>,
+    pub w: PlonkWitness<C::Scalar>,
 }
 
 #[derive(Debug)]
-pub struct RelaxedPlonkTraceArgs {
-    num_io: usize,
-    num_challenges: usize,
-    num_witness: usize,
-    k_table_size: usize,
-    round_sizes: Box<[usize]>,
+pub struct PlonkTraceArgs {
+    pub num_io: usize,
+    pub num_challenges: usize,
+    pub num_witness: usize,
+    pub k_table_size: usize,
+    pub round_sizes: Box<[usize]>,
 }
 
-impl<F: PrimeField> From<&PlonkStructure<F>> for RelaxedPlonkTraceArgs {
+impl<F: PrimeField> From<&PlonkStructure<F>> for PlonkTraceArgs {
     fn from(value: &PlonkStructure<F>) -> Self {
         Self {
             num_io: value.num_io,
@@ -258,34 +228,19 @@ impl<F: PrimeField> From<&PlonkStructure<F>> for RelaxedPlonkTraceArgs {
     }
 }
 
-impl<C: CurveAffine> RelaxedPlonkTrace<C> {
-    pub fn new(args: RelaxedPlonkTraceArgs) -> Self {
+impl<C: CurveAffine> PlonkTrace<C> {
+    pub fn new(args: PlonkTraceArgs) -> Self {
         Self {
-            U: RelaxedPlonkInstance::new(args.num_io, args.num_challenges, args.num_witness),
-            W: RelaxedPlonkWitness::new(args.k_table_size, &args.round_sizes),
+            u: PlonkInstance::new(args.num_io, args.num_challenges, args.num_witness),
+            w: PlonkWitness::new(&args.round_sizes),
         }
     }
-}
-
-impl<C: CurveAffine> From<&PlonkStructure<C::ScalarExt>> for RelaxedPlonkTrace<C> {
-    fn from(value: &PlonkStructure<C::ScalarExt>) -> Self {
-        Self::new(RelaxedPlonkTraceArgs::from(value))
-    }
-}
-
-// TODO #31 docs
-#[derive(Debug, Clone)]
-pub struct PlonkTrace<C: CurveAffine> {
-    pub u: PlonkInstance<C>,
-    pub w: PlonkWitness<C::Scalar>,
 }
 
 /// Generalized trait to get witness
 ///
 /// Used to generalize:
 /// - [`PlonkWitness`]
-/// - [`RelaxedPlonkWitness`]
-/// - [`RelaxedPlonkTrace`]
 /// - [`PlonkTrace`]
 pub(crate) trait GetWitness<F: PrimeField> {
     fn get_witness(&self) -> &[Vec<F>];
@@ -295,19 +250,9 @@ impl<F: PrimeField> GetWitness<F> for PlonkWitness<F> {
         &self.W
     }
 }
-impl<F: PrimeField> GetWitness<F> for RelaxedPlonkWitness<F> {
-    fn get_witness(&self) -> &[Vec<F>] {
-        &self.W
-    }
-}
 impl<C: CurveAffine> GetWitness<C::ScalarExt> for PlonkTrace<C> {
     fn get_witness(&self) -> &[Vec<C::ScalarExt>] {
         self.w.get_witness()
-    }
-}
-impl<C: CurveAffine> GetWitness<C::ScalarExt> for RelaxedPlonkTrace<C> {
-    fn get_witness(&self) -> &[Vec<C::ScalarExt>] {
-        self.W.get_witness()
     }
 }
 
@@ -315,18 +260,11 @@ impl<C: CurveAffine> GetWitness<C::ScalarExt> for RelaxedPlonkTrace<C> {
 ///
 /// Used to generalize:
 /// - [`PlonkWitness`]
-/// - [`RelaxedPlonkWitness`]
-/// - [`RelaxedPlonkTrace`]
 /// - [`PlonkTrace`]
 pub(crate) trait GetChallenges<F: PrimeField> {
     fn get_challenges(&self) -> &[F];
 }
 impl<C: CurveAffine> GetChallenges<C::ScalarExt> for PlonkInstance<C> {
-    fn get_challenges(&self) -> &[C::ScalarExt] {
-        &self.challenges
-    }
-}
-impl<C: CurveAffine> GetChallenges<C::ScalarExt> for RelaxedPlonkInstance<C> {
     fn get_challenges(&self) -> &[C::ScalarExt] {
         &self.challenges
     }
@@ -337,36 +275,12 @@ impl<C: CurveAffine> GetChallenges<C::ScalarExt> for PlonkTrace<C> {
         self.u.get_challenges()
     }
 }
-impl<C: CurveAffine> GetChallenges<C::ScalarExt> for RelaxedPlonkTrace<C> {
-    fn get_challenges(&self) -> &[C::ScalarExt] {
-        self.U.get_challenges()
-    }
-}
-
-impl<C: CurveAffine> PlonkTrace<C> {
-    pub fn to_relax(&self, k: usize) -> RelaxedPlonkTrace<C> {
-        RelaxedPlonkTrace {
-            U: self.u.to_relax(),
-            W: self.w.to_relax(k),
-        }
-    }
-}
 
 impl<C: CurveAffine, RO: ROTrait<C::Base>> AbsorbInRO<C::Base, RO> for PlonkInstance<C> {
     fn absorb_into(&self, ro: &mut RO) {
         ro.absorb_point_iter(self.W_commitments.iter())
             .absorb_field_iter(self.instance.iter().map(|inst| fe_to_fe(inst).unwrap()))
             .absorb_field_iter(self.challenges.iter().map(|cha| fe_to_fe(cha).unwrap()));
-    }
-}
-
-impl<C: CurveAffine, RO: ROTrait<C::Base>> AbsorbInRO<C::Base, RO> for RelaxedPlonkInstance<C> {
-    fn absorb_into(&self, ro: &mut RO) {
-        ro.absorb_point_iter(self.W_commitments.iter())
-            .absorb_point(&self.E_commitment)
-            .absorb_field_iter(self.instance.iter().map(|inst| fe_to_fe(inst).unwrap()))
-            .absorb_field_iter(self.challenges.iter().map(|cha| fe_to_fe(cha).unwrap()))
-            .absorb_field(fe_to_fe(&self.u).unwrap());
     }
 }
 
@@ -744,144 +658,6 @@ impl<C: CurveAffine> PlonkInstance<C> {
             instance: vec![C::ScalarExt::ZERO; num_io],
             challenges: vec![C::ScalarExt::ZERO; num_challenges],
         }
-    }
-
-    pub fn to_relax(&self) -> RelaxedPlonkInstance<C> {
-        RelaxedPlonkInstance {
-            W_commitments: self.W_commitments.clone(),
-            E_commitment: C::identity(),
-            instance: self.instance.clone(),
-            challenges: self.challenges.clone(),
-            u: C::ScalarExt::ONE,
-        }
-    }
-}
-
-impl<C: CurveAffine> RelaxedPlonkInstance<C> {
-    pub fn new(num_io: usize, num_challenges: usize, num_witness: usize) -> Self {
-        Self {
-            W_commitments: vec![CommitmentKey::<C>::default_value(); num_witness],
-            E_commitment: CommitmentKey::<C>::default_value(),
-            instance: vec![C::ScalarExt::ZERO; num_io],
-            challenges: vec![C::ScalarExt::ZERO; num_challenges],
-            u: C::ScalarExt::ZERO,
-        }
-    }
-
-    /// Folds a `RelaxedPlonkInstance` with another `PlonkInstance` while preserving their Plonk relation.
-    ///
-    /// This function combines the current relaxed Plonk instance with a given Plonk instance by
-    /// computing new commitments, instances, and scalar values using provided cross-term
-    /// commitments and random value `r`.
-    ///
-    /// # Arguments
-    /// * `U2`: A `PlonkInstance` used to combine with the current relaxed Plonk instance.
-    /// * `cross_term_commits`: The commitments of the cross terms used to calculate the folded
-    /// value comm_E
-    /// * `r`: A random scalar value used for combining the instances and commitments.
-    ///
-    /// # Returns
-    /// The folded `RelaxedPlonkInstance` after combining the instances and commitments.
-    /// for detail of how fold works, please refer to: [nifs](https://hackmd.io/d7syox5tTeaxkepc9nLvHw?view#31-NIFS)
-    #[instrument(name = "fold_plonk_instance", skip_all)]
-    pub fn fold(&self, U2: &PlonkInstance<C>, cross_term_commits: &[C], r: &C::ScalarExt) -> Self {
-        let W_commitments = self
-            .W_commitments
-            .iter()
-            .zip(U2.W_commitments.clone())
-            .enumerate()
-            .map(|(W_index, (W1, W2))| {
-                let rW = best_multiexp(&[*r], &[W2]).into();
-                let res = *W1 + rW;
-                debug!(
-                    "W1 = {W1:?}; W2 = {W2:?}; rW2[{W_index}] = {rW:?}; rW1 + rW2 * r = {res:?}"
-                );
-                res.into()
-            })
-            .collect::<Vec<C>>();
-
-        let instance = self
-            .instance
-            .par_iter()
-            .zip(&U2.instance)
-            .map(|(a, b)| *a + *r * b)
-            .collect::<Vec<C::ScalarExt>>();
-
-        let challenges = self
-            .challenges
-            .iter()
-            .zip_eq(U2.challenges.iter())
-            .map(|(a, b)| *a + *r * b)
-            .collect::<Vec<C::ScalarExt>>();
-
-        let u = self.u + *r;
-
-        let comm_E = cross_term_commits
-            .iter()
-            .zip(iter::successors(Some(*r), |el| Some(*el * *r))) // r^1, r^2, ...
-            .map(|(tk, power_of_r)| best_multiexp(&[power_of_r], &[*tk]).into())
-            .fold(self.E_commitment, |acc, x| (acc + x).into());
-
-        RelaxedPlonkInstance {
-            W_commitments,
-            E_commitment: comm_E,
-            instance,
-            u,
-            challenges,
-        }
-    }
-}
-
-impl<F: PrimeField> RelaxedPlonkWitness<F> {
-    /// round_sizes: specify the size of witness vector for each round
-    /// in special soundness protocol.
-    /// In current version, we have either one round (without lookup)
-    /// or two rounds (with lookup)
-    pub fn new(k_table_size: usize, round_sizes: &[usize]) -> Self {
-        Self {
-            W: round_sizes.iter().map(|sz| vec![F::ZERO; *sz]).collect(),
-            E: iter::repeat(F::ZERO).take(1 << k_table_size).collect(),
-        }
-    }
-
-    #[instrument(name = "fold_witness", skip_all)]
-    pub fn fold(&self, W2: &PlonkWitness<F>, cross_terms: &[Box<[F]>], r: &F) -> Self {
-        debug!("start W: {} len", self.W.len());
-        let W = self
-            .W
-            .iter()
-            .zip_eq(W2.W.iter())
-            .map(|(vec1, vec2)| {
-                vec1.par_iter()
-                    .zip_eq(vec2.par_iter())
-                    .map(|(w1, w2)| *w1 + *r * *w2)
-                    .collect::<Vec<_>>()
-            })
-            .collect::<Vec<_>>();
-
-        debug!(
-            "start E {} len & cross term {} len",
-            self.E.len(),
-            cross_terms.len()
-        );
-
-        // r^1, r^2, ...
-        let powers_or_r = iter::successors(Some(*r), |el| Some(*el * r))
-            .take(cross_terms.len())
-            .collect::<Box<[_]>>();
-        let E = self
-            .E
-            .par_iter()
-            .enumerate()
-            .map(|(i, ei)| {
-                cross_terms
-                    .iter()
-                    .zip_eq(powers_or_r.iter().copied())
-                    .fold(*ei, |acc, (tk, power_of_r)| acc + power_of_r * tk[i])
-            })
-            .collect();
-
-        RelaxedPlonkWitness { W, E }
     }
 }
 


### PR DESCRIPTION
**Motivation**
After the introduction of new types `FoldingScheme` `Relaxed*` structures turned out to be just one of the subtypes of accumulators and to keep their fields out of the way, they were moved to a separate structure

**Overview**
No new code was introduced as part of this PR, just moved the strings and renamed the `to_relax` -> `from_regular` methods