### PR TITLE
feat(poly): add functionality to `univariate` mod

### DIFF
--- a/src/polynomial/univariate.rs
+++ b/src/polynomial/univariate.rs
@@ -1,11 +1,16 @@
-use std::iter;
+use std::{
+    iter,
+    ops::{Add, Mul},
+};
 
-use crate::ff::Field;
+use halo2_proofs::halo2curves::ff::{PrimeField, WithSmallOrderMulGroup};
+
+use crate::{ff::Field, fft};
 
 /// Represents a univariate polynomial
 ///
 /// Coefficients of the polynomial are presented from smaller to larger
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct UnivariatePoly<F: Field>(pub(crate) Box<[F]>);
 
 impl<F: Field> UnivariatePoly<F> {
@@ -14,6 +19,23 @@ impl<F: Field> UnivariatePoly<F> {
     }
     pub fn iter(&self) -> impl Iterator<Item = &F> {
         self.0.iter()
+    }
+    pub fn degree(&self) -> usize {
+        self.0
+            .iter()
+            .enumerate()
+            .rev()
+            .find_map(|(i, coeff)| F::ZERO.ne(coeff).then_some(i))
+            .unwrap_or_default()
+    }
+}
+
+impl<F: Field> IntoIterator for UnivariatePoly<F> {
+    type Item = F;
+    type IntoIter = <Box<[F]> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        <Box<[F]> as IntoIterator>::into_iter(self.0)
     }
 }
 
@@ -39,13 +61,116 @@ impl<F: Field> UnivariatePoly<F> {
                 res + (challenge_in_degree * *coeff)
             })
     }
+
+    pub fn resize(self, new_len: usize) -> Self {
+        if self.len() == new_len {
+            return self;
+        }
+
+        let mut coeff = self.0.into_vec();
+        coeff.resize(new_len, F::ZERO);
+        Self(coeff.into_boxed_slice())
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Multiplies all coefficients of the polynomial by a field element.
+    pub fn scale(&self, factor: F) -> UnivariatePoly<F> {
+        let scaled_coeffs: Vec<F> = self.iter().map(|&coeff| coeff * factor).collect();
+        UnivariatePoly(scaled_coeffs.into_boxed_slice())
+    }
 }
+
+impl<F: Field> Mul<&UnivariatePoly<F>> for UnivariatePoly<F> {
+    type Output = UnivariatePoly<F>;
+
+    fn mul(self, rhs: &UnivariatePoly<F>) -> UnivariatePoly<F> {
+        let new_len = self.len() + rhs.len() - 1;
+        let mut result = vec![F::ZERO; new_len];
+
+        for (i, &a) in self.iter().enumerate() {
+            for (j, &b) in rhs.iter().enumerate() {
+                result[i + j] += a * b;
+            }
+        }
+
+        // Skip trailing zeros using itertools
+        // Efficiently remove trailing zeros
+        let last_non_zero = result
+            .iter()
+            .rposition(|&x| x != F::ZERO)
+            .map_or(0, |pos| pos + 1);
+
+        result.truncate(last_non_zero);
+
+        UnivariatePoly(result.into_boxed_slice())
+    }
+}
+
+impl<F: Field> Add for UnivariatePoly<F> {
+    type Output = UnivariatePoly<F>;
+
+    fn add(self, rhs: UnivariatePoly<F>) -> UnivariatePoly<F> {
+        let (longer, shorter) = if self.len() >= rhs.len() {
+            (self, rhs)
+        } else {
+            (rhs, self)
+        };
+
+        let mut result = longer.0.into_vec();
+
+        for (res_coeff, &short_coeff) in result.iter_mut().zip(shorter.iter()) {
+            *res_coeff += short_coeff;
+        }
+
+        // Efficiently remove trailing zeros
+        let last_non_zero = result
+            .iter()
+            .rposition(|&x| x != F::ZERO)
+            .map_or(0, |pos| pos + 1);
+
+        result.truncate(last_non_zero);
+
+        UnivariatePoly(result.into_boxed_slice())
+    }
+}
+
+impl<F: PrimeField> UnivariatePoly<F> {
+    pub fn fft(mut self) -> Box<[F]> {
+        fft::fft(self.as_mut());
+        self.0
+    }
+
+    pub fn ifft(mut input: Box<[F]>) -> Self {
+        fft::ifft(&mut input);
+        Self(input)
+    }
+}
+
+impl<F: WithSmallOrderMulGroup<3>> UnivariatePoly<F> {
+    pub fn coset_fft(mut self) -> Box<[F]> {
+        fft::coset_fft(self.as_mut());
+        self.0
+    }
+
+    pub fn coset_ifft(mut input: Box<[F]>) -> Self {
+        fft::coset_ifft(&mut input);
+        Self(input)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::iter;
 
     use super::UnivariatePoly;
-    use crate::halo2curves::bn256::Fr;
+    use crate::{halo2_proofs::arithmetic::Field, halo2curves::bn256::Fr};
 
     // Helper to create an `Fr` iterator from a `u64` iterator
     trait ToF<I: Into<Fr>>: Sized + IntoIterator<Item = I> {
@@ -110,5 +235,94 @@ mod tests {
             Fr::zero(),
             "Zero polynomial evaluation failed."
         );
+    }
+
+    #[test]
+    fn test_degree_zero_polynomial() {
+        let poly = UnivariatePoly::from_iter([Fr::from(5)]);
+        assert_eq!(poly.degree(), 0, "Degree of a zero polynomial failed.");
+
+        let poly = UnivariatePoly::from_iter([Fr::from(0)]);
+        assert_eq!(poly.degree(), 0, "Degree of a zero polynomial failed.");
+    }
+
+    #[test]
+    fn test_degree_nonzero_polynomial() {
+        let poly = UnivariatePoly::from_iter([Fr::from(3), Fr::from(0), Fr::from(7)]);
+        assert_eq!(poly.degree(), 2, "Degree of a nonzero polynomial failed.");
+    }
+
+    #[test]
+    fn test_degree_zero_start() {
+        let poly = UnivariatePoly::from_iter([Fr::from(3), Fr::from(0), Fr::from(0)]);
+        assert_eq!(poly.degree(), 0, "Degree of a nonzero polynomial failed.");
+    }
+
+    #[test]
+    fn test_add_polynomials() {
+        let poly1 = UnivariatePoly::from_iter([Fr::from(3), Fr::from(2), Fr::from(1)]);
+        let poly2 = UnivariatePoly::from_iter([Fr::from(1), Fr::from(3), Fr::from(2)]);
+        let expected_sum = UnivariatePoly::from_iter([Fr::from(4), Fr::from(5), Fr::from(3)]);
+
+        assert_eq!(
+            poly1.clone() + poly2.clone(),
+            expected_sum,
+            "Adding polynomials failed."
+        );
+    }
+
+    #[test]
+    fn test_multiply_polynomials() {
+        let poly1 = UnivariatePoly::from_iter([Fr::from(1), Fr::from(2)]);
+        let poly2 = UnivariatePoly::from_iter([Fr::from(1), Fr::from(2)]);
+        let expected_product = UnivariatePoly::from_iter([Fr::from(1), Fr::from(4), Fr::from(4)]);
+
+        assert_eq!(
+            poly1.clone() * &poly2.clone(),
+            expected_product,
+            "Multiplying polynomials failed."
+        );
+    }
+
+    #[test]
+    fn test_resize_polynomial_larger() {
+        let poly = UnivariatePoly::from_iter((0..3).map(Fr::from));
+        let resized = poly.clone().resize(5);
+        let expected =
+            UnivariatePoly::from_iter((0..3).map(Fr::from).chain(iter::repeat(Fr::ZERO).take(2)));
+        assert_eq!(
+            resized, expected,
+            "Resizing polynomial to a larger size failed."
+        );
+    }
+
+    #[test]
+    fn test_resize_polynomial_smaller() {
+        let poly = UnivariatePoly::from_iter((0..5).map(Fr::from));
+        let resized = poly.clone().resize(3);
+        let expected = UnivariatePoly::from_iter((0..3).map(Fr::from));
+        assert_eq!(
+            resized, expected,
+            "Resizing polynomial to a smaller size failed."
+        );
+    }
+
+    #[test]
+    fn test_resize_polynomial_same_size() {
+        let poly = UnivariatePoly::from_iter((0..3).map(Fr::from));
+        let resized = poly.clone().resize(3);
+        assert_eq!(
+            resized, poly,
+            "Resizing polynomial to the same size failed."
+        );
+    }
+
+    #[test]
+    fn test_scale_polynomial() {
+        let poly = UnivariatePoly::from_iter((0..3).map(Fr::from)); // Polynomial: 0 + 1*x + 2*x^2
+        let factor = Fr::from(2);
+        let scaled = poly.scale(factor);
+        let expected = UnivariatePoly::from_iter((0..3).map(|x| Fr::from(x) * factor)); // Polynomial: 0 + 2*x + 4*x^2
+        assert_eq!(scaled, expected, "Scaling polynomial failed.");
     }
 }


### PR DESCRIPTION
**Motivation**
In testing #267, basic operations on `UnivariatePoly` were needed

**Overview**
- impl `Add`
- impl `Mul`
- impl `degree`
- impl `into_iter`
- impl `resize`
- impl `len` & `is_empty`
- impl `scale`
- impl `fft` & `ifft` proxy