### PR TITLE
chore: bump version to v0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sirius"
-version = "0.1.0"
+version = "0.1.1"
 authors = [
     "chaosma chao@snarkify.io",
     "cyphersnake mikhail@snarkify.io",


### PR DESCRIPTION
**Motivation**
To use the version tag in the documentation

**Overview**
Once the PR is merged, I'll also git-tag to commit in master it and that will allow to add a project depending on the tag, which is the most idiotmatic way to add project to deps

Like:
```
cargo add --git https://github.com/snarkify/sirius/ --tag v0.1.1;
```