### PR TITLE
refactor(fft): rm `fft_domain_size` from args

### DIFF
--- a/src/nifs/protogalaxy/poly/mod.rs
+++ b/src/nifs/protogalaxy/poly/mod.rs
@@ -170,7 +170,7 @@ pub(crate) fn compute_F<F: PrimeField>(
 
     match evaluated {
         Some(Ok(Node::Calculated { mut points, .. })) => {
-            fft::ifft(&mut points, fft_domain_size.get());
+            fft::ifft(&mut points);
             Ok(UnivariatePoly(points))
         }
         Some(Err(err)) => Err(err.into()),
@@ -294,7 +294,7 @@ pub(crate) fn compute_G<F: PrimeField>(
         Some(Ok(Node {
             values: mut points, ..
         })) => {
-            fft::ifft(&mut points, fft_domain_size);
+            fft::ifft(&mut points);
             Ok(UnivariatePoly(points))
         }
         Some(Err(err)) => Err(err.into()),


### PR DESCRIPTION
**Motivation**
In this case the parameter is derived from another parameter and their equality is checked, to avoid an error it is better not to do it this way

**Overview**
- rm `log_n: u32` from fft/ifft
- add tests for `bitreverse`