### PR TITLE
refactor: simplify trivial example

### DIFF
--- a/examples/my_circuit.rs
+++ b/examples/my_circuit.rs
@@ -50,6 +50,8 @@ impl<const A: usize, F: PrimeField> StepCircuit<A, F> for MyStepCircuit {
     /// Configure the step circuit. This method initializes necessary
     /// fixed columns and advice columns, but does not create any instance
     /// columns.
+    ///
+    // TODO #329
     fn configure(_cs: &mut ConstraintSystem<F>) -> Self::Config {
         todo!()
     }

--- a/examples/my_circuit.rs
+++ b/examples/my_circuit.rs
@@ -1,12 +1,20 @@
 use std::{array, num::NonZeroUsize};
 
 use sirius::{
-    commitment::CommitmentKey,
-    ivc::{step_circuit::trivial, IVC},
+    ivc::{
+        step_circuit::{trivial, AssignedCell, ConstraintSystem, Layouter},
+        SynthesisError,
+    },
+    prelude::{
+        bn256::{new_default_pp, C1Affine, C1Scalar, C2Affine, C2Scalar},
+        CommitmentKey, PrimeField, StepCircuit, IVC,
+    },
 };
 
+/// Number of folding steps
+const FOLD_STEP_COUNT: usize = 5;
+
 /// Arity : Input/output size per fold-step for primary step-circuit
-/// For tivial case it can be any number
 const A1: usize = 5;
 
 /// Arity : Input/output size per fold-step for secondary step-circuit
@@ -31,10 +39,38 @@ const PRIMARY_CIRCUIT_TABLE_SIZE: usize = 17;
 /// Key size for Primary Circuit
 const SECONDARY_COMMITMENT_KEY_SIZE: usize = 21;
 
-use sirius::prelude::bn256::{new_default_pp, C1Affine, C1Scalar, C2Affine, C2Scalar};
+#[derive(Debug, Clone)]
+struct MyConfig {}
+struct MyStepCircuit {}
+
+impl<const A: usize, F: PrimeField> StepCircuit<A, F> for MyStepCircuit {
+    /// This is a configuration object that stores things like columns.
+    type Config = MyConfig;
+
+    /// Configure the step circuit. This method initializes necessary
+    /// fixed columns and advice columns, but does not create any instance
+    /// columns.
+    fn configure(_cs: &mut ConstraintSystem<F>) -> Self::Config {
+        todo!()
+    }
+
+    /// Sythesize the circuit for a computation step and return variable
+    /// that corresponds to the output of the step z_{i+1}
+    /// this method will be called when we synthesize the IVC_Circuit
+    ///
+    /// Return `z_out` result
+    fn synthesize_step(
+        &self,
+        _config: Self::Config,
+        _layouter: &mut impl Layouter<F>,
+        _z_i: &[AssignedCell<F, F>; A],
+    ) -> Result<[AssignedCell<F, F>; A], SynthesisError> {
+        todo!()
+    }
+}
 
 fn main() {
-    let sc1 = trivial::Circuit::<A1, C1Scalar>::default();
+    let sc1 = MyStepCircuit {};
     let sc2 = trivial::Circuit::<A2, C2Scalar>::default();
 
     let primary_commitment_key =
@@ -58,7 +94,7 @@ fn main() {
         array::from_fn(|i| C1Scalar::from(i as u64)),
         &sc2,
         array::from_fn(|i| C2Scalar::from(i as u64)),
-        NonZeroUsize::new(5).unwrap(),
+        NonZeroUsize::new(FOLD_STEP_COUNT).unwrap(),
     )
     .unwrap();
 }

--- a/src/ivc/step_circuit.rs
+++ b/src/ivc/step_circuit.rs
@@ -1,11 +1,17 @@
-use halo2_proofs::{
-    circuit::{floor_planner::single_pass::SingleChipLayouter, AssignedCell, Layouter, Value},
-    plonk::ConstraintSystem,
-};
 use tracing::*;
 
 use super::fold_relaxed_plonk_instance_chip;
-use crate::{ff::PrimeField, main_gate::RegionCtx, table::WitnessCollector};
+pub use crate::halo2_proofs::{
+    circuit::{AssignedCell, Layouter},
+    plonk::ConstraintSystem,
+};
+
+use crate::{
+    ff::PrimeField,
+    halo2_proofs::circuit::{floor_planner::single_pass::SingleChipLayouter, Value},
+    main_gate::RegionCtx,
+    table::WitnessCollector,
+};
 
 #[derive(Debug, thiserror::Error)]
 pub enum SynthesisError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,3 +24,214 @@ pub use halo2_proofs::{
     self, halo2curves,
     halo2curves::{ff, group},
 };
+
+pub mod prelude {
+    use std::num::NonZeroUsize;
+
+    use crate::ff::{FromUniformBytes, PrimeFieldBits};
+    pub use crate::{
+        commitment::CommitmentKey,
+        ff::PrimeField,
+        ivc::{StepCircuit, IVC},
+    };
+
+    /// Within the IVC framework, on-circuit & off-circuit random oracle will be used
+    ///
+    /// This type defines this pair
+    ///
+    /// Only poiseidon is currently available
+    pub type RandomOracle<const T: usize, const RATE: usize> = super::poseidon::PoseidonRO<T, RATE>;
+
+    /// Within the IVC framework, on-circuit & off-circuit random oracle will be used
+    ///
+    /// This type defines constant what needed for create random oracle
+    ///
+    /// Only poiseidon is currently available
+    pub type RandomOracleConstant<F, const T: usize, const RATE: usize> =
+        <RandomOracle<T, RATE> as super::poseidon::ROPair<F>>::Args;
+
+    /// The IVC uses big uint math on-circuit and this parameter allows you to configure
+    /// the limb width of limb
+    ///
+    /// Safety: because 32 != 0
+    pub const DEFAULT_LIMB_WIDTH: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(32) };
+
+    /// The IVC uses big uint math on-circuit and this parameter allows you to configure
+    /// the maximum number of limbs allowed
+    ///
+    /// Safety: because 10 != 0
+    pub const DEFAULT_LIMBS_COUNT_LIMIT: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(10) };
+
+    pub const DEFAULT_STEP_FOLDING_CIRCUIT_SIZE: usize = 5;
+    pub const DEFAULT_RANDOM_ORACLE_SIZE: usize = 5;
+    pub const DEFAULT_RANDOM_ORACLE_RATE: usize = DEFAULT_RANDOM_ORACLE_SIZE - 1;
+
+    /// Create constants for random oracle, with R_F & R_P as defaults
+    pub fn default_random_oracle_constant<F>(
+    ) -> RandomOracleConstant<F, DEFAULT_STEP_FOLDING_CIRCUIT_SIZE, DEFAULT_RANDOM_ORACLE_RATE>
+    where
+        F: serde::Serialize + FromUniformBytes<64> + PrimeFieldBits,
+    {
+        /// Number of complete rounds
+        const POSEIDON_DEFUALT_R_F: usize = 10;
+
+        /// Number of partial rounds
+        const POSEIDON_DEFAULT_R_P: usize = 10;
+
+        RandomOracleConstant::new(POSEIDON_DEFUALT_R_F, POSEIDON_DEFAULT_R_P)
+    }
+
+    /// All imports and alias related to what will use bn256 & grumpkin as the first and second
+    /// curve respectively
+    pub mod bn256 {
+        pub use bn256::G1;
+        pub use grumpkin::G1 as G2;
+
+        use crate::{
+            commitment::CommitmentKey,
+            halo2curves::{
+                bn256,
+                group::{prime::PrimeCurve, Group},
+                grumpkin,
+            },
+            ivc::step_circuit::StepCircuit,
+        };
+
+        pub type C1Affine = <G1 as PrimeCurve>::Affine;
+        pub type C2Affine = <G2 as PrimeCurve>::Affine;
+
+        pub type C1Scalar = <G1 as Group>::Scalar;
+        pub type C2Scalar = <G2 as Group>::Scalar;
+
+        pub type PublicParams<'l, const A1: usize, C1, const A2: usize, C2> =
+            crate::ivc::PublicParams<
+                'l,
+                A1,
+                A2,
+                { super::DEFAULT_STEP_FOLDING_CIRCUIT_SIZE },
+                C1Affine,
+                C2Affine,
+                C1,
+                C2,
+                super::RandomOracle<
+                    { super::DEFAULT_RANDOM_ORACLE_SIZE },
+                    { super::DEFAULT_RANDOM_ORACLE_RATE },
+                >,
+                super::RandomOracle<
+                    { super::DEFAULT_RANDOM_ORACLE_SIZE },
+                    { super::DEFAULT_RANDOM_ORACLE_RATE },
+                >,
+            >;
+
+        /// This function creates public parameters for IVC
+        ///
+        /// All values except the input are selected by default
+        pub fn new_default_pp<'k, const A1: usize, C1, const A2: usize, C2>(
+            primary_k_table_size: u32,
+            primary_commitment_key: &'k CommitmentKey<C1Affine>,
+            sc1: &C1,
+            secondary_k_table_size: u32,
+            secondary_commitment_key: &'k CommitmentKey<C2Affine>,
+            sc2: &C2,
+        ) -> PublicParams<'k, A1, C1, A2, C2>
+        where
+            C1: StepCircuit<A1, C1Scalar>,
+            C2: StepCircuit<A2, C2Scalar>,
+        {
+            PublicParams::new(
+                crate::ivc::CircuitPublicParamsInput::new(
+                    primary_k_table_size,
+                    primary_commitment_key,
+                    super::default_random_oracle_constant(),
+                    sc1,
+                ),
+                crate::ivc::CircuitPublicParamsInput::new(
+                    secondary_k_table_size,
+                    secondary_commitment_key,
+                    super::default_random_oracle_constant(),
+                    sc2,
+                ),
+                super::DEFAULT_LIMB_WIDTH,
+                super::DEFAULT_LIMBS_COUNT_LIMIT,
+            )
+            .unwrap()
+        }
+    }
+
+    /// All imports and alias related to what will use grumpkin & bn256 as the first and second
+    /// curve respectively
+    pub mod grumpkin {
+        pub use bn256::G1 as G2;
+        pub use grumpkin::G1;
+
+        use crate::{
+            commitment::CommitmentKey,
+            halo2curves::{
+                bn256,
+                group::{prime::PrimeCurve, Group},
+                grumpkin,
+            },
+            ivc::step_circuit::StepCircuit,
+        };
+
+        pub type C1Affine = <G1 as PrimeCurve>::Affine;
+        pub type C2Affine = <G2 as PrimeCurve>::Affine;
+
+        pub type C1Scalar = <G1 as Group>::Scalar;
+        pub type C2Scalar = <G2 as Group>::Scalar;
+
+        pub type PublicParams<'l, const A1: usize, C1, const A2: usize, C2> =
+            crate::ivc::PublicParams<
+                'l,
+                A1,
+                A2,
+                { super::DEFAULT_STEP_FOLDING_CIRCUIT_SIZE },
+                C1Affine,
+                C2Affine,
+                C1,
+                C2,
+                super::RandomOracle<
+                    { super::DEFAULT_RANDOM_ORACLE_SIZE },
+                    { super::DEFAULT_RANDOM_ORACLE_RATE },
+                >,
+                super::RandomOracle<
+                    { super::DEFAULT_RANDOM_ORACLE_SIZE },
+                    { super::DEFAULT_RANDOM_ORACLE_RATE },
+                >,
+            >;
+
+        /// This function creates public parameters for IVC
+        ///
+        /// All values except the input are selected by default
+        pub fn new_default_pp<'k, const A1: usize, C1, const A2: usize, C2>(
+            primary_k_table_size: u32,
+            primary_commitment_key: &'k CommitmentKey<C1Affine>,
+            sc1: &C1,
+            secondary_k_table_size: u32,
+            secondary_commitment_key: &'k CommitmentKey<C2Affine>,
+            sc2: &C2,
+        ) -> PublicParams<'k, A1, C1, A2, C2>
+        where
+            C1: StepCircuit<A1, C1Scalar>,
+            C2: StepCircuit<A2, C2Scalar>,
+        {
+            PublicParams::new(
+                crate::ivc::CircuitPublicParamsInput::new(
+                    primary_k_table_size,
+                    primary_commitment_key,
+                    super::default_random_oracle_constant(),
+                    sc1,
+                ),
+                crate::ivc::CircuitPublicParamsInput::new(
+                    secondary_k_table_size,
+                    secondary_commitment_key,
+                    super::default_random_oracle_constant(),
+                    sc2,
+                ),
+                super::DEFAULT_LIMB_WIDTH,
+                super::DEFAULT_LIMBS_COUNT_LIMIT,
+            )
+            .unwrap()
+        }
+    }
+}

--- a/src/nifs/protogalaxy/tests.rs
+++ b/src/nifs/protogalaxy/tests.rs
@@ -6,7 +6,7 @@ use halo2_proofs::{
     plonk::Circuit,
 };
 
-use super::{super::tests::*, *};
+use super::*;
 
 const T: usize = 3;
 const RATE: usize = 2;
@@ -14,6 +14,7 @@ const R_F: usize = 4;
 const R_P: usize = 3;
 
 use crate::{
+    commitment,
     halo2curves::bn256::G1Affine as Affine,
     nifs::tests::{
         fibo_circuit::{get_fibo_seq, FiboCircuit},
@@ -73,7 +74,7 @@ impl<C: Circuit<Scalar>> Mock<C> {
         let circuits_runners =
             circuits.map(|(circuit, instance)| CircuitRunner::new(k_table_size, circuit, instance));
 
-        let ck = setup_smallest_commitment_key(k_table_size, &circuits_runners[0].cs, b"");
+        let ck = commitment::setup_smallest_key(k_table_size, &circuits_runners[0].cs, b"");
         let S = circuits_runners[0]
             .try_collect_plonk_structure()
             .expect("failed to collect plonk structure");

--- a/src/nifs/tests.rs
+++ b/src/nifs/tests.rs
@@ -2,28 +2,11 @@ use std::marker::PhantomData;
 
 use halo2_proofs::{
     circuit::{AssignedCell, Layouter, SimpleFloorPlanner, Value},
-    halo2curves::CurveAffine,
     plonk::{self, Advice, Circuit, Column, ConstraintSystem, Instance, Selector},
     poly::Rotation,
 };
 
-use crate::{commitment::CommitmentKey, ff::PrimeField, halo2curves::group::ff::FromUniformBytes};
-
-/// calculate smallest w such that 2^w >= n*(2^K)
-pub fn smallest_power(n: usize, K: u32) -> usize {
-    ((n * 2usize.pow(K)) as f64).log2().ceil() as usize
-}
-
-pub fn setup_smallest_commitment_key<C: CurveAffine>(
-    k_table_size: u32,
-    cs: &ConstraintSystem<C::ScalarExt>,
-    tag: &'static [u8],
-) -> CommitmentKey<C> {
-    let num_lookup = cs.lookups().len();
-    let p1 = smallest_power(cs.num_advice_columns() + 5 * num_lookup, k_table_size);
-    let p2 = smallest_power(cs.num_selectors + cs.num_fixed_columns(), k_table_size);
-    CommitmentKey::<C>::setup(p1.max(p2), tag)
-}
+use crate::{ff::PrimeField, halo2curves::group::ff::FromUniformBytes};
 
 pub(crate) mod random_linear_combination_circuit {
     use super::*;

--- a/src/nifs/vanilla/tests.rs
+++ b/src/nifs/vanilla/tests.rs
@@ -4,6 +4,7 @@ use tracing_test::traced_test;
 
 use super::*;
 use crate::{
+    commitment,
     ff::{PrimeField, PrimeFieldBits},
     halo2curves::{
         bn256::{Fr, G1Affine},
@@ -11,7 +12,6 @@ use crate::{
     },
     nifs::{
         self,
-        tests::setup_smallest_commitment_key,
         vanilla::{
             accumulator::{RelaxedPlonkInstance, RelaxedPlonkTrace, RelaxedPlonkWitness},
             VanillaFS,
@@ -82,7 +82,7 @@ where
     const R_P: usize = 3;
 
     let td1 = CircuitRunner::new(K, circuit1, public_inputs1.clone());
-    let ck = setup_smallest_commitment_key(K, &td1.cs, b"prepare_trace");
+    let ck = commitment::setup_smallest_key(K, &td1.cs, b"prepare_trace");
 
     let S = td1.try_collect_plonk_structure()?;
     let W1 = td1.try_collect_witness()?;


### PR DESCRIPTION
**Motivation**
As part of #330 task, documentation is needed, so we need to simplify the API and put all the entrainment values in some module (prelude) so that the developer can focus on development

**Overview**
- Added `sirius::prelude` & `sirius::prelude::bn256` module.
- Refactored `get_smallest_commitment_key` fn
- Trivial example was simplified
- Added `MyCircuit` example
- Pub re-import for step-circuit module

Basically check out trivial-example to see if I've taken out anything too critical

It seems to me that the same `T` (which we have for both poseidon and step-folding-circuit size) is not understood by the developer, so we can take it as default and simplify the public API