### PR TITLE
feat: upd API with instances columns

### DIFF
--- a/src/gadgets/nonnative/bn/big_uint_mul_mod_chip/tests.rs
+++ b/src/gadgets/nonnative/bn/big_uint_mul_mod_chip/tests.rs
@@ -882,7 +882,6 @@ mod decompose_tests {
                             F::from_u128(u128::MAX),
                             F::from_u128(u128::MAX) * F::from_u128(1_000_000_000),
                         ] {
-                            dbg!(&val);
                             region.next();
 
                             let new_val = region

--- a/src/ivc/fold_relaxed_plonk_instance_chip.rs
+++ b/src/ivc/fold_relaxed_plonk_instance_chip.rs
@@ -778,7 +778,7 @@ where
             .collect::<Result<Vec<_>, _>>()?;
         let assigned_E = assign_point!(&self.relaxed.E_commitment)?;
 
-        let [X0, X1] = self.relaxed.get_consistency_markers();
+        let [X0, X1] = self.relaxed.get_consistency_markers().unwrap();
         let assigned_X0 = assign_diff_field_as_bn!(X0, || "X0")?;
         let assigned_X1 = assign_diff_field_as_bn!(X1, || "X1")?;
 
@@ -871,11 +871,9 @@ where
             .collect::<Result<Vec<_>, _>>()?;
         let assigned_E = assign_and_absorb_point!(&self.relaxed.E_commitment)?;
 
-        let assigned_X0 =
-            assign_and_absorb_diff_field_as_bn!(&self.relaxed.get_consistency_markers()[0], || "X0")?.1;
-        let assigned_X1 =
-            assign_and_absorb_diff_field_as_bn!(&self.relaxed.get_consistency_markers()[1], || "X1")?.1;
-        assert_eq!(self.relaxed.get_consistency_markers().len(), 2);
+        let [X0, X1] = self.relaxed.get_consistency_markers().unwrap();
+        let assigned_X0 = assign_and_absorb_diff_field_as_bn!(X0, || "X0")?.1;
+        let assigned_X1 = assign_and_absorb_diff_field_as_bn!(X1, || "X1")?.1;
 
         let assigned_challenges = self
             .relaxed
@@ -904,7 +902,9 @@ where
             .map(|com| assign_and_absorb_point!(com))
             .collect::<Result<Vec<_>, _>>()?;
 
-        let assigned_input_instance = input_plonk.get_consistency_markers()
+        let assigned_input_instance = input_plonk
+            .get_consistency_markers()
+            .unwrap()
             .iter()
             .enumerate()
             .map(|(index, instance)| {
@@ -1441,6 +1441,7 @@ mod tests {
 
                     let assigned_fold_instances = relaxed_plonk
                         .get_consistency_markers()
+                        .unwrap()
                         .iter()
                         .map(|instance| {
                             assign_scalar_as_bn!(&mut ctx, instance, "folded instance".to_owned())
@@ -1492,6 +1493,7 @@ mod tests {
 
             let off_circuit_instances = relaxed_plonk
                 .get_consistency_markers()
+                .unwrap()
                 .iter()
                 .map(|instance| {
                     BigUint::from_f(

--- a/src/ivc/incrementally_verifiable_computation.rs
+++ b/src/ivc/incrementally_verifiable_computation.rs
@@ -598,25 +598,25 @@ where
         });
 
         if let Err(err) =
-            VanillaFS::is_sat_acc(pp.primary.ck(), pp.primary.S(), &self.primary.relaxed_trace)
+            VanillaFS::is_sat(pp.primary.ck(), pp.primary.S(), &self.primary.relaxed_trace)
         {
-            errors.push(VerificationError::NotSat {
+            errors.extend(err.into_iter().map(|err| VerificationError::NotSat {
                 err,
                 is_primary: true,
-                is_relaxed: false,
-            })
+                is_relaxed: true,
+            }));
         }
 
-        if let Err(err) = VanillaFS::is_sat_acc(
+        if let Err(err) = VanillaFS::is_sat(
             pp.secondary.ck(),
             pp.secondary.S(),
             &self.secondary.relaxed_trace,
         ) {
-            errors.push(VerificationError::NotSat {
+            errors.extend(err.into_iter().map(|err| VerificationError::NotSat {
                 err,
                 is_primary: false,
                 is_relaxed: true,
-            })
+            }));
         }
 
         if let Err(err) = pp.secondary.S().is_sat(
@@ -628,23 +628,7 @@ where
             errors.push(VerificationError::NotSat {
                 err,
                 is_primary: false,
-                is_relaxed: true,
-            })
-        }
-
-        if let Err(err) = VanillaFS::is_sat_perm(pp.primary.S(), &self.primary.relaxed_trace) {
-            errors.push(VerificationError::NotSat {
-                err,
-                is_primary: false,
-                is_relaxed: true,
-            })
-        }
-
-        if let Err(err) = VanillaFS::is_sat_perm(pp.secondary.S(), &self.secondary.relaxed_trace) {
-            errors.push(VerificationError::NotSat {
-                err,
-                is_primary: false,
-                is_relaxed: true,
+                is_relaxed: false,
             })
         }
 

--- a/src/ivc/incrementally_verifiable_computation.rs
+++ b/src/ivc/incrementally_verifiable_computation.rs
@@ -17,7 +17,7 @@ use crate::{
     main_gate::MainGateConfig,
     nifs::{
         self,
-        vanilla::{accumulator::RelaxedPlonkTrace, VanillaFS},
+        vanilla::{accumulator::RelaxedPlonkTrace, GetConsistencyMarkers, VanillaFS},
         FoldingScheme, IsSatAccumulator,
     },
     plonk::{self, PlonkTrace},
@@ -210,10 +210,11 @@ where
         );
 
         // Prepare primary constraint system for folding
-        let primary_instance = {
+        let primary_consistency_marker = {
             let _s = info_span!("generate_instance").entered();
             [
-                util::fe_to_fe(&secondary_pre_round_plonk_trace.u.instance[1]).unwrap(),
+                util::fe_to_fe(&secondary_pre_round_plonk_trace.u.get_consistency_markers()[1])
+                    .unwrap(),
                 RandomOracleComputationInstance::<'_, A1, C2, RP1::OffCircuit> {
                     random_oracle_constant: pp.primary.params().ro_constant().clone(),
                     public_params_hash: &pp.digest_2(),
@@ -245,12 +246,13 @@ where
             },
         };
 
+        let primary_instances = primary_sfc.instances(primary_consistency_marker);
         if debug_mode {
             let _s = debug_span!("debug").entered();
             MockProver::run(
                 pp.primary.k_table_size(),
                 &primary_sfc,
-                vec![primary_instance.to_vec()],
+                primary_instances.clone(),
             )?
             .verify()
             .map_err(|err| Error::from_mock_verify(err, true, 0))?;
@@ -259,7 +261,7 @@ where
         let primary_witness = CircuitRunner::new(
             pp.primary.k_table_size(),
             primary_sfc,
-            primary_instance.to_vec(),
+            primary_instances.clone(),
         )
         .try_collect_witness()?;
 
@@ -268,7 +270,7 @@ where
 
         let primary_plonk_trace = VanillaFS::generate_plonk_trace(
             pp.primary.ck(),
-            &primary_instance,
+            &primary_instances,
             &primary_witness,
             &primary_nifs_pp,
             &mut RP2::OffCircuit::new(pp.secondary.params().ro_constant().clone()),
@@ -286,10 +288,10 @@ where
             secondary.process_step(&secondary_z_0, pp.secondary.k_table_size())?;
 
         // Will be used as input & output `U` of zero-step of IVC
-        let secondary_instance = {
+        let secondary_consistency_marker = {
             let _s = info_span!("generate_instance");
             [
-                util::fe_to_fe(&primary_plonk_trace.u.instance[1]).unwrap(),
+                util::fe_to_fe(&primary_plonk_trace.u.get_consistency_markers()[1]).unwrap(),
                 RandomOracleComputationInstance::<'_, A2, C1, RP2::OffCircuit> {
                     random_oracle_constant: pp.secondary.params().ro_constant().clone(),
                     public_params_hash: &pp.digest_1(),
@@ -324,12 +326,13 @@ where
             },
         };
 
+        let secondary_instances = secondary_sfc.instances(secondary_consistency_marker);
         if debug_mode {
             let _s = debug_span!("debug").entered();
             MockProver::run(
                 pp.secondary.k_table_size(),
                 &secondary_sfc,
-                vec![secondary_instance.to_vec()],
+                secondary_instances.clone(),
             )?
             .verify()
             .map_err(|err| Error::from_mock_verify(err, false, 0))?;
@@ -338,7 +341,7 @@ where
         let secondary_witness = CircuitRunner::new(
             pp.secondary.k_table_size(),
             secondary_sfc,
-            secondary_instance.to_vec(),
+            secondary_instances.clone(),
         )
         .try_collect_witness()?;
 
@@ -347,7 +350,7 @@ where
 
         let secondary_plonk_trace = VanillaFS::generate_plonk_trace(
             pp.secondary.ck(),
-            &secondary_instance,
+            &secondary_instances,
             &secondary_witness,
             &secondary_nifs_pp,
             &mut RP1::OffCircuit::new(pp.primary.params().ro_constant().clone()),
@@ -401,10 +404,10 @@ where
         // Prepare primary constraint system for folding
         let primary_z_next = primary.process_step(&self.primary.z_i, pp.primary.k_table_size())?;
 
-        let primary_instance = {
+        let primary_consistency_marker = {
             let _s = info_span!("generate_instance").entered();
             [
-                util::fe_to_fe(&self.secondary_trace[0].u.instance[1]).unwrap(),
+                util::fe_to_fe(&self.secondary_trace[0].u.get_consistency_markers()[1]).unwrap(),
                 RandomOracleComputationInstance::<'_, A1, C2, RP1::OffCircuit> {
                     random_oracle_constant: pp.primary.params().ro_constant().clone(),
                     public_params_hash: &pp.digest_2(),
@@ -433,12 +436,13 @@ where
             },
         };
 
+        let primary_instances = primary_sfc.instances(primary_consistency_marker);
         if self.debug_mode {
             let _s = debug_span!("debug").entered();
             MockProver::run(
                 pp.primary.k_table_size(),
                 &primary_sfc,
-                vec![primary_instance.to_vec()],
+                primary_instances.clone(),
             )?
             .verify()
             .map_err(|err| Error::from_mock_verify(err, true, self.step))?;
@@ -447,7 +451,7 @@ where
         let primary_witness = CircuitRunner::new(
             pp.primary.k_table_size(),
             primary_sfc,
-            primary_instance.to_vec(),
+            primary_instances.clone(),
         )
         .try_collect_witness()?;
 
@@ -456,7 +460,7 @@ where
 
         let primary_plonk_trace = [VanillaFS::generate_plonk_trace(
             pp.primary.ck(),
-            &primary_instance,
+            &primary_instances,
             &primary_witness,
             &self.primary_nifs_pp,
             &mut RP2::OffCircuit::new(pp.secondary.params().ro_constant().clone()),
@@ -478,10 +482,10 @@ where
         let next_secondary_z_i =
             secondary.process_step(&self.secondary.z_i, pp.secondary.k_table_size())?;
 
-        let secondary_instance = {
+        let secondary_consistency_marker = {
             let _s = info_span!("generate_instance");
             [
-                util::fe_to_fe(&primary_plonk_trace[0].u.instance[1]).unwrap(),
+                util::fe_to_fe(&primary_plonk_trace[0].u.get_consistency_markers()[1]).unwrap(),
                 RandomOracleComputationInstance::<'_, A2, C1, RP2::OffCircuit> {
                     random_oracle_constant: pp.secondary.params().ro_constant().clone(),
                     public_params_hash: &pp.digest_1(),
@@ -510,12 +514,13 @@ where
             },
         };
 
+        let secondary_instance = secondary_sfc.instances(secondary_consistency_marker);
         if self.debug_mode {
             let _s = debug_span!("debug").entered();
             MockProver::run(
                 pp.secondary.k_table_size(),
                 &secondary_sfc,
-                vec![secondary_instance.to_vec()],
+                secondary_instance.clone(),
             )?
             .verify()
             .map_err(|err| Error::from_mock_verify(err, false, self.step))?;
@@ -524,7 +529,7 @@ where
         let secondary_witness = CircuitRunner::new(
             pp.secondary.k_table_size(),
             secondary_sfc,
-            secondary_instance.to_vec(),
+            secondary_instance.clone(),
         )
         .try_collect_witness()?;
 
@@ -568,7 +573,7 @@ where
         .generate_with_inspect::<C2::Scalar>(|buf| {
             debug!("primary X0 verify at {}-step: {buf:?}", self.step)
         })
-        .ne(&self.secondary_trace[0].u.instance[0])
+        .ne(&self.secondary_trace[0].u.get_consistency_markers()[0])
         .then(|| {
             errors.push(VerificationError::InstanceNotMatch {
                 index: 0,
@@ -589,7 +594,7 @@ where
         .generate_with_inspect::<C1::Scalar>(|buf| {
             debug!("primary X1 verify at {}-step: {buf:?}", self.step)
         })
-        .ne(&util::fe_to_fe(&self.secondary_trace[0].u.instance[1]).unwrap())
+        .ne(&util::fe_to_fe(&self.secondary_trace[0].u.get_consistency_markers()[1]).unwrap())
         .then(|| {
             errors.push(VerificationError::InstanceNotMatch {
                 index: 1,

--- a/src/ivc/incrementally_verifiable_computation.rs
+++ b/src/ivc/incrementally_verifiable_computation.rs
@@ -213,8 +213,13 @@ where
         let primary_consistency_marker = {
             let _s = info_span!("generate_instance").entered();
             [
-                util::fe_to_fe(&secondary_pre_round_plonk_trace.u.get_consistency_markers()[1])
-                    .unwrap(),
+                util::fe_to_fe(
+                    &secondary_pre_round_plonk_trace
+                        .u
+                        .get_consistency_markers()
+                        .unwrap()[1],
+                )
+                .unwrap(),
                 RandomOracleComputationInstance::<'_, A1, C2, RP1::OffCircuit> {
                     random_oracle_constant: pp.primary.params().ro_constant().clone(),
                     public_params_hash: &pp.digest_2(),
@@ -291,7 +296,8 @@ where
         let secondary_consistency_marker = {
             let _s = info_span!("generate_instance");
             [
-                util::fe_to_fe(&primary_plonk_trace.u.get_consistency_markers()[1]).unwrap(),
+                util::fe_to_fe(&primary_plonk_trace.u.get_consistency_markers().unwrap()[1])
+                    .unwrap(),
                 RandomOracleComputationInstance::<'_, A2, C1, RP2::OffCircuit> {
                     random_oracle_constant: pp.secondary.params().ro_constant().clone(),
                     public_params_hash: &pp.digest_1(),
@@ -407,7 +413,8 @@ where
         let primary_consistency_marker = {
             let _s = info_span!("generate_instance").entered();
             [
-                util::fe_to_fe(&self.secondary_trace[0].u.get_consistency_markers()[1]).unwrap(),
+                util::fe_to_fe(&self.secondary_trace[0].u.get_consistency_markers().unwrap()[1])
+                    .unwrap(),
                 RandomOracleComputationInstance::<'_, A1, C2, RP1::OffCircuit> {
                     random_oracle_constant: pp.primary.params().ro_constant().clone(),
                     public_params_hash: &pp.digest_2(),
@@ -485,7 +492,8 @@ where
         let secondary_consistency_marker = {
             let _s = info_span!("generate_instance");
             [
-                util::fe_to_fe(&primary_plonk_trace[0].u.get_consistency_markers()[1]).unwrap(),
+                util::fe_to_fe(&primary_plonk_trace[0].u.get_consistency_markers().unwrap()[1])
+                    .unwrap(),
                 RandomOracleComputationInstance::<'_, A2, C1, RP2::OffCircuit> {
                     random_oracle_constant: pp.secondary.params().ro_constant().clone(),
                     public_params_hash: &pp.digest_1(),
@@ -573,7 +581,7 @@ where
         .generate_with_inspect::<C2::Scalar>(|buf| {
             debug!("primary X0 verify at {}-step: {buf:?}", self.step)
         })
-        .ne(&self.secondary_trace[0].u.get_consistency_markers()[0])
+        .ne(&self.secondary_trace[0].u.get_consistency_markers().unwrap()[0])
         .then(|| {
             errors.push(VerificationError::InstanceNotMatch {
                 index: 0,
@@ -594,7 +602,10 @@ where
         .generate_with_inspect::<C1::Scalar>(|buf| {
             debug!("primary X1 verify at {}-step: {buf:?}", self.step)
         })
-        .ne(&util::fe_to_fe(&self.secondary_trace[0].u.get_consistency_markers()[1]).unwrap())
+        .ne(
+            &util::fe_to_fe(&self.secondary_trace[0].u.get_consistency_markers().unwrap()[1])
+                .unwrap(),
+        )
         .then(|| {
             errors.push(VerificationError::InstanceNotMatch {
                 index: 1,

--- a/src/ivc/instance_computation.rs
+++ b/src/ivc/instance_computation.rs
@@ -120,6 +120,7 @@ where
             W_commitments: &self.relaxed.W_commitments,
             E_commitment: &self.relaxed.E_commitment,
             consistency_marker: self.relaxed.get_consistency_markers()
+                .unwrap()
                 .iter()
                 .map(|v| {
                     BigUint::from_f(

--- a/src/ivc/instance_computation.rs
+++ b/src/ivc/instance_computation.rs
@@ -10,7 +10,7 @@ use crate::{
     gadgets::{ecc::AssignedPoint, nonnative::bn::big_uint::BigUint},
     halo2curves::CurveAffine,
     main_gate::{AssignedValue, MainGate, MainGateConfig, RegionCtx, WrapValue},
-    nifs::vanilla::accumulator::RelaxedPlonkInstance,
+    nifs::vanilla::{accumulator::RelaxedPlonkInstance, GetConsistencyMarkers},
     poseidon::{AbsorbInRO, ROCircuitTrait, ROTrait},
     util,
 };
@@ -89,7 +89,7 @@ where
         pub struct RelaxedPlonkInstanceBigUintView<'l, C: CurveAffine> {
             pub(crate) W_commitments: &'l Vec<C>,
             pub(crate) E_commitment: &'l C,
-            pub(crate) instance: Vec<BigUint<C::Base>>,
+            pub(crate) consistency_marker: Vec<BigUint<C::Base>>,
             pub(crate) challenges: Vec<BigUint<C::Base>>,
             pub(crate) u: &'l C::ScalarExt,
         }
@@ -101,7 +101,7 @@ where
                 ro.absorb_point_iter(self.W_commitments.iter())
                     .absorb_point(self.E_commitment)
                     .absorb_field_iter(
-                        self.instance
+                        self.consistency_marker
                             .iter()
                             .flat_map(|bn| bn.limbs().iter())
                             .copied(),
@@ -119,9 +119,7 @@ where
         let relaxed = RelaxedPlonkInstanceBigUintView {
             W_commitments: &self.relaxed.W_commitments,
             E_commitment: &self.relaxed.E_commitment,
-            instance: self
-                .relaxed
-                .instance
+            consistency_marker: self.relaxed.get_consistency_markers()
                 .iter()
                 .map(|v| {
                     BigUint::from_f(
@@ -214,7 +212,7 @@ mod tests {
         let relaxed = RelaxedPlonkInstance {
             inner: PlonkInstance {
                 W_commitments: vec![CommitmentKey::<C1>::default_value(); 10],
-                instance: vec![Scalar::from_u128(0x67899); 2],
+                instances: vec![vec![Scalar::from_u128(0x67899); 2]],
                 challenges: vec![Scalar::from_u128(0x123456); 10],
             },
             E_commitment: CommitmentKey::<C1>::default_value(),
@@ -242,7 +240,7 @@ mod tests {
         let config = MainGate::<Base, 10>::configure(&mut cs);
 
         let mut td = WitnessCollector {
-            instance: vec![],
+            instances: vec![vec![]],
             advice: vec![vec![Base::ZERO.into(); 1 << K_TABLE_SIZE]; cs.num_advice_columns()],
         };
 

--- a/src/ivc/public_params.rs
+++ b/src/ivc/public_params.rs
@@ -19,7 +19,11 @@ use crate::{
         NUM_IO,
     },
     main_gate::MainGateConfig,
-    nifs::{self, vanilla::{VanillaFS, GetConsistencyMarkers}, FoldingScheme},
+    nifs::{
+        self,
+        vanilla::{GetConsistencyMarkers, VanillaFS},
+        FoldingScheme,
+    },
     plonk::{PlonkStructure, PlonkTrace},
     poseidon::{random_oracle::ROTrait, ROPair},
     table::CircuitRunner,
@@ -283,7 +287,13 @@ where
             );
 
             let secondary_initial_instance: [C2::Scalar; 2] = [
-                util::fe_to_fe(&secondary_initial_step_input.u.get_consistency_markers()[0]).unwrap(),
+                util::fe_to_fe(
+                    &secondary_initial_step_input
+                        .u
+                        .get_consistency_markers()
+                        .unwrap()[0],
+                )
+                .unwrap(),
                 RandomOracleComputationInstance::<'_, A2, C1, RP2::OffCircuit> {
                     random_oracle_constant: secondary.ro_constant.clone(),
                     public_params_hash: &secondary_initial_step_input.public_params_hash,

--- a/src/ivc/public_params.rs
+++ b/src/ivc/public_params.rs
@@ -19,7 +19,7 @@ use crate::{
         NUM_IO,
     },
     main_gate::MainGateConfig,
-    nifs::{self, vanilla::VanillaFS, FoldingScheme},
+    nifs::{self, vanilla::{VanillaFS, GetConsistencyMarkers}, FoldingScheme},
     plonk::{PlonkStructure, PlonkTrace},
     poseidon::{random_oracle::ROTrait, ROPair},
     table::CircuitRunner,
@@ -254,21 +254,18 @@ where
         let primary_S = {
             let _primary_span = info_span!("primary").entered();
 
-            CircuitRunner::new(
-                primary.k_table_size,
-                StepFoldingCircuit::<'_, A1, C2, SC1, RP1::OnCircuit, MAIN_GATE_T> {
-                    step_circuit: primary.step_circuit,
-                    input: StepInputs::without_witness::<
-                        StepFoldingCircuit<'_, A2, C1, SC2, RP2::OnCircuit, MAIN_GATE_T>,
-                    >(
-                        primary.k_table_size,
-                        NUM_IO,
-                        &StepParams::new(limb_width, limbs_count, primary.ro_constant.clone()),
-                    ),
-                },
-                vec![C1::Scalar::ZERO; NUM_IO],
-            )
-            .try_collect_plonk_structure()
+            let primary_step_params =
+                StepParams::new(limb_width, limbs_count, primary.ro_constant.clone());
+            let primary_sfc = StepFoldingCircuit::<'_, A1, C2, SC1, RP1::OnCircuit, MAIN_GATE_T> {
+                step_circuit: primary.step_circuit,
+                input: StepInputs::without_witness::<
+                    StepFoldingCircuit<'_, A2, C1, SC2, RP2::OnCircuit, MAIN_GATE_T>,
+                >(primary.k_table_size, NUM_IO, &primary_step_params),
+            };
+            let primary_instances = primary_sfc.instances([C1::Scalar::ZERO; NUM_IO]);
+
+            CircuitRunner::new(primary.k_table_size, primary_sfc, primary_instances)
+                .try_collect_plonk_structure()
         }?;
 
         let (secondary_S, secondary_initial_plonk_trace) = {
@@ -286,7 +283,7 @@ where
             );
 
             let secondary_initial_instance: [C2::Scalar; 2] = [
-                util::fe_to_fe(&secondary_initial_step_input.u.instance[0]).unwrap(),
+                util::fe_to_fe(&secondary_initial_step_input.u.get_consistency_markers()[0]).unwrap(),
                 RandomOracleComputationInstance::<'_, A2, C1, RP2::OffCircuit> {
                     random_oracle_constant: secondary.ro_constant.clone(),
                     public_params_hash: &secondary_initial_step_input.public_params_hash,
@@ -307,16 +304,17 @@ where
                 input: secondary_initial_step_input,
             };
 
+            let secondary_instances = secondary_sfc.instances(secondary_initial_instance);
             let secondary_cr = CircuitRunner::new(
                 secondary.k_table_size,
                 secondary_sfc,
-                vec![C2::Scalar::ZERO; NUM_IO],
+                secondary_instances.clone(),
             );
 
             let secondary_S = secondary_cr.try_collect_plonk_structure()?;
             let secondary_initial_plonk_trace = VanillaFS::generate_plonk_trace(
                 secondary.commitment_key,
-                &secondary_initial_instance,
+                &secondary_instances,
                 &secondary_cr.try_collect_witness()?,
                 &VanillaFS::setup_params(C2::identity(), secondary_S.clone())?.0,
                 &mut RP1::OffCircuit::new(primary.ro_constant.clone()),

--- a/src/ivc/step_circuit.rs
+++ b/src/ivc/step_circuit.rs
@@ -55,6 +55,20 @@ pub trait StepCircuit<const ARITY: usize, F: PrimeField> {
     /// TODO improve
     type Config: Clone;
 
+    /// Returns a vector of public input instances for each step.
+    ///
+    /// This method allows for the specification of public input instances at each step
+    ///
+    /// By default, this method returns an empty vector, indicating no public inputs
+    /// for the step. However, this method can be overridden in implementations
+    /// of `StepCircuit` to return the required instances.
+    ///
+    /// The dimensionality of the output vector must match how many instance columns you created
+    /// during the [`StepCircuit::configure`] call.
+    fn instances(&self) -> Vec<Vec<F>> {
+        vec![]
+    }
+
     /// Configure the step circuit. This method initializes necessary
     /// fixed columns and advice columns, but does not create any instance
     /// columns.
@@ -95,7 +109,7 @@ pub trait StepCircuit<const ARITY: usize, F: PrimeField> {
         let config = Self::configure(&mut cs);
 
         let mut witness = WitnessCollector {
-            instance: vec![F::ZERO, F::ZERO],
+            instances: vec![vec![F::ZERO, F::ZERO]],
             advice: vec![vec![F::ZERO.into(); 1 << k_table_size as usize]; cs.num_advice_columns()],
         };
         let mut layouter =

--- a/src/ivc/step_folding_circuit.rs
+++ b/src/ivc/step_folding_circuit.rs
@@ -237,7 +237,11 @@ where
                 z_i: [C::Base::ZERO; ARITY],
                 cross_term_commits: vec![C::identity(); self.input.cross_term_commits.len()],
                 U: RelaxedPlonkInstance::new(
-                    self.input.U.get_consistency_markers().len(),
+                    self.input
+                        .U
+                        .get_consistency_markers()
+                        .map(|m| m.len())
+                        .unwrap_or_default(),
                     self.input.U.challenges.len(),
                     self.input.U.W_commitments.len(),
                 ),

--- a/src/nifs/mod.rs
+++ b/src/nifs/mod.rs
@@ -47,7 +47,7 @@ pub trait FoldingScheme<C: CurveAffine, const L: usize = 1> {
 
     fn generate_plonk_trace(
         ck: &CommitmentKey<C>,
-        instance: &[C::ScalarExt],
+        instances: &[Vec<C::ScalarExt>],
         witness: &[Vec<C::ScalarExt>],
         pp: &Self::ProverParam,
         ro_nark: &mut impl ROTrait<C::Base>,

--- a/src/nifs/protogalaxy/poly/mod.rs
+++ b/src/nifs/protogalaxy/poly/mod.rs
@@ -510,7 +510,7 @@ mod test {
         let PlonkTrace { u, w } = S
             .run_sps_protocol(
                 &key,
-                &instance,
+                &[instance],
                 &witness,
                 &mut RO::new(PoseidonSpec::new(R_F1, R_P1)),
                 S.num_challenges,

--- a/src/nifs/protogalaxy/tests.rs
+++ b/src/nifs/protogalaxy/tests.rs
@@ -128,7 +128,7 @@ impl<C: Circuit<Scalar>> Mock<C> {
         let init_accumulator =
             ProtoGalaxy::new_accumulator(AccumulatorArgs::from(&self.S), &self.pp, &mut ro());
 
-        ProtoGalaxy::is_sat_acc(&self.ck, &self.S, &init_accumulator)
+        ProtoGalaxy::is_sat_accumulation(&self.S, &init_accumulator)
             .expect("The newly created accumulator is not satisfactory");
 
         let (accumulator_from_prove, proof) = ProtoGalaxy::prove(
@@ -140,7 +140,7 @@ impl<C: Circuit<Scalar>> Mock<C> {
         )
         .expect("`protogalaxy::prove` failed");
 
-        ProtoGalaxy::is_sat_acc(&self.ck, &self.S, &accumulator_from_prove)
+        ProtoGalaxy::is_sat(&self.ck, &self.S, &accumulator_from_prove)
             .expect("The accumulator after calling `prove` is not satisfactory");
 
         let accumulator_from_verify = ProtoGalaxy::verify(

--- a/src/nifs/protogalaxy/tests.rs
+++ b/src/nifs/protogalaxy/tests.rs
@@ -1,18 +1,15 @@
 use halo2_proofs::{
+    dev::MockProver,
     halo2curves::{
         ff::{FromUniformBytes, PrimeFieldBits},
         group::prime::PrimeCurveAffine,
     },
     plonk::Circuit,
 };
+use tracing::info_span;
+use tracing_test::traced_test;
 
 use super::*;
-
-const T: usize = 3;
-const RATE: usize = 2;
-const R_F: usize = 4;
-const R_P: usize = 3;
-
 use crate::{
     commitment,
     halo2curves::bn256::G1Affine as Affine,
@@ -25,13 +22,17 @@ use crate::{
     table::{CircuitRunner, Witness},
 };
 
+const T: usize = 3;
+const RATE: usize = 2;
+const R_F: usize = 4;
+const R_P: usize = 3;
+const L: usize = 3;
+
 type Scalar = <Affine as CurveAffine>::ScalarExt;
 type Base = <Affine as CurveAffine>::Base;
 
 type RO<F> = PoseidonHash<F, T, RATE>;
 type Instance<F> = Vec<F>;
-
-const L: usize = 3;
 
 type ProtoGalaxy = crate::nifs::protogalaxy::ProtoGalaxy<Affine, L>;
 type ProverParam = <ProtoGalaxy as FoldingScheme<Affine, L>>::ProverParam;
@@ -57,11 +58,6 @@ struct Mock<CIRCUIT: Circuit<Scalar>> {
     S: PlonkStructure<Scalar>,
     ck: CommitmentKey<Affine>,
 
-    ro_nark_generate: RO<Base>,
-    ro_nark_verifier: RO<Base>,
-    ro_acc_prover: RO<Base>,
-    ro_acc_verifier: RO<Base>,
-
     circuits_ctx: [CircuitCtx; L],
 
     pp: ProverParam,
@@ -70,10 +66,25 @@ struct Mock<CIRCUIT: Circuit<Scalar>> {
     _p: PhantomData<CIRCUIT>,
 }
 
+fn ro<F: PrimeFieldBits + FromUniformBytes<64>>() -> PoseidonHash<F, T, RATE> {
+    PoseidonHash::<F, T, RATE>::new(Spec::<F, T, RATE>::new(R_F, R_P))
+}
+
 impl<C: Circuit<Scalar>> Mock<C> {
     pub fn new(k_table_size: u32, circuits: [(C, Vec<Scalar>); L]) -> Self {
-        let circuits_runners =
-            circuits.map(|(circuit, instance)| CircuitRunner::new(k_table_size, circuit, instance));
+        let circuits_runners = circuits.map(|(circuit, instance)| {
+            let instances = if instance.is_empty() {
+                vec![]
+            } else {
+                vec![instance.clone()]
+            };
+            MockProver::run(k_table_size, &circuit, instances)
+                .unwrap()
+                .verify()
+                .unwrap();
+
+            CircuitRunner::new(k_table_size, circuit, instance)
+        });
 
         let ck = commitment::setup_smallest_key(k_table_size, &circuits_runners[0].cs, b"");
         let S = circuits_runners[0]
@@ -82,16 +93,8 @@ impl<C: Circuit<Scalar>> Mock<C> {
 
         let (pp, vp) = ProtoGalaxy::setup_params(Affine::identity(), S.clone()).unwrap();
 
-        fn ro<F: PrimeFieldBits + FromUniformBytes<64>>() -> PoseidonHash<F, T, RATE> {
-            PoseidonHash::<F, T, RATE>::new(Spec::<F, T, RATE>::new(R_F, R_P))
-        }
-
         Mock {
             ck,
-            ro_nark_generate: ro(),
-            ro_nark_verifier: ro(),
-            ro_acc_prover: ro(),
-            ro_acc_verifier: ro(),
             circuits_ctx: circuits_runners.map(CircuitCtx::collect),
             pp,
             vp,
@@ -101,6 +104,7 @@ impl<C: Circuit<Scalar>> Mock<C> {
     }
 
     pub fn generate_plonk_traces(&mut self) -> [PlonkTrace<Affine>; L] {
+        let mut ro = ro();
         self.circuits_ctx
             .iter()
             .map(|ctx| {
@@ -109,7 +113,7 @@ impl<C: Circuit<Scalar>> Mock<C> {
                     &ctx.instance,
                     &ctx.witness,
                     &self.pp,
-                    &mut self.ro_nark_generate,
+                    &mut ro,
                 )
                 .unwrap()
             })
@@ -121,28 +125,46 @@ impl<C: Circuit<Scalar>> Mock<C> {
     pub fn run(mut self) {
         let incoming = self.generate_plonk_traces();
 
-        let acc = ProtoGalaxy::new_accumulator(
-            AccumulatorArgs::from(&self.S),
+        let init_accumulator =
+            ProtoGalaxy::new_accumulator(AccumulatorArgs::from(&self.S), &self.pp, &mut ro());
+
+        ProtoGalaxy::is_sat_acc(&self.ck, &self.S, &init_accumulator)
+            .expect("The newly created accumulator is not satisfactory");
+
+        let (accumulator_from_prove, proof) = ProtoGalaxy::prove(
+            &self.ck,
             &self.pp,
-            &mut self.ro_acc_prover,
-        );
+            &mut ro(),
+            init_accumulator.clone(),
+            &incoming,
+        )
+        .expect("`protogalaxy::prove` failed");
 
-        let (accumulator, proof) =
-            ProtoGalaxy::prove(&self.ck, &self.pp, &mut self.ro_acc_prover, acc, &incoming)
-                .expect("`protogalaxy::prove` failed");
+        ProtoGalaxy::is_sat_acc(&self.ck, &self.S, &accumulator_from_prove)
+            .expect("The accumulator after calling `prove` is not satisfactory");
 
-        let _acc_instance = ProtoGalaxy::verify(
+        let accumulator_from_verify = ProtoGalaxy::verify(
             &self.vp,
-            &mut self.ro_nark_verifier,
-            &mut self.ro_acc_verifier,
-            &AccumulatorInstance::from(accumulator),
+            &mut ro(),
+            &mut ro(),
+            &init_accumulator.into(),
             &incoming.map(|tr| tr.u),
             &proof,
         )
         .unwrap();
+
+        let accumulator_inst_from_prove = AccumulatorInstance::from(accumulator_from_prove);
+
+        assert_eq!(
+            accumulator_inst_from_prove.betas,
+            accumulator_from_verify.betas,
+        );
+        assert_eq!(accumulator_inst_from_prove.e, accumulator_from_verify.e,);
+        assert_eq!(accumulator_inst_from_prove.ins, accumulator_from_verify.ins);
     }
 }
 
+#[traced_test]
 #[test]
 fn random_linear_combination() {
     Mock::new(
@@ -174,14 +196,17 @@ fn random_linear_combination() {
     .run();
 }
 
+#[traced_test]
 #[test]
 fn fibo() {
+    let _s = info_span!("fibo").entered();
+
     const K: u32 = 4;
     const SIZE: usize = 16;
 
     let seq1 = get_fibo_seq(1, 1, SIZE);
     let seq2 = get_fibo_seq(2, 3, SIZE);
-    let seq3 = get_fibo_seq(4, 5, SIZE);
+    let seq3 = get_fibo_seq(3, 5, SIZE);
 
     Mock::new(
         10,
@@ -200,7 +225,7 @@ fn fibo() {
                     b: Scalar::from(seq2[1]),
                     num: SIZE,
                 },
-                vec![Scalar::from(seq1[SIZE - 1])],
+                vec![Scalar::from(seq2[SIZE - 1])],
             ),
             (
                 FiboCircuit {
@@ -208,15 +233,18 @@ fn fibo() {
                     b: Scalar::from(seq3[1]),
                     num: SIZE,
                 },
-                vec![Scalar::from(seq2[SIZE - 1])],
+                vec![Scalar::from(seq3[SIZE - 1])],
             ),
         ],
     )
     .run();
 }
 
+#[traced_test]
 #[test]
 fn fibo_lookup() {
+    let _s = info_span!("fibo_lookup").entered();
+
     const K: u32 = 5;
     const SIZE: usize = 7;
 

--- a/src/nifs/protogalaxy/tests.rs
+++ b/src/nifs/protogalaxy/tests.rs
@@ -104,7 +104,8 @@ impl<C: Circuit<Scalar>> Mock<C> {
     }
 
     pub fn generate_plonk_traces(&mut self) -> [PlonkTrace<Affine>; L] {
-        let mut ro = ro();
+        let mut generate_ro = ro();
+        let mut is_sat_ro = ro();
         self.circuits_ctx
             .iter()
             .map(|ctx| {
@@ -113,9 +114,14 @@ impl<C: Circuit<Scalar>> Mock<C> {
                     &ctx.instance,
                     &ctx.witness,
                     &self.pp,
-                    &mut ro,
+                    &mut generate_ro,
                 )
                 .unwrap()
+            })
+            .inspect(|trace| {
+                self.S
+                    .is_sat(&self.ck, &mut is_sat_ro, &trace.u, &trace.w)
+                    .unwrap()
             })
             .collect::<Vec<_>>()
             .try_into()

--- a/src/nifs/tests.rs
+++ b/src/nifs/tests.rs
@@ -464,6 +464,7 @@ pub(crate) mod fibo_circuit_with_lookup {
                 meta.advice_column(),
             ];
             let selector = [meta.selector(), meta.complex_selector()];
+
             FiboChip::configure(meta, advice, selector)
         }
 

--- a/src/nifs/vanilla/accumulator.rs
+++ b/src/nifs/vanilla/accumulator.rs
@@ -98,8 +98,9 @@ impl<C: CurveAffine> RelaxedPlonkInstance<C> {
 
         let instance = self
             .get_consistency_markers()
+            .unwrap()
             .par_iter()
-            .zip(U2.get_consistency_markers())
+            .zip(U2.get_consistency_markers().unwrap())
             .map(|(a, b)| *a + *r * b)
             .collect::<Vec<C::ScalarExt>>();
 

--- a/src/nifs/vanilla/mod.rs
+++ b/src/nifs/vanilla/mod.rs
@@ -337,6 +337,8 @@ impl<C: CurveAffine> VerifyAccumulation<C> for VanillaFS<C> {
 
         let Z = U
             .get_consistency_markers()
+            .copied()
+            .unwrap_or_default()
             .iter()
             .chain(W.W[0].iter().take((1 << S.k) * S.num_advice_columns))
             .copied()
@@ -380,22 +382,18 @@ impl<C: CurveAffine> VerifyAccumulation<C> for VanillaFS<C> {
 }
 
 pub trait GetConsistencyMarkers<F> {
-    fn get_consistency_markers(&self) -> &[F; 2];
+    fn get_consistency_markers(&self) -> Option<&[F; 2]>;
 }
 
 impl<C: CurveAffine> GetConsistencyMarkers<C::ScalarExt> for PlonkInstance<C> {
-    fn get_consistency_markers(&self) -> &[C::ScalarExt; 2] {
-        self.instance(0)
-            .try_into()
-            .expect("Failed to get X0 & X1 from `PlonkInstance`")
+    fn get_consistency_markers(&self) -> Option<&[C::ScalarExt; 2]> {
+        self.instance(0).try_into().ok()
     }
 }
 
 impl<C: CurveAffine> GetConsistencyMarkers<C::ScalarExt> for RelaxedPlonkInstance<C> {
-    fn get_consistency_markers(&self) -> &[C::ScalarExt; 2] {
-        self.instance(0)
-            .try_into()
-            .expect("Failed to get X0 & X1 from `RelaxedPlonkInstance`")
+    fn get_consistency_markers(&self) -> Option<&[C::ScalarExt; 2]> {
+        self.instance(0).try_into().ok()
     }
 }
 

--- a/src/nifs/vanilla/tests.rs
+++ b/src/nifs/vanilla/tests.rs
@@ -276,7 +276,7 @@ fn one_round_test() -> Result<(), Error<G1Affine>> {
         b: Fr::from(seq[1]),
         num: SIZE,
     };
-    let public_inputs1 = vec![Fr::from(seq[SIZE - 1]), Fr::ZERO];
+    let public_inputs1 = vec![Fr::from(seq[SIZE - 1])];
 
     // circuit 2
     let seq = get_fibo_seq(2, 3, SIZE);
@@ -285,7 +285,7 @@ fn one_round_test() -> Result<(), Error<G1Affine>> {
         b: Fr::from(seq[1]),
         num: SIZE,
     };
-    let public_inputs2 = vec![Fr::from(seq[SIZE - 1]), Fr::ZERO];
+    let public_inputs2 = vec![Fr::from(seq[SIZE - 1])];
 
     let (ck, S, pair1, pair2) = prepare_trace(
         K,
@@ -322,13 +322,7 @@ fn three_rounds_test() -> Result<(), Error<G1Affine>> {
         num: NUM,
     };
 
-    let (ck, S, pair1, pair2) = prepare_trace(
-        K,
-        circuit1,
-        circuit2,
-        vec![Fr::ZERO, Fr::ZERO],
-        vec![Fr::ZERO, Fr::ZERO],
-        G1Affine::default(),
-    )?;
+    let (ck, S, pair1, pair2) =
+        prepare_trace(K, circuit1, circuit2, vec![], vec![], G1Affine::default())?;
     fold_instances(&ck, &S, pair1, pair2, G1Affine::default())
 }

--- a/src/nifs/vanilla/tests.rs
+++ b/src/nifs/vanilla/tests.rs
@@ -108,13 +108,13 @@ where
     if let Err(err) = S.is_sat(&ck, &mut ro_nark_decider, &pair1.u, &pair1.w) {
         errors.push(("is_sat_pair1", err));
     }
-    if let Err(err) = VanillaFS::is_sat_perm(&S, &pair1_relaxed) {
+    if let Err(err) = VanillaFS::is_sat_permutation(&S, &pair1_relaxed) {
         errors.push(("is_sat_perm_pair1", err));
     }
     if let Err(err) = S.is_sat(&ck, &mut ro_nark_decider, &pair2.u, &pair2.w) {
         errors.push(("is_sat_pair2", err));
     }
-    if let Err(err) = VanillaFS::is_sat_perm(&S, &pair2_relaxed) {
+    if let Err(err) = VanillaFS::is_sat_permutation(&S, &pair2_relaxed) {
         errors.push(("is_sat_perm_pair2", err));
     }
 
@@ -185,11 +185,8 @@ where
 
     let mut errors = Vec::new();
 
-    if let Err(err) = VanillaFS::is_sat_acc(ck, S, &f_tr) {
-        errors.push(("is_sat_acc 1", err));
-    }
-    if let Err(err) = VanillaFS::is_sat_perm(S, &f_tr) {
-        errors.push(("is_sat_perm 1", err));
+    if let Err(err) = VanillaFS::is_sat(ck, S, &f_tr) {
+        errors.extend(err.into_iter().map(|err| ("f_tr", err)));
     }
 
     let pair2 = [pair2];
@@ -223,12 +220,10 @@ where
     f_tr.U = U_from_verify;
     f_tr.W = _W;
 
-    if let Err(err) = VanillaFS::is_sat_acc(ck, S, &f_tr) {
-        errors.push(("is_sat_relaxed 2", err));
+    if let Err(err) = VanillaFS::is_sat(ck, S, &f_tr) {
+        errors.extend(err.into_iter().map(|err| ("f_tr", err)));
     }
-    if let Err(err) = VanillaFS::is_sat_perm(S, &f_tr) {
-        errors.push(("is_sat_perm 2", err));
-    }
+
     if errors.is_empty() {
         Ok(())
     } else {

--- a/src/plonk/mod.rs
+++ b/src/plonk/mod.rs
@@ -738,11 +738,13 @@ pub(crate) mod test_eval_witness {
         }
 
         #[derive(Debug, Default)]
-        pub struct TestPoseidonCircuit<F: PrimeFieldBits> {
+        pub struct TestPoseidonCircuit<F: PrimeFieldBits, const L: usize = 50> {
             _p: PhantomData<F>,
         }
 
-        impl<F: PrimeFieldBits + FromUniformBytes<64>> Circuit<F> for TestPoseidonCircuit<F> {
+        impl<F: PrimeFieldBits + FromUniformBytes<64>, const L: usize> Circuit<F>
+            for TestPoseidonCircuit<F, L>
+        {
             type Config = TestPoseidonCircuitConfig;
             type FloorPlanner = SimpleFloorPlanner;
 
@@ -765,7 +767,7 @@ pub(crate) mod test_eval_witness {
                 layouter.assign_region(
                     || "poseidon hash",
                     move |region| {
-                        let z_i: [F; 50] = array::from_fn(|i| F::from(i as u64));
+                        let z_i: [F; L] = array::from_fn(|i| F::from(i as u64));
                         let ctx = &mut RegionCtx::new(region, 0);
 
                         let mut pchip = PoseidonChip::new(config.pconfig.clone(), spec.clone());
@@ -818,7 +820,7 @@ pub(crate) mod test_eval_witness {
     fn basic() {
         let runner = CircuitRunner::<Field, _>::new(
             12,
-            poseidon_circuit::TestPoseidonCircuit::default(),
+            poseidon_circuit::TestPoseidonCircuit::<_, 50>::default(),
             vec![],
         );
 

--- a/src/plonk/mod.rs
+++ b/src/plonk/mod.rs
@@ -433,15 +433,14 @@ impl<F: PrimeField> PlonkStructure<F> {
         ro_nark: &mut RO,
         num_challenges: usize,
     ) -> Result<PlonkTrace<C>, SpsError> {
-        debug!("run sps protocol with {num_challenges} challenges");
-        assert_eq!(instances.len(), 1, "TODO Will rm this assert in #329");
-        assert_eq!(instances[0].len(), 2, "TODO Will rm this assert in #329");
+        assert!(instances.len() <= 1, "TODO #329");
+        let instance = instances.first().cloned().unwrap_or_default();
 
         match num_challenges {
-            0 => self.run_sps_protocol_0(&instances[0], advice, ck),
-            1 => self.run_sps_protocol_1(&instances[0], advice, ck, ro_nark),
-            2 => self.run_sps_protocol_2(&instances[0], advice, ck, ro_nark),
-            3 => self.run_sps_protocol_3(&instances[0], advice, ck, ro_nark),
+            0 => self.run_sps_protocol_0(&instance, advice, ck),
+            1 => self.run_sps_protocol_1(&instance, advice, ck, ro_nark),
+            2 => self.run_sps_protocol_2(&instance, advice, ck, ro_nark),
+            3 => self.run_sps_protocol_3(&instance, advice, ck, ro_nark),
             challenges_count => Err(SpsError::UnsupportedChallengesCount { challenges_count }),
         }
     }

--- a/src/sps.rs
+++ b/src/sps.rs
@@ -1,9 +1,12 @@
-use crate::commitment;
-use crate::constants::NUM_CHALLENGE_BITS;
-use crate::plonk::{eval::Error as EvalError, PlonkInstance};
-use crate::poseidon::ROTrait;
-use crate::util::fe_to_fe;
 use halo2_proofs::arithmetic::CurveAffine;
+
+use crate::{
+    commitment,
+    constants::NUM_CHALLENGE_BITS,
+    plonk::{eval::Error as EvalError, PlonkInstance},
+    poseidon::ROTrait,
+    util::fe_to_fe,
+};
 
 #[derive(Debug, thiserror::Error, PartialEq)]
 pub enum Error {
@@ -38,7 +41,11 @@ impl<C: CurveAffine, RO: ROTrait<C::Base>> SpecialSoundnessVerifier<C, RO> for P
             return Ok(());
         }
 
-        ro_nark.absorb_field_iter(self.instance.iter().map(|inst| fe_to_fe(inst).unwrap()));
+        ro_nark.absorb_field_iter(
+            self.instances
+                .iter()
+                .flat_map(|instance| instance.iter().map(|value| fe_to_fe(value).unwrap())),
+        );
 
         for i in 0..num_challenges {
             if ro_nark

--- a/src/table/circuit_runner.rs
+++ b/src/table/circuit_runner.rs
@@ -57,7 +57,7 @@ impl<F: PrimeField, CT: Circuit<F>> CircuitRunner<F, CT> {
             k: self.k as usize,
             num_io: self
                 .instances
-                .get(0)
+                .first()
                 .map(|instance| instance.len())
                 .unwrap_or_default(),
             selectors,
@@ -91,7 +91,7 @@ impl<F: PrimeField, CT: Circuit<F>> CircuitRunner<F, CT> {
             k: self.k,
             num_io: self
                 .instances
-                .get(0)
+                .first()
                 .map(|instance| instance.len())
                 .unwrap_or_default(),
             fixed: vec![vec![F::ZERO.into(); nrow]; self.cs.num_fixed_columns()],
@@ -110,7 +110,7 @@ impl<F: PrimeField, CT: Circuit<F>> CircuitRunner<F, CT> {
             permutation_matrix: plonk::util::construct_permutation_matrix(
                 self.k as usize,
                 self.instances
-                    .get(0)
+                    .first()
                     .map(|instance| instance.len())
                     .unwrap_or_default(),
                 &self.cs,

--- a/src/table/tests.rs
+++ b/src/table/tests.rs
@@ -80,7 +80,7 @@ fn test_assembly() -> Result<(), Error> {
     }
     let circuit = TestCircuit::new(inputs, Fp::ONE);
     let output = Fp::from_str_vartime("45").unwrap();
-    let public_inputs = vec![output];
+    let public_inputs = vec![vec![output]];
 
     let td = CircuitRunner::<Fp, _>::new(K, circuit, public_inputs);
     let witness = td.try_collect_witness()?;

--- a/src/table/witness_data.rs
+++ b/src/table/witness_data.rs
@@ -9,7 +9,7 @@ use tracing::*;
 use crate::ff::PrimeField;
 
 pub struct WitnessCollector<F: PrimeField> {
-    pub(crate) instance: Vec<F>,
+    pub(crate) instances: Vec<Vec<F>>,
     pub(crate) advice: Vec<Vec<Assigned<F>>>,
 }
 
@@ -48,9 +48,9 @@ impl<F: PrimeField> Assignment<F> for WitnessCollector<F> {
     }
 
     fn query_instance(&self, column: Column<Instance>, row: usize) -> Result<Value<F>, Error> {
-        assert!(column.index() == 0); // require just single instance
-        self.instance
-            .get(row)
+        self.instances
+            .get(column.index())
+            .and_then(|col| col.get(row))
             .map(|v| Value::known(*v))
             .ok_or(Error::BoundsFailure)
     }


### PR DESCRIPTION
**Motivation**
Close #329

**Overview**
This PR still prohibits folding and using multiple instance columns, however, changes from a single element to a collection of instance columns wherever it will be needed

It also introduces the concept of a consistency_marker instead of an instance column, which better reflects the nature of X0,X1 usage within IVC