### PR TITLE
fix(nifs): impl `PolyContext` for protogalaxy

### DIFF
--- a/src/nifs/protogalaxy/accumulator.rs
+++ b/src/nifs/protogalaxy/accumulator.rs
@@ -3,13 +3,16 @@ use std::iter;
 use crate::{
     ff::Field,
     halo2curves::CurveAffine,
-    plonk::{self, PlonkInstance, PlonkTrace},
+    plonk::{self, PlonkInstance, PlonkTrace, PlonkWitness},
     poseidon::{AbsorbInRO, ROTrait},
     util,
 };
 
 /// Represents an accumulator for folding multiple instances into a single instance,
 /// following the accumulation schemes.
+///
+/// TODO#266 Docs
+#[derive(Clone, Debug)]
 pub struct Accumulator<C: CurveAffine> {
     /// `φ`: Represents the combined state of all instances & witnesses. It is a summary that
     /// captures the essential data and relationships from the instances being merged.
@@ -49,6 +52,7 @@ impl<C: CurveAffine> Accumulator<C> {
 
 /// Represents an accumulator for folding multiple instances into a single instance,
 /// following the accumulation schemes.
+#[derive(Debug, PartialEq, Eq)]
 pub struct AccumulatorInstance<C: CurveAffine> {
     /// `φ`: Represents the combined state of all instances. It is a summary that captures the
     /// essential data and relationships from the instances being merged.
@@ -61,6 +65,17 @@ pub struct AccumulatorInstance<C: CurveAffine> {
     /// `e`: an accumulated value that encapsulates the result of the folding operation. it serves
     /// as a concise representation of the correctness and properties of the folded instances.
     pub(super) e: C::ScalarExt,
+}
+
+impl<C: CurveAffine> AccumulatorInstance<C> {
+    pub fn into_acc(self, w: PlonkWitness<C::Scalar>) -> Accumulator<C> {
+        let Self { ins, betas, e } = self;
+        Accumulator {
+            trace: PlonkTrace { u: ins, w },
+            betas,
+            e,
+        }
+    }
 }
 
 impl<C: CurveAffine> From<Accumulator<C>> for AccumulatorInstance<C> {

--- a/src/nifs/protogalaxy/poly/mod.rs
+++ b/src/nifs/protogalaxy/poly/mod.rs
@@ -1,20 +1,19 @@
-use std::num::{NonZeroU32, NonZeroUsize};
+use std::{iter, num::NonZeroUsize, ops::Add};
 
 use itertools::*;
-use num_traits::Zero;
 use tracing::*;
 
 use crate::{
     ff::PrimeField,
-    fft::{self, coset_fft, coset_ifft},
+    fft,
     group::ff::WithSmallOrderMulGroup,
     plonk::{self, eval, GetChallenges, GetWitness, PlonkStructure},
     polynomial::{expression::QueryIndexContext, lagrange, univariate::UnivariatePoly},
     util::TryMultiProduct,
 };
 
-mod folded_trace;
-use folded_trace::FoldedTrace;
+mod folded_witness;
+pub(crate) use folded_witness::FoldedWitness;
 
 #[derive(Debug, thiserror::Error, PartialEq, Eq, Clone)]
 pub enum Error {
@@ -64,34 +63,22 @@ pub enum Error {
 /// except leaves.
 #[instrument(skip_all)]
 pub(crate) fn compute_F<F: PrimeField>(
+    ctx: &PolyContext<'_, F>,
     betas: impl Iterator<Item = F>,
     delta: F,
-    S: &PlonkStructure<F>,
     trace: &(impl Sync + GetChallenges<F> + GetWitness<F>),
 ) -> Result<UnivariatePoly<F>, Error> {
-    let count_of_rows = 2usize.pow(S.k as u32);
-    let count_of_gates = S.gates.len();
-
-    let count_of_evaluation = count_of_rows * count_of_gates;
-
-    if count_of_evaluation == 0 {
+    // `n` in paper
+    let Some(count_of_evaluation) = get_count_of_valuation_with_padding(ctx.S) else {
         return Ok(UnivariatePoly::new_zeroed(0));
-    }
+    };
 
-    let points_count = count_of_evaluation
-        .next_power_of_two()
-        .ilog2()
-        .next_power_of_two() as usize;
-
-    let fft_domain_size = NonZeroU32::new(points_count.ilog2()).unwrap();
+    // `t` in paper
+    let fft_points_count_F = ctx.fft_points_count_F();
 
     debug!(
-        "
-        count_of_rows: {count_of_rows};
-        count_of_gates: {count_of_gates};
-        count_of_evaluation: {count_of_evaluation};
-        fft_domain_size: {fft_domain_size};
-        points_count: {points_count}"
+        "count_of_evaluation: {count_of_evaluation};
+        points_count: {fft_points_count_F}"
     );
 
     // Use the elements of the cyclic group together with beta & delta as challenge and calculate them
@@ -102,18 +89,23 @@ pub(crate) fn compute_F<F: PrimeField>(
     //
     // Even for large `count_of_evaluation` this will be a small number, so we can
     // collect it
-    let betas = betas
-        .take(count_of_evaluation.next_power_of_two().ilog2() as usize)
+    let betas = betas.take(ctx.betas_count()).collect::<Box<[_]>>();
+    assert_eq!(betas.len(), ctx.betas_count());
+    let deltas = iter::successors(Some(delta), |d| Some(d.double()))
+        .take(ctx.betas_count())
         .collect::<Box<[_]>>();
-    let challenges_powers = lagrange::iter_cyclic_subgroup::<F>(fft_domain_size.get())
+    debug!("betas & deltas ready");
+
+    let challenges_powers = lagrange::iter_cyclic_subgroup::<F>(fft_points_count_F.ilog2())
         .map(|X| {
             betas
                 .iter()
-                .map(|beta| *beta + X * delta)
+                .zip_eq(deltas.iter())
+                .map(|(beta, delta)| *beta + (X * delta))
                 .collect::<Box<_>>()
         })
-        .take(points_count)
         .collect::<Box<[_]>>();
+    debug!("challenges powers ready ready");
 
     /// Auxiliary wrapper for using the tree to evaluate polynomials
     #[derive(Debug)]
@@ -128,10 +120,15 @@ pub(crate) fn compute_F<F: PrimeField>(
         },
     }
 
-    let evaluated = plonk::iter_evaluate_witness::<F>(S, trace)
-        .map(|result_with_evaluated_gate| result_with_evaluated_gate.map(Node::Leaf))
-        // TODO #259 Migrate to a parallel algorithm
-        // TODO #259 Implement `try_tree_reduce` to stop on the first error
+    let evaluated = plonk::iter_evaluate_witness::<F>(ctx.S, trace)
+        .chain(iter::repeat(Ok(F::ZERO)))
+        .take(count_of_evaluation.get())
+        .map(|result_with_evaluated_gate| {
+            debug!("witness row: {:?}", result_with_evaluated_gate);
+            result_with_evaluated_gate.map(Node::Leaf)
+        })
+        // TODO #324 Migrate to a parallel algorithm
+        // TODO #324 Implement `try_tree_reduce` to stop on the first error
         .tree_reduce(|left_w, right_w| {
             let (left_w, right_w) = (left_w?, right_w?);
 
@@ -178,6 +175,64 @@ pub(crate) fn compute_F<F: PrimeField>(
     }
 }
 
+pub struct PolyContext<'s, F: PrimeField> {
+    S: &'s PlonkStructure<F>,
+    /// Equal to the number of incoming traces plus one (accumulator)
+    /// Must be a power of two
+    instances_to_fold: usize,
+    /// The number of points used in G(X)
+    ///
+    /// Used in [`compute_G`]
+    ///
+    /// Equal to `(traces_len * max_gate_degree + 1).next_power_of_two()`
+    fft_points_count_G: usize,
+    /// Number of calculations, padding with zeros to the nearest power of two
+    count_of_evaluation_with_padding: usize,
+}
+
+impl<'s, F: PrimeField> PolyContext<'s, F> {
+    pub fn new(
+        S: &'s PlonkStructure<F>,
+        traces: &[(impl Sync + GetChallenges<F> + GetWitness<F>)],
+    ) -> Self {
+        let count_of_evaluation = get_count_of_valuation_with_padding(S).unwrap().get();
+
+        let instances_to_fold = traces.len() + 1;
+        assert!(instances_to_fold.is_power_of_two());
+
+        let fft_points_count_G = get_points_count(S, traces.len());
+
+        Self {
+            S,
+            instances_to_fold,
+            fft_points_count_G,
+            count_of_evaluation_with_padding: count_of_evaluation,
+        }
+    }
+
+    pub fn betas_count(&self) -> usize {
+        self.count_of_evaluation_with_padding.ilog2() as usize
+    }
+
+    pub fn fft_points_count_F(&self) -> usize {
+        (self.betas_count() + 1).next_power_of_two()
+    }
+
+    pub fn fft_log_domain_size_G(&self) -> u32 {
+        self.fft_points_count_G.ilog2()
+    }
+
+    pub fn lagrange_domain(&self) -> u32 {
+        self.instances_to_fold.ilog2()
+    }
+
+    pub fn get_lagrange_domain<const TRACES_LEN: usize>() -> u32 {
+        let instances_to_fold = TRACES_LEN + 1;
+        assert!(instances_to_fold.is_power_of_two());
+        instances_to_fold.ilog2()
+    }
+}
+
 /// This function calculates G(X), which mathematically looks like this:
 ///
 /// $$G(X)=\sum_{i=0}^{n-1}\operatorname{pow}_i(\boldsymbol{\beta}+\alpha\cdot\boldsymbol{\delta})f_i(L_0(X)w+\sum_{j\in[k]}L_j(X)w_j)$$
@@ -216,40 +271,20 @@ pub(crate) fn compute_F<F: PrimeField>(
 /// is in the nodes
 #[instrument(skip_all)]
 pub(crate) fn compute_G<F: PrimeField>(
-    S: &PlonkStructure<F>,
+    ctx: &PolyContext<F>,
     betas_stroke: impl Iterator<Item = F>,
     accumulator: &(impl Sync + GetChallenges<F> + GetWitness<F>),
     traces: &[(impl Sync + GetChallenges<F> + GetWitness<F>)],
 ) -> Result<UnivariatePoly<F>, Error> {
-    let ctx = QueryIndexContext::from(S);
-    let max_degree = S
-        .gates
-        .iter()
-        .map(|poly| poly.degree(&ctx))
-        .max()
-        .unwrap_or_default();
-
     if traces.is_empty() {
         return Err(Error::EmptyTracesNotAllowed);
     }
 
-    let count_of_rows = 2usize.pow(S.k as u32);
-    let count_of_gates = S.gates.len();
+    let betas_stroke = betas_stroke.take(ctx.betas_count()).collect::<Box<[_]>>();
+    assert_eq!(ctx.betas_count(), betas_stroke.len());
 
-    let count_of_evaluation = count_of_rows * count_of_gates;
-    if count_of_evaluation.is_zero() {
-        return Ok(UnivariatePoly::new_zeroed(0));
-    }
-
-    let points_count = (traces.len() * max_degree + 1).next_power_of_two();
-    let fft_domain_size = points_count.ilog2();
-
-    let betas_stroke = betas_stroke
-        .take(count_of_evaluation.next_power_of_two().ilog2() as usize)
-        .collect::<Box<[_]>>();
-
-    let points_for_fft = lagrange::iter_cyclic_subgroup(fft_domain_size)
-        .take(points_count)
+    let points_for_fft = lagrange::iter_cyclic_subgroup(ctx.fft_log_domain_size_G())
+        .take(ctx.fft_points_count_G)
         .collect::<Box<[_]>>();
 
     /// Auxiliary wrapper for using the tree to evaluate polynomials
@@ -259,9 +294,13 @@ pub(crate) fn compute_G<F: PrimeField>(
         height: usize,
     }
 
-    let evaluated = FoldedTrace::new(&points_for_fft, accumulator, traces)
-        .iter()
-        .map(|folded_trace| plonk::iter_evaluate_witness::<F>(S, folded_trace))
+    let evaluated =
+        FoldedWitness::new(&points_for_fft, ctx.lagrange_domain(), accumulator, traces)
+        .iter() // folded witness iter per each X
+        .map(|folded_trace| plonk::iter_evaluate_witness::<F>(ctx.S, folded_trace)
+            .chain(iter::repeat(Ok(F::ZERO)))
+            .take(ctx.count_of_evaluation_with_padding)
+        )
         .try_multi_product()
         .map(|points| points.map(|points| Node { values: points, height: 0 }))
         .tree_reduce(|left, right| {
@@ -337,16 +376,73 @@ impl<F: PrimeField> Iterator for BetaStrokeIter<F> {
 }
 
 pub(crate) fn compute_K<F: WithSmallOrderMulGroup<3>>(
-    S: &PlonkStructure<F>,
-    f_alpha: F,
+    ctx: &PolyContext<F>,
+    poly_F_in_alpha: F,
     betas_stroke: impl Iterator<Item = F>,
     accumulator: &(impl Sync + GetChallenges<F> + GetWitness<F>),
     traces: &[(impl Sync + GetChallenges<F> + GetWitness<F>)],
 ) -> Result<UnivariatePoly<F>, Error> {
-    let mut g_poly = compute_G(S, betas_stroke, accumulator, traces)?;
-    // is coeffs here, will transform to evals by fft later
-    let ctx = QueryIndexContext::from(S);
+    let poly_G = compute_G(ctx, betas_stroke, accumulator, traces)?;
+    Ok(compute_K_from_G(ctx, poly_G, poly_F_in_alpha))
+}
 
+fn compute_K_from_G<F: WithSmallOrderMulGroup<3>>(
+    ctx: &PolyContext<F>,
+    poly_G: UnivariatePoly<F>,
+    poly_F_in_alpha: F,
+) -> UnivariatePoly<F> {
+    let fft_log_domain_size_K = poly_G
+        .degree()
+        .add(1)
+        .saturating_sub(ctx.instances_to_fold)
+        .next_power_of_two() as u32;
+
+    UnivariatePoly::coset_ifft(
+        lagrange::iter_cyclic_subgroup::<F>(fft_log_domain_size_K)
+            .map(|X| F::ZETA * X)
+            // TODO #293
+            //.zip(poly_G.coset_fft())
+            //.map(|(X, poly_G_in_X)| {
+            .map(|X| {
+                let poly_G_in_X = poly_G.eval(X);
+
+                let poly_L0_in_X =
+                    lagrange::iter_eval_lagrange_poly_for_cyclic_group(X, ctx.lagrange_domain())
+                        .next()
+                        .unwrap();
+
+                // Z(X) == 0, for X in coset_cyclic_subgroup
+                let poly_Z_in_X = lagrange::eval_vanish_polynomial(ctx.instances_to_fold, X);
+
+                let poly_K_in_X = (poly_G_in_X - (poly_F_in_alpha * poly_L0_in_X))
+                    * poly_Z_in_X.invert().expect("Z(X) must be not equal to 0");
+
+                assert_eq!(
+                    (poly_F_in_alpha * poly_L0_in_X) + (poly_Z_in_X * poly_K_in_X),
+                    poly_G_in_X
+                );
+
+                poly_K_in_X
+            })
+            .collect::<Box<[_]>>(),
+    )
+}
+
+fn get_count_of_valuation<F: PrimeField>(S: &PlonkStructure<F>) -> Option<NonZeroUsize> {
+    let count_of_rows = 2usize.pow(S.k as u32);
+    let count_of_gates = S.gates.len();
+
+    NonZeroUsize::new(count_of_rows * count_of_gates)
+}
+
+fn get_count_of_valuation_with_padding<F: PrimeField>(
+    S: &PlonkStructure<F>,
+) -> Option<NonZeroUsize> {
+    get_count_of_valuation(S).and_then(|v| v.checked_next_power_of_two())
+}
+
+fn get_points_count<F: PrimeField>(S: &PlonkStructure<F>, traces_len: usize) -> usize {
+    let ctx = QueryIndexContext::from(S);
     let max_degree = S
         .gates
         .iter()
@@ -354,45 +450,25 @@ pub(crate) fn compute_K<F: WithSmallOrderMulGroup<3>>(
         .max()
         .unwrap_or_default();
 
-    let points_count = (traces.len() * max_degree + 1).next_power_of_two();
-    let log_n = points_count.ilog2();
-
-    coset_fft(g_poly.as_mut());
-
-    let mut k_evals = lagrange::iter_cyclic_subgroup::<F>(log_n)
-        .map(|pt| F::ZETA * pt)
-        .zip(g_poly.iter())
-        .map(|(pt, g_y)| {
-            let l_y = f_alpha
-                * lagrange::iter_eval_lagrange_poly_for_cyclic_group(pt, log_n)
-                    .next()
-                    .unwrap();
-
-            let z_y = lagrange::eval_vanish_polynomial(log_n, pt);
-
-            // when z_y is on coset domain, invert is save
-            (*g_y - l_y) * z_y.invert().unwrap()
-        })
-        .take(points_count)
-        .collect::<Box<[_]>>();
-
-    coset_ifft(k_evals.as_mut());
-
-    Ok(UnivariatePoly(k_evals))
+    (traces_len * max_degree + 1).next_power_of_two()
 }
 
 #[cfg(test)]
 mod test {
     use std::iter;
 
+    use bitter::{BitReader, LittleEndianReader};
+    use halo2_proofs::{halo2curves::ff::PrimeField, plonk::Circuit};
+    use tracing::*;
     use tracing_test::traced_test;
 
+    use super::{folded_witness::FoldedWitness, PolyContext};
     use crate::{
         commitment::CommitmentKey,
         ff::Field as _Field,
         halo2curves::{bn256, CurveAffine},
-        plonk::{test_eval_witness::poseidon_circuit, PlonkStructure, PlonkTrace},
-        polynomial::univariate::UnivariatePoly,
+        plonk::{self, test_eval_witness::poseidon_circuit, PlonkStructure, PlonkTrace},
+        polynomial::{lagrange, univariate::UnivariatePoly},
         poseidon::{
             random_oracle::{self, ROTrait},
             PoseidonRO, Spec,
@@ -416,20 +492,24 @@ mod test {
         <Curve as CurveAffine>::Base,
     >>::OffCircuit;
 
-    fn poseidon_trace() -> (PlonkStructure<Field>, PlonkTrace<Curve>) {
-        let runner = CircuitRunner::<Field, _>::new(
-            12,
-            poseidon_circuit::TestPoseidonCircuit::default(),
-            vec![],
-        );
+    fn get_trace(
+        k_table_size: u32,
+        circuit: impl Circuit<Field>,
+        instance: Vec<Field>,
+    ) -> (PlonkStructure<Field>, PlonkTrace<Curve>) {
+        let runner = CircuitRunner::<Field, _>::new(k_table_size, circuit, vec![]);
 
         let S = runner.try_collect_plonk_structure().unwrap();
+        debug!("plonk collected");
         let witness = runner.try_collect_witness().unwrap();
+        debug!("witness collected");
 
+        let key = CommitmentKey::setup(18, b"");
+        debug!("key generated");
         let PlonkTrace { u, w } = S
             .run_sps_protocol(
-                &CommitmentKey::setup(17, b""),
-                &[],
+                &key,
+                &instance,
                 &witness,
                 &mut RO::new(PoseidonSpec::new(R_F1, R_P1)),
                 S.num_challenges,
@@ -439,18 +519,172 @@ mod test {
         (S, PlonkTrace { u, w })
     }
 
+    fn poseidon_trace() -> (PlonkStructure<Field>, PlonkTrace<Curve>) {
+        get_trace(
+            13,
+            poseidon_circuit::TestPoseidonCircuit::<_>::default(),
+            vec![Field::from(4097)],
+        )
+    }
+
+    fn pow_i<'l, F: PrimeField>(
+        i: usize,
+        t: usize,
+        challenges_powers: impl Iterator<Item = &'l F>,
+    ) -> F {
+        let bytes = i.to_le_bytes();
+        let mut reader = LittleEndianReader::new(&bytes);
+
+        iter::repeat_with(|| reader.read_bit().unwrap_or(false))
+            .zip(challenges_powers)
+            .map(|(b_j, beta_in_2j)| match b_j {
+                true => *beta_in_2j,
+                false => F::ONE,
+            })
+            .take(t)
+            .reduce(|acc, coeff| acc * coeff)
+            .unwrap()
+    }
+
+    #[traced_test]
+    #[test]
+    fn cmp_with_direct_eval_of_F() {
+        let (S, mut trace) = poseidon_trace();
+
+        let mut rnd = rand::thread_rng();
+        let mut gen = iter::repeat_with(|| Field::random(&mut rnd));
+
+        trace.w.W.iter_mut().for_each(|row| {
+            row.iter_mut()
+                .for_each(|v| *v = gen.by_ref().next().unwrap())
+        });
+
+        let traces = [trace];
+        let ctx = PolyContext::new(&S, &traces);
+
+        let delta = gen.by_ref().next().unwrap();
+        let betas = gen.by_ref().take(ctx.betas_count()).collect::<Box<[_]>>();
+
+        let evaluated_poly_F =
+            super::compute_F(&ctx, betas.iter().copied(), delta, &traces[0]).unwrap();
+
+        lagrange::iter_cyclic_subgroup::<Field>(ctx.fft_points_count_F().ilog2())
+            .chain(gen.take(10))
+            .for_each(|X| {
+                let challenge_vector = betas
+                    .iter()
+                    .zip(iter::successors(Some(delta), |d| Some(d.double())))
+                    .take(ctx.count_of_evaluation_with_padding)
+                    .map(|(beta, delta)| beta + (X * delta))
+                    .collect::<Box<[_]>>();
+
+                let result_with_direct_algo = plonk::iter_evaluate_witness::<Field>(&S, &traces[0])
+                    .enumerate()
+                    .map(|(index, f_i)| {
+                        pow_i(
+                            index,
+                            ctx.count_of_evaluation_with_padding,
+                            challenge_vector.iter(),
+                        ) * f_i.unwrap()
+                    })
+                    .sum();
+
+                assert_eq!(
+                    evaluated_poly_F.eval(X),
+                    result_with_direct_algo,
+                    "not match for {X:?}"
+                );
+            })
+    }
+
+    #[traced_test]
+    #[test]
+    fn cmp_with_direct_eval_of_G() {
+        let (S, trace) = poseidon_trace();
+        let mut rnd = rand::thread_rng();
+        let mut gen = iter::repeat_with(|| Field::random(&mut rnd));
+
+        let traces = iter::repeat_with(|| {
+            let mut trace = trace.clone();
+            trace
+                .w
+                .W
+                .iter_mut()
+                .for_each(|row| row.iter_mut().zip(gen.by_ref()).for_each(|(v, r)| *v = r));
+            trace
+        })
+        .take(3)
+        .collect::<Box<[_]>>();
+
+        let ctx = PolyContext::new(&S, &traces);
+
+        let beta_stroke = gen.by_ref().take(ctx.betas_count()).collect::<Box<[_]>>();
+
+        let accumulator = trace;
+        let evaluated_poly_G =
+            super::compute_G(&ctx, beta_stroke.iter().copied(), &accumulator, &traces).unwrap();
+
+        let points_for_fft =
+            lagrange::iter_cyclic_subgroup(ctx.fft_log_domain_size_G()).collect::<Box<[_]>>();
+
+        FoldedWitness::new(
+            &points_for_fft,
+            ctx.lagrange_domain(),
+            &accumulator,
+            &traces,
+        )
+        .iter()
+        .map(|folded_trace| {
+            plonk::iter_evaluate_witness::<Field>(&S, folded_trace)
+                .chain(iter::repeat(Ok(Field::ZERO)))
+                .take(ctx.count_of_evaluation_with_padding)
+        })
+        .zip(points_for_fft.iter().copied().chain(gen.take(10)))
+        .for_each(|(folded_witness, X)| {
+            let result_with_direct_algo = folded_witness
+                .enumerate()
+                .map(|(index, f_i)| {
+                    pow_i(
+                        index,
+                        ctx.count_of_evaluation_with_padding,
+                        beta_stroke.iter(),
+                    ) * f_i.unwrap()
+                })
+                .sum();
+
+            assert_eq!(
+                evaluated_poly_G.eval(X),
+                result_with_direct_algo,
+                "for {X:?}"
+            );
+        });
+    }
+
+    pub fn vanish_poly<F: PrimeField>(degree: usize) -> UnivariatePoly<F> {
+        let mut coeff = vec![F::ZERO; degree].into_boxed_slice();
+        coeff[0] = -F::ONE;
+        coeff[degree - 1] = F::ONE;
+        UnivariatePoly(coeff)
+    }
+
     #[traced_test]
     #[test]
     fn zero_f() {
+        debug!("start");
         let (S, trace) = poseidon_trace();
+        debug!("trace ready");
         let mut rnd = rand::thread_rng();
 
         let delta = Field::random(&mut rnd);
+
+        let traces = [trace];
+
+        debug!("start compute F");
         assert!(super::compute_F(
+            &super::PolyContext::new(&S, &traces),
             iter::repeat_with(move || Field::random(&mut rnd)),
             delta,
-            &S,
-            &trace,
+            &traces[0],
         )
         .unwrap()
         .iter()
@@ -469,12 +703,15 @@ mod test {
             .for_each(|row| row.iter_mut().for_each(|el| *el = Field::random(&mut rnd)));
 
         let delta = Field::random(&mut rnd);
+
+        let traces = [trace];
+
         assert_ne!(
             super::compute_F(
+                &super::PolyContext::new(&S, &traces),
                 iter::repeat_with(|| Field::random(&mut rnd)),
                 delta,
-                &S,
-                &trace,
+                &traces[0],
             ),
             Ok(UnivariatePoly::from_iter(
                 iter::repeat(Field::ZERO).take(16)
@@ -488,11 +725,12 @@ mod test {
         let (S, trace) = poseidon_trace();
         let mut rnd = rand::thread_rng();
 
+        let traces = [trace];
         assert!(super::compute_G(
-            &S,
+            &super::PolyContext::new(&S, &traces),
             iter::repeat_with(|| Field::random(&mut rnd)),
-            &trace.clone(),
-            &[trace],
+            &traces[0].clone(),
+            &traces
         )
         .unwrap()
         .iter()
@@ -510,12 +748,13 @@ mod test {
             .iter_mut()
             .for_each(|row| row.iter_mut().for_each(|el| *el = Field::random(&mut rnd)));
 
+        let traces = [trace];
         assert_ne!(
             super::compute_G(
-                &S,
+                &super::PolyContext::new(&S, &traces),
                 iter::repeat_with(|| Field::random(&mut rnd)),
-                &trace.clone(),
-                &[trace]
+                &traces[0].clone(),
+                &traces
             ),
             Ok(UnivariatePoly::from_iter(
                 iter::repeat(Field::ZERO).take(16)

--- a/src/nifs/protogalaxy/poly/mod.rs
+++ b/src/nifs/protogalaxy/poly/mod.rs
@@ -231,6 +231,13 @@ impl<'s, F: PrimeField> PolyContext<'s, F> {
         assert!(instances_to_fold.is_power_of_two());
         instances_to_fold.ilog2()
     }
+
+    pub fn fft_log_domain_size_K(&self) -> u32 {
+        self.fft_points_count_G
+            .add(1)
+            .saturating_sub(self.instances_to_fold)
+            .next_power_of_two() as u32
+    }
 }
 
 /// This function calculates G(X), which mathematically looks like this:
@@ -391,14 +398,8 @@ fn compute_K_from_G<F: WithSmallOrderMulGroup<3>>(
     poly_G: UnivariatePoly<F>,
     poly_F_in_alpha: F,
 ) -> UnivariatePoly<F> {
-    let fft_log_domain_size_K = poly_G
-        .degree()
-        .add(1)
-        .saturating_sub(ctx.instances_to_fold)
-        .next_power_of_two() as u32;
-
     UnivariatePoly::coset_ifft(
-        lagrange::iter_cyclic_subgroup::<F>(fft_log_domain_size_K)
+        lagrange::iter_cyclic_subgroup::<F>(ctx.fft_log_domain_size_K())
             .map(|X| F::ZETA * X)
             // TODO #293
             //.zip(poly_G.coset_fft())

--- a/src/nifs/protogalaxy/tests.rs
+++ b/src/nifs/protogalaxy/tests.rs
@@ -30,7 +30,8 @@ type Base = <Affine as CurveAffine>::Base;
 
 type RO<F> = PoseidonHash<F, T, RATE>;
 type Instance<F> = Vec<F>;
-const L: usize = 2;
+
+const L: usize = 3;
 
 type ProtoGalaxy = crate::nifs::protogalaxy::ProtoGalaxy<Affine, L>;
 type ProverParam = <ProtoGalaxy as FoldingScheme<Affine, L>>::ProverParam;
@@ -156,6 +157,13 @@ fn random_linear_combination() {
             ),
             (
                 RandomLinearCombinationCircuit::new(
+                    (1..10).map(Scalar::from).collect(),
+                    Scalar::from(2),
+                ),
+                vec![Scalar::from(4097)],
+            ),
+            (
+                RandomLinearCombinationCircuit::new(
                     (2..11).map(Scalar::from).collect(),
                     Scalar::from(3),
                 ),
@@ -173,6 +181,7 @@ fn fibo() {
 
     let seq1 = get_fibo_seq(1, 1, SIZE);
     let seq2 = get_fibo_seq(2, 3, SIZE);
+    let seq3 = get_fibo_seq(4, 5, SIZE);
 
     Mock::new(
         10,
@@ -191,6 +200,14 @@ fn fibo() {
                     b: Scalar::from(seq2[1]),
                     num: SIZE,
                 },
+                vec![Scalar::from(seq1[SIZE - 1])],
+            ),
+            (
+                FiboCircuit {
+                    a: Scalar::from(seq3[0]),
+                    b: Scalar::from(seq3[1]),
+                    num: SIZE,
+                },
                 vec![Scalar::from(seq2[SIZE - 1])],
             ),
         ],
@@ -206,6 +223,7 @@ fn fibo_lookup() {
     // circuit 1
     let seq1 = get_sequence(1, 3, 2, SIZE);
     let seq2 = get_sequence(3, 2, 2, SIZE);
+    let seq3 = get_sequence(3, 2, 2, SIZE);
 
     Mock::new(
         10,
@@ -224,6 +242,15 @@ fn fibo_lookup() {
                     a: Scalar::from(seq2[0]),
                     b: Scalar::from(seq2[1]),
                     c: Scalar::from(seq2[2]),
+                    num: SIZE,
+                },
+                vec![],
+            ),
+            (
+                FiboCircuitWithLookup {
+                    a: Scalar::from(seq3[0]),
+                    b: Scalar::from(seq3[1]),
+                    c: Scalar::from(seq3[2]),
                     num: SIZE,
                 },
                 vec![],


### PR DESCRIPTION
**Motivation**
Within the protogalaxy implementation we count many intermediate constants, we need SSOT to count in one place and easily verifiable

Part of #267

**Overview**
- impl `AccumulatorInstance::into_acc`
- impl `poly::PolyContext` struct
- refactor `FoldedTrace` -> `FoldedWitness`
- fix in `FoldedWitness` -> use correct `lagrange_domain`
- refactor `compute_K` for better testing