### PR TITLE
refactor(ivc): use `ConsistencyMarkersComputation` name

### DIFF
--- a/src/ivc/consistency_marker_computation.rs
+++ b/src/ivc/consistency_marker_computation.rs
@@ -1,4 +1,4 @@
-/// Module name acronym `instance_computation` -> `icomp`
+/// Module name acronym `consistency_marker_computation` -> `consistency_comp`
 use std::num::NonZeroUsize;
 
 use serde::Serialize;
@@ -15,7 +15,7 @@ use crate::{
     util,
 };
 
-pub(crate) struct AssignedRandomOracleComputationInstance<
+pub(crate) struct AssignedConsistencyMarkerComputation<
     'l,
     RP,
     const A: usize,
@@ -34,7 +34,7 @@ pub(crate) struct AssignedRandomOracleComputationInstance<
 }
 
 impl<'l, const A: usize, const T: usize, C: CurveAffine, RO>
-    AssignedRandomOracleComputationInstance<'l, RO, A, T, C>
+    AssignedConsistencyMarkerComputation<'l, RO, A, T, C>
 where
     C::Base: FromUniformBytes<64> + PrimeFieldBits,
     RO: ROCircuitTrait<C::Base, Config = MainGateConfig<T>>,
@@ -65,7 +65,7 @@ where
     }
 }
 
-pub(crate) struct RandomOracleComputationInstance<'l, const A: usize, C, RP>
+pub(crate) struct ConsistencyMarkerComputation<'l, const A: usize, C, RP>
 where
     RP: ROTrait<C::Base>,
     C: CurveAffine + Serialize,
@@ -80,7 +80,7 @@ where
     pub limbs_count: NonZeroUsize,
 }
 
-impl<'l, C, RP, const A: usize> RandomOracleComputationInstance<'l, A, C, RP>
+impl<'l, C, RP, const A: usize> ConsistencyMarkerComputation<'l, A, C, RP>
 where
     RP: ROTrait<C::Base>,
     C: CurveAffine + Serialize,
@@ -222,7 +222,7 @@ mod tests {
             u: Scalar::from_u128(u128::MAX),
         };
 
-        let off_circuit_hash: Base = RandomOracleComputationInstance::<
+        let off_circuit_hash: Base = ConsistencyMarkerComputation::<
             '_,
             10,
             C1,
@@ -287,20 +287,15 @@ mod tests {
                     .assign_current_relaxed(&mut ctx)
                     .unwrap();
 
-                    AssignedRandomOracleComputationInstance::<
-                            PoseidonChip<Base, 10, 9>,
-                            10,
-                            10,
-                            C1,
-                        > {
-                            random_oracle_constant: random_oracle_constant.clone(),
-                            public_params_hash: &public_params_hash,
-                            step: &step,
-                            z_0: &assigned_z_0,
-                            z_i: &assigned_z_i,
-                            relaxed: &assigned_relaxed,
-                        }
-                        .generate(&mut ctx, config.clone())
+                    AssignedConsistencyMarkerComputation::<PoseidonChip<Base, 10, 9>, 10, 10, C1> {
+                        random_oracle_constant: random_oracle_constant.clone(),
+                        public_params_hash: &public_params_hash,
+                        step: &step,
+                        z_0: &assigned_z_0,
+                        z_i: &assigned_z_i,
+                        relaxed: &assigned_relaxed,
+                    }
+                    .generate(&mut ctx, config.clone())
                 },
             )
             .unwrap()

--- a/src/ivc/consistency_markers_computation.rs
+++ b/src/ivc/consistency_markers_computation.rs
@@ -15,7 +15,7 @@ use crate::{
     util,
 };
 
-pub(crate) struct AssignedConsistencyMarkerComputation<
+pub(crate) struct AssignedConsistencyMarkersComputationnn<
     'l,
     RP,
     const A: usize,
@@ -34,7 +34,7 @@ pub(crate) struct AssignedConsistencyMarkerComputation<
 }
 
 impl<'l, const A: usize, const T: usize, C: CurveAffine, RO>
-    AssignedConsistencyMarkerComputation<'l, RO, A, T, C>
+    AssignedConsistencyMarkersComputationnn<'l, RO, A, T, C>
 where
     C::Base: FromUniformBytes<64> + PrimeFieldBits,
     RO: ROCircuitTrait<C::Base, Config = MainGateConfig<T>>,
@@ -287,7 +287,7 @@ mod tests {
                     .assign_current_relaxed(&mut ctx)
                     .unwrap();
 
-                    AssignedConsistencyMarkerComputation::<PoseidonChip<Base, 10, 9>, 10, 10, C1> {
+                    AssignedConsistencyMarkersComputationnn::<PoseidonChip<Base, 10, 9>, 10, 10, C1> {
                         random_oracle_constant: random_oracle_constant.clone(),
                         public_params_hash: &public_params_hash,
                         step: &step,

--- a/src/ivc/consistency_markers_computation.rs
+++ b/src/ivc/consistency_markers_computation.rs
@@ -247,48 +247,47 @@ mod tests {
             advice: vec![vec![Base::ZERO.into(); 1 << K_TABLE_SIZE]; cs.num_advice_columns()],
         };
 
-        let on_circuit_hash =
-            SingleChipLayouter::<'_, Base, _>::new(&mut td, vec![])
-                .unwrap()
-                .assign_region(
-                    || "test",
-                    |region| {
-                        let mut ctx = RegionCtx::new(region, 0);
+        let on_circuit_hash = SingleChipLayouter::<'_, Base, _>::new(&mut td, vec![])
+            .unwrap()
+            .assign_region(
+                || "test",
+                |region| {
+                    let mut ctx = RegionCtx::new(region, 0);
 
-                        let mut advice_columns_assigner = config.advice_cycle_assigner();
+                    let mut advice_columns_assigner = config.advice_cycle_assigner();
 
-                        let public_params_hash = assign_next_advice_from_point(
-                            &mut advice_columns_assigner,
-                            &mut ctx,
-                            &public_params_hash,
-                            || "public_params",
-                        )
+                    let public_params_hash = assign_next_advice_from_point(
+                        &mut advice_columns_assigner,
+                        &mut ctx,
+                        &public_params_hash,
+                        || "public_params",
+                    )
+                    .unwrap();
+
+                    let step = advice_columns_assigner
+                        .assign_next_advice(&mut ctx, || "step", Base::from_u128(step as u128))
                         .unwrap();
 
-                        let step = advice_columns_assigner
-                            .assign_next_advice(&mut ctx, || "step", Base::from_u128(step as u128))
-                            .unwrap();
-
-                        let assigned_z_0 = advice_columns_assigner
-                            .assign_all_advice(&mut ctx, || "z0", z_0.iter().copied())
-                            .map(|inp| inp.try_into().unwrap())
-                            .unwrap();
-
-                        let assigned_z_i = advice_columns_assigner
-                            .assign_all_advice(&mut ctx, || "zi", z_i.iter().copied())
-                            .map(|inp| inp.try_into().unwrap())
-                            .unwrap();
-
-                        let assigned_relaxed = FoldRelaxedPlonkInstanceChip::new(
-                            relaxed.clone(),
-                            NonZeroUsize::new(10).unwrap(),
-                            NonZeroUsize::new(10).unwrap(),
-                            config.clone(),
-                        )
-                        .assign_current_relaxed(&mut ctx)
+                    let assigned_z_0 = advice_columns_assigner
+                        .assign_all_advice(&mut ctx, || "z0", z_0.iter().copied())
+                        .map(|inp| inp.try_into().unwrap())
                         .unwrap();
 
-                        AssignedConsistencyMarkersComputationnn::<
+                    let assigned_z_i = advice_columns_assigner
+                        .assign_all_advice(&mut ctx, || "zi", z_i.iter().copied())
+                        .map(|inp| inp.try_into().unwrap())
+                        .unwrap();
+
+                    let assigned_relaxed = FoldRelaxedPlonkInstanceChip::new(
+                        relaxed.clone(),
+                        NonZeroUsize::new(10).unwrap(),
+                        NonZeroUsize::new(10).unwrap(),
+                        config.clone(),
+                    )
+                    .assign_current_relaxed(&mut ctx)
+                    .unwrap();
+
+                    AssignedConsistencyMarkersComputationnn::<
                             PoseidonChip<Base, 10, 9>,
                             10,
                             10,
@@ -302,13 +301,13 @@ mod tests {
                             relaxed: &assigned_relaxed,
                         }
                         .generate(&mut ctx, config.clone())
-                    },
-                )
-                .unwrap()
-                .value()
-                .unwrap()
-                .copied()
-                .unwrap();
+                },
+            )
+            .unwrap()
+            .value()
+            .unwrap()
+            .copied()
+            .unwrap();
 
         assert_eq!(on_circuit_hash, off_circuit_hash);
     }

--- a/src/ivc/incrementally_verifiable_computation.rs
+++ b/src/ivc/incrementally_verifiable_computation.rs
@@ -4,7 +4,7 @@ use halo2_proofs::dev::MockProver;
 use serde::Serialize;
 use tracing::*;
 
-use super::consistency_marker_computation::ConsistencyMarkerComputation;
+use super::consistency_markers_computation::ConsistencyMarkerComputation;
 pub use super::step_circuit::{self, StepCircuit, SynthesisError};
 use crate::{
     ff::{Field, FromUniformBytes, PrimeField, PrimeFieldBits},

--- a/src/ivc/incrementally_verifiable_computation.rs
+++ b/src/ivc/incrementally_verifiable_computation.rs
@@ -4,7 +4,7 @@ use halo2_proofs::dev::MockProver;
 use serde::Serialize;
 use tracing::*;
 
-use super::instance_computation::RandomOracleComputationInstance;
+use super::consistency_marker_computation::ConsistencyMarkerComputation;
 pub use super::step_circuit::{self, StepCircuit, SynthesisError};
 use crate::{
     ff::{Field, FromUniformBytes, PrimeField, PrimeFieldBits},
@@ -220,7 +220,7 @@ where
                         .expect("For `vanilla::FoldingScheme` should always be")[1],
                 )
                 .unwrap(),
-                RandomOracleComputationInstance::<'_, A1, C2, RP1::OffCircuit> {
+                ConsistencyMarkerComputation::<'_, A1, C2, RP1::OffCircuit> {
                     random_oracle_constant: pp.primary.params().ro_constant().clone(),
                     public_params_hash: &pp.digest_2(),
                     step: 1,
@@ -310,7 +310,7 @@ where
                         .expect("For `vanilla::FoldingScheme` should always be")[1],
                 )
                 .unwrap(),
-                RandomOracleComputationInstance::<'_, A2, C1, RP2::OffCircuit> {
+                ConsistencyMarkerComputation::<'_, A2, C1, RP2::OffCircuit> {
                     random_oracle_constant: pp.secondary.params().ro_constant().clone(),
                     public_params_hash: &pp.digest_1(),
                     step: 1,
@@ -438,7 +438,7 @@ where
                         .expect("For `vanilla::FoldingScheme` should always be")[1],
                 )
                 .unwrap(),
-                RandomOracleComputationInstance::<'_, A1, C2, RP1::OffCircuit> {
+                ConsistencyMarkerComputation::<'_, A1, C2, RP1::OffCircuit> {
                     random_oracle_constant: pp.primary.params().ro_constant().clone(),
                     public_params_hash: &pp.digest_2(),
                     step: self.step + 1,
@@ -528,7 +528,7 @@ where
                         .expect("For `vanilla::FoldingScheme` should always be")[1],
                 )
                 .unwrap(),
-                RandomOracleComputationInstance::<'_, A2, C1, RP2::OffCircuit> {
+                ConsistencyMarkerComputation::<'_, A2, C1, RP2::OffCircuit> {
                     random_oracle_constant: pp.secondary.params().ro_constant().clone(),
                     public_params_hash: &pp.digest_1(),
                     step: self.step + 1,
@@ -608,7 +608,7 @@ where
     {
         let mut errors = vec![];
 
-        RandomOracleComputationInstance::<'_, A1, C2, RP1::OffCircuit> {
+        ConsistencyMarkerComputation::<'_, A1, C2, RP1::OffCircuit> {
             random_oracle_constant: pp.primary.params().ro_constant().clone(),
             public_params_hash: &pp.digest_2(),
             step: self.step,
@@ -632,7 +632,7 @@ where
             })
         });
 
-        RandomOracleComputationInstance::<'_, A2, C1, RP2::OffCircuit> {
+        ConsistencyMarkerComputation::<'_, A2, C1, RP2::OffCircuit> {
             random_oracle_constant: pp.secondary.params().ro_constant().clone(),
             public_params_hash: &pp.digest_1(),
             step: self.step,

--- a/src/ivc/mod.rs
+++ b/src/ivc/mod.rs
@@ -2,7 +2,7 @@ pub mod step_circuit;
 
 pub mod step_folding_circuit;
 
-mod consistency_marker_computation;
+mod consistency_markers_computation;
 mod fold_relaxed_plonk_instance_chip;
 mod incrementally_verifiable_computation;
 mod public_params;

--- a/src/ivc/mod.rs
+++ b/src/ivc/mod.rs
@@ -2,9 +2,9 @@ pub mod step_circuit;
 
 pub mod step_folding_circuit;
 
+mod consistency_marker_computation;
 mod fold_relaxed_plonk_instance_chip;
 mod incrementally_verifiable_computation;
-mod instance_computation;
 mod public_params;
 
 pub use halo2_proofs::circuit::SimpleFloorPlanner;

--- a/src/ivc/public_params.rs
+++ b/src/ivc/public_params.rs
@@ -14,13 +14,13 @@ use crate::{
     halo2curves::CurveAffine,
     ivc::{
         self,
-        consistency_marker_computation::ConsistencyMarkerComputation,
+        consistency_markers_computation::ConsistencyMarkerComputation,
         step_folding_circuit::{StepFoldingCircuit, StepInputs},
     },
     main_gate::MainGateConfig,
     nifs::{
         self,
-        vanilla::{GetConsistencyMarkers, VanillaFS, CONSISTENCY_MARKER_COUNT},
+        vanilla::{GetConsistencyMarkers, VanillaFS, CONSISTENCY_MARKERS_COUNT},
         FoldingScheme,
     },
     plonk::{PlonkStructure, PlonkTrace},
@@ -266,14 +266,14 @@ where
                     StepFoldingCircuit<'_, A2, C1, SC2, RP2::OnCircuit, MAIN_GATE_T>,
                 >(
                     primary.k_table_size,
-                    &iter::once(CONSISTENCY_MARKER_COUNT)
+                    &iter::once(CONSISTENCY_MARKERS_COUNT)
                         .chain(primary.step_circuit.instances().iter().map(Vec::len))
                         .collect::<Box<[_]>>(),
                     &primary_step_params,
                 ),
             };
             let primary_instances =
-                primary_sfc.instances([C1::Scalar::ZERO; CONSISTENCY_MARKER_COUNT]);
+                primary_sfc.instances([C1::Scalar::ZERO; CONSISTENCY_MARKERS_COUNT]);
 
             CircuitRunner::new(primary.k_table_size, primary_sfc, primary_instances)
                 .try_collect_plonk_structure()
@@ -285,7 +285,7 @@ where
             let secondary_initial_step_params =
                 StepParams::new(limb_width, limbs_count, secondary.ro_constant.clone());
 
-            let secondary_num_io = iter::once(CONSISTENCY_MARKER_COUNT)
+            let secondary_num_io = iter::once(CONSISTENCY_MARKERS_COUNT)
                 .chain(secondary.step_circuit.instances().iter().map(Vec::len))
                 .collect::<Box<[_]>>();
 

--- a/src/ivc/public_params.rs
+++ b/src/ivc/public_params.rs
@@ -14,7 +14,7 @@ use crate::{
     halo2curves::CurveAffine,
     ivc::{
         self,
-        instance_computation::RandomOracleComputationInstance,
+        consistency_marker_computation::ConsistencyMarkerComputation,
         step_folding_circuit::{StepFoldingCircuit, StepInputs},
     },
     main_gate::MainGateConfig,
@@ -305,7 +305,7 @@ where
                         .expect("For `vanilla::FoldingScheme` should always be")[0],
                 )
                 .unwrap(),
-                RandomOracleComputationInstance::<'_, A2, C1, RP2::OffCircuit> {
+                ConsistencyMarkerComputation::<'_, A2, C1, RP2::OffCircuit> {
                     random_oracle_constant: secondary.ro_constant.clone(),
                     public_params_hash: &secondary_initial_step_input.public_params_hash,
                     step: 1,

--- a/src/ivc/step_folding_circuit.rs
+++ b/src/ivc/step_folding_circuit.rs
@@ -9,7 +9,7 @@ use itertools::Itertools;
 use serde::Serialize;
 use tracing::*;
 
-use super::instance_computation::AssignedRandomOracleComputationInstance;
+use super::consistency_marker_computation::AssignedConsistencyMarkerComputation;
 use crate::{
     ff::{Field, FromUniformBytes, PrimeField, PrimeFieldBits},
     halo2curves::CurveAffine,
@@ -468,20 +468,19 @@ where
                     )?;
                     ctx.next();
 
-                    let expected_X0 =
-                        AssignedRandomOracleComputationInstance::<'_, RO, ARITY, T, C> {
-                            random_oracle_constant: self.input.step_pp.ro_constant.clone(),
-                            public_params_hash: &w.public_params_hash,
-                            step: &assigned_step,
-                            z_0: &assigned_z_0,
-                            z_i: &assigned_z_i,
-                            relaxed: &w.assigned_relaxed,
-                        }
-                        .generate_with_inspect(
-                            &mut ctx,
-                            config.main_gate_config.clone(),
-                            |buf| debug!("expected X0 {buf:?}"),
-                        )?;
+                    let expected_X0 = AssignedConsistencyMarkerComputation::<'_, RO, ARITY, T, C> {
+                        random_oracle_constant: self.input.step_pp.ro_constant.clone(),
+                        public_params_hash: &w.public_params_hash,
+                        step: &assigned_step,
+                        z_0: &assigned_z_0,
+                        z_i: &assigned_z_i,
+                        relaxed: &w.assigned_relaxed,
+                    }
+                    .generate_with_inspect(
+                        &mut ctx,
+                        config.main_gate_config.clone(),
+                        |buf| debug!("expected X0 {buf:?}"),
+                    )?;
 
                     debug!("expected X0: {expected_X0:?}");
                     debug!("input instance 0: {:?}", w.input_instance[0].0);
@@ -572,7 +571,7 @@ where
             .assign_region(
                 || "generate output hash",
                 |region| {
-                    AssignedRandomOracleComputationInstance::<'_, RO, ARITY, T, C> {
+                    AssignedConsistencyMarkerComputation::<'_, RO, ARITY, T, C> {
                         random_oracle_constant: self.input.step_pp.ro_constant.clone(),
                         public_params_hash: &assigned_input_witness.public_params_hash,
                         step: &assigned_next_step,

--- a/src/ivc/step_folding_circuit.rs
+++ b/src/ivc/step_folding_circuit.rs
@@ -484,14 +484,17 @@ where
                         )?;
 
                     debug!("expected X0: {expected_X0:?}");
-                    debug!("input instance 0: {:?}", w.input_instance[0].0);
+                    debug!(
+                        "input instance 0: {:?}",
+                        w.input_consistency_markers[0].as_value
+                    );
 
                     Ok((
                         base_case_input_check,
                         MainGate::new(config.main_gate_config.clone()).is_equal_term(
                             &mut ctx,
                             &expected_X0,
-                            &w.input_instance[0].0,
+                            &w.input_consistency_markers[0].as_value,
                         )?,
                     ))
                 },
@@ -597,7 +600,9 @@ where
         // Check that old_X1 == new_X0
         layouter
             .constrain_instance(
-                assigned_input_witness.input_instance[1].0.cell(),
+                assigned_input_witness.input_consistency_markers[1]
+                    .as_value
+                    .cell(),
                 config.consistency_marker,
                 0,
             )

--- a/src/ivc/step_folding_circuit.rs
+++ b/src/ivc/step_folding_circuit.rs
@@ -468,19 +468,20 @@ where
                     )?;
                     ctx.next();
 
-                    let expected_X0 = AssignedConsistencyMarkersComputationnn::<'_, RO, ARITY, T, C> {
-                        random_oracle_constant: self.input.step_pp.ro_constant.clone(),
-                        public_params_hash: &w.public_params_hash,
-                        step: &assigned_step,
-                        z_0: &assigned_z_0,
-                        z_i: &assigned_z_i,
-                        relaxed: &w.assigned_relaxed,
-                    }
-                    .generate_with_inspect(
-                        &mut ctx,
-                        config.main_gate_config.clone(),
-                        |buf| debug!("expected X0 {buf:?}"),
-                    )?;
+                    let expected_X0 =
+                        AssignedConsistencyMarkersComputationnn::<'_, RO, ARITY, T, C> {
+                            random_oracle_constant: self.input.step_pp.ro_constant.clone(),
+                            public_params_hash: &w.public_params_hash,
+                            step: &assigned_step,
+                            z_0: &assigned_z_0,
+                            z_i: &assigned_z_i,
+                            relaxed: &w.assigned_relaxed,
+                        }
+                        .generate_with_inspect(
+                            &mut ctx,
+                            config.main_gate_config.clone(),
+                            |buf| debug!("expected X0 {buf:?}"),
+                        )?;
 
                     debug!("expected X0: {expected_X0:?}");
                     debug!("input instance 0: {:?}", w.input_instance[0].0);

--- a/src/ivc/step_folding_circuit.rs
+++ b/src/ivc/step_folding_circuit.rs
@@ -9,7 +9,7 @@ use itertools::Itertools;
 use serde::Serialize;
 use tracing::*;
 
-use super::consistency_marker_computation::AssignedConsistencyMarkerComputation;
+use super::consistency_markers_computation::AssignedConsistencyMarkersComputationnn;
 use crate::{
     ff::{Field, FromUniformBytes, PrimeField, PrimeFieldBits},
     halo2curves::CurveAffine,
@@ -110,7 +110,7 @@ where
     RO: ROCircuitTrait<C::Base>,
 {
     pub fn num_io(&self) -> Box<[usize]> {
-        iter::once(vanilla::CONSISTENCY_MARKER_COUNT)
+        iter::once(vanilla::CONSISTENCY_MARKERS_COUNT)
             .chain(
                 self.step_circuit_instances
                     .iter()
@@ -139,7 +139,7 @@ where
             panic!("Empty instances not expected, because consistency markers");
         };
 
-        assert_eq!(consistency_markers, &vanilla::CONSISTENCY_MARKER_COUNT);
+        assert_eq!(consistency_markers, &vanilla::CONSISTENCY_MARKERS_COUNT);
 
         Self {
             step: C::Base::ZERO,
@@ -468,7 +468,7 @@ where
                     )?;
                     ctx.next();
 
-                    let expected_X0 = AssignedConsistencyMarkerComputation::<'_, RO, ARITY, T, C> {
+                    let expected_X0 = AssignedConsistencyMarkersComputationnn::<'_, RO, ARITY, T, C> {
                         random_oracle_constant: self.input.step_pp.ro_constant.clone(),
                         public_params_hash: &w.public_params_hash,
                         step: &assigned_step,
@@ -571,7 +571,7 @@ where
             .assign_region(
                 || "generate output hash",
                 |region| {
-                    AssignedConsistencyMarkerComputation::<'_, RO, ARITY, T, C> {
+                    AssignedConsistencyMarkersComputationnn::<'_, RO, ARITY, T, C> {
                         random_oracle_constant: self.input.step_pp.ro_constant.clone(),
                         public_params_hash: &assigned_input_witness.public_params_hash,
                         step: &assigned_next_step,

--- a/src/nifs/vanilla/mod.rs
+++ b/src/nifs/vanilla/mod.rs
@@ -383,7 +383,7 @@ impl<C: CurveAffine> VerifyAccumulation<C> for VanillaFS<C> {
 }
 
 /// Number of consistency markers in instance column
-pub const CONSISTENCY_MARKER_COUNT: usize = 2;
+pub const CONSISTENCY_MARKERS_COUNT: usize = 2;
 
 /// As part of the vanilla folding scheme, we use the values in the zero instance of the column for
 /// consistency between folding steps
@@ -394,7 +394,7 @@ pub const CONSISTENCY_MARKER_COUNT: usize = 2;
 ///     hash of the state at the end of previous folding step
 /// - X1 is a hash of the state at the end of the current folding step
 pub trait GetConsistencyMarkers<F> {
-    fn get_consistency_markers(&self) -> Option<[F; CONSISTENCY_MARKER_COUNT]>;
+    fn get_consistency_markers(&self) -> Option<[F; CONSISTENCY_MARKERS_COUNT]>;
 }
 
 impl<C: CurveAffine> GetConsistencyMarkers<C::ScalarExt> for PlonkInstance<C> {

--- a/src/plonk/mod.rs
+++ b/src/plonk/mod.rs
@@ -164,7 +164,6 @@ pub struct PlonkStructure<F: PrimeField> {
 pub struct PlonkInstance<C: CurveAffine> {
     /// `W_commitments = round_sizes.len()`, see [`PlonkStructure::round_sizes`]
     pub(crate) W_commitments: Vec<C>,
-    /// inst = [X0, X1]
     pub(crate) instances: Vec<Vec<C::ScalarExt>>,
     /// challenges generated in special soundness protocol
     /// we will have 0 ~ 3 challenges depending on different cases:


### PR DESCRIPTION
**Motivation**
Since thanks to #316 we support as many instance columns as we like, the old name can be misleading, so wherever possible we enter the name "consistency marker", including this module

**Overview**
N/A