### PR TITLE
refactor(nifs): rm instances from `RelaxedPlonkInstance`

### DIFF
--- a/src/ivc/consistency_markers_computation.rs
+++ b/src/ivc/consistency_markers_computation.rs
@@ -15,7 +15,7 @@ use crate::{
     util,
 };
 
-pub(crate) struct AssignedConsistencyMarkersComputationnn<
+pub(crate) struct AssignedConsistencyMarkersComputation<
     'l,
     RP,
     const A: usize,
@@ -34,7 +34,7 @@ pub(crate) struct AssignedConsistencyMarkersComputationnn<
 }
 
 impl<'l, const A: usize, const T: usize, C: CurveAffine, RO>
-    AssignedConsistencyMarkersComputationnn<'l, RO, A, T, C>
+    AssignedConsistencyMarkersComputation<'l, RO, A, T, C>
 where
     C::Base: FromUniformBytes<64> + PrimeFieldBits,
     RO: ROCircuitTrait<C::Base, Config = MainGateConfig<T>>,
@@ -287,7 +287,7 @@ mod tests {
                     .assign_current_relaxed(&mut ctx)
                     .unwrap();
 
-                    AssignedConsistencyMarkersComputationnn::<
+                    AssignedConsistencyMarkersComputation::<
                             PoseidonChip<Base, 10, 9>,
                             10,
                             10,

--- a/src/ivc/consistency_markers_computation.rs
+++ b/src/ivc/consistency_markers_computation.rs
@@ -181,7 +181,6 @@ mod tests {
     use crate::{
         ff::Field,
         halo2curves::{bn256, grumpkin},
-        plonk::PlonkInstance,
     };
 
     type C1 = <bn256::G1 as PrimeCurve>::Affine;
@@ -213,11 +212,9 @@ mod tests {
         let z_0 = [Base::from_u128(0x1024); 10];
         let z_i = [Base::from_u128(0x2048); 10];
         let relaxed = RelaxedPlonkInstance {
-            inner: PlonkInstance {
-                W_commitments: vec![CommitmentKey::<C1>::default_value(); 10],
-                instances: vec![vec![Scalar::from_u128(0x67899); 2]],
-                challenges: vec![Scalar::from_u128(0x123456); 10],
-            },
+            W_commitments: vec![CommitmentKey::<C1>::default_value(); 10],
+            consistency_markers: [Scalar::from_u128(0x67899); 2],
+            challenges: vec![Scalar::from_u128(0x123456); 10],
             E_commitment: CommitmentKey::<C1>::default_value(),
             u: Scalar::from_u128(u128::MAX),
         };
@@ -287,20 +284,15 @@ mod tests {
                     .assign_current_relaxed(&mut ctx)
                     .unwrap();
 
-                    AssignedConsistencyMarkersComputation::<
-                            PoseidonChip<Base, 10, 9>,
-                            10,
-                            10,
-                            C1,
-                        > {
-                            random_oracle_constant: random_oracle_constant.clone(),
-                            public_params_hash: &public_params_hash,
-                            step: &step,
-                            z_0: &assigned_z_0,
-                            z_i: &assigned_z_i,
-                            relaxed: &assigned_relaxed,
-                        }
-                        .generate(&mut ctx, config.clone())
+                    AssignedConsistencyMarkersComputation::<PoseidonChip<Base, 10, 9>, 10, 10, C1> {
+                        random_oracle_constant: random_oracle_constant.clone(),
+                        public_params_hash: &public_params_hash,
+                        step: &step,
+                        z_0: &assigned_z_0,
+                        z_i: &assigned_z_i,
+                        relaxed: &assigned_relaxed,
+                    }
+                    .generate(&mut ctx, config.clone())
                 },
             )
             .unwrap()

--- a/src/ivc/step_folding_circuit.rs
+++ b/src/ivc/step_folding_circuit.rs
@@ -9,7 +9,7 @@ use itertools::Itertools;
 use serde::Serialize;
 use tracing::*;
 
-use super::consistency_markers_computation::AssignedConsistencyMarkersComputationnn;
+use super::consistency_markers_computation::AssignedConsistencyMarkersComputation;
 use crate::{
     ff::{Field, FromUniformBytes, PrimeField, PrimeFieldBits},
     halo2curves::CurveAffine,
@@ -469,7 +469,7 @@ where
                     ctx.next();
 
                     let expected_X0 =
-                        AssignedConsistencyMarkersComputationnn::<'_, RO, ARITY, T, C> {
+                        AssignedConsistencyMarkersComputation::<'_, RO, ARITY, T, C> {
                             random_oracle_constant: self.input.step_pp.ro_constant.clone(),
                             public_params_hash: &w.public_params_hash,
                             step: &assigned_step,
@@ -575,7 +575,7 @@ where
             .assign_region(
                 || "generate output hash",
                 |region| {
-                    AssignedConsistencyMarkersComputationnn::<'_, RO, ARITY, T, C> {
+                    AssignedConsistencyMarkersComputation::<'_, RO, ARITY, T, C> {
                         random_oracle_constant: self.input.step_pp.ro_constant.clone(),
                         public_params_hash: &assigned_input_witness.public_params_hash,
                         step: &assigned_next_step,

--- a/src/ivc/step_folding_circuit.rs
+++ b/src/ivc/step_folding_circuit.rs
@@ -147,7 +147,8 @@ where
             public_params_hash: C::identity(),
             z_0: [C::Base::ZERO; ARITY],
             z_i: [C::Base::ZERO; ARITY],
-            U: RelaxedPlonkInstance::new(num_io, num_challenges, round_sizes.len()),
+            U: RelaxedPlonkInstance::try_new(num_io, num_challenges, round_sizes.len())
+                .expect("TODO #316"),
             u: PlonkInstance::new(num_io, num_challenges, round_sizes.len()),
             step_circuit_instances: step_circuit_instances
                 .iter()
@@ -274,11 +275,12 @@ where
                 z_0: [C::Base::ZERO; ARITY],
                 z_i: [C::Base::ZERO; ARITY],
                 cross_term_commits: vec![C::identity(); self.input.cross_term_commits.len()],
-                U: RelaxedPlonkInstance::new(
+                U: RelaxedPlonkInstance::try_new(
                     instances_len,
                     self.input.U.challenges.len(),
                     self.input.U.W_commitments.len(),
-                ),
+                )
+                .expect("TODO #316"),
                 u: PlonkInstance::new(
                     instances_len,
                     self.input.u.challenges.len(),

--- a/src/nifs/protogalaxy/tests.rs
+++ b/src/nifs/protogalaxy/tests.rs
@@ -269,7 +269,7 @@ fn fibo_lookup() {
                     c: Scalar::from(seq1[2]),
                     num: SIZE,
                 },
-                vec![],
+                vec![Scalar::ONE],
             ),
             (
                 FiboCircuitWithLookup {
@@ -278,7 +278,7 @@ fn fibo_lookup() {
                     c: Scalar::from(seq2[2]),
                     num: SIZE,
                 },
-                vec![],
+                vec![Scalar::ONE],
             ),
             (
                 FiboCircuitWithLookup {
@@ -287,7 +287,7 @@ fn fibo_lookup() {
                     c: Scalar::from(seq3[2]),
                     num: SIZE,
                 },
-                vec![],
+                vec![Scalar::ONE],
             ),
         ],
     )

--- a/src/nifs/vanilla/mod.rs
+++ b/src/nifs/vanilla/mod.rs
@@ -183,6 +183,12 @@ impl<C: CurveAffine> FoldingScheme<C> for VanillaFS<C> {
         pp_digest: C,
         S: PlonkStructure<C::ScalarExt>,
     ) -> Result<(Self::ProverParam, Self::VerifierParam), Error> {
+        assert_eq!(
+            S.num_io.as_ref(),
+            &[2],
+            "TODO Until #316 is done completely"
+        );
+
         Ok((VanillaFSProverParam { S, pp_digest }, pp_digest))
     }
 
@@ -336,9 +342,9 @@ impl<C: CurveAffine> VerifyAccumulation<C> for VanillaFS<C> {
         let RelaxedPlonkTrace { U, W } = acc;
 
         let Z = U
-            .instances
+            .instances()
             .iter()
-            .flat_map(|inst| inst.iter())
+            .flat_map(|i| i.iter())
             .chain(W.W[0].iter().take((1 << S.k) * S.num_advice_columns))
             .copied()
             .collect::<Vec<_>>();
@@ -411,7 +417,7 @@ impl<C: CurveAffine> GetConsistencyMarkers<C::ScalarExt> for PlonkInstance<C> {
 
 impl<C: CurveAffine> GetConsistencyMarkers<C::ScalarExt> for RelaxedPlonkInstance<C> {
     fn get_consistency_markers(&self) -> Option<[C::ScalarExt; 2]> {
-        self.inner.get_consistency_markers()
+        Some(self.consistency_markers)
     }
 }
 

--- a/src/nifs/vanilla/tests.rs
+++ b/src/nifs/vanilla/tests.rs
@@ -156,7 +156,7 @@ where
     const R_P: usize = 3;
 
     let mut f_tr = RelaxedPlonkTrace {
-        U: RelaxedPlonkInstance::new(&S.num_io, S.num_challenges, S.round_sizes.len()),
+        U: RelaxedPlonkInstance::try_new(&S.num_io, S.num_challenges, S.round_sizes.len()).unwrap(),
         W: RelaxedPlonkWitness::new(S.k, &S.round_sizes),
     };
 
@@ -247,11 +247,11 @@ fn zero_round_test() -> Result<(), Error<G1Affine>> {
     let inputs2 = (2..11).map(Fr::from).collect();
     let circuit1 = RandomLinearCombinationCircuit::new(inputs1, Fr::from_u128(2));
     let output1 = Fr::from_u128(4097);
-    let public_inputs1 = vec![output1];
+    let public_inputs1 = vec![output1, Fr::ZERO];
 
     let circuit2 = RandomLinearCombinationCircuit::new(inputs2, Fr::from_u128(3));
     let output2 = Fr::from_u128(93494);
-    let public_inputs2 = vec![output2];
+    let public_inputs2 = vec![output2, Fr::ZERO];
 
     let (ck, S, pair1, pair2) = prepare_trace(
         K,
@@ -276,7 +276,7 @@ fn one_round_test() -> Result<(), Error<G1Affine>> {
         b: Fr::from(seq[1]),
         num: SIZE,
     };
-    let public_inputs1 = vec![Fr::from(seq[SIZE - 1])];
+    let public_inputs1 = vec![Fr::from(seq[SIZE - 1]), Fr::ZERO];
 
     // circuit 2
     let seq = get_fibo_seq(2, 3, SIZE);
@@ -285,7 +285,7 @@ fn one_round_test() -> Result<(), Error<G1Affine>> {
         b: Fr::from(seq[1]),
         num: SIZE,
     };
-    let public_inputs2 = vec![Fr::from(seq[SIZE - 1])];
+    let public_inputs2 = vec![Fr::from(seq[SIZE - 1]), Fr::ZERO];
 
     let (ck, S, pair1, pair2) = prepare_trace(
         K,
@@ -322,7 +322,13 @@ fn three_rounds_test() -> Result<(), Error<G1Affine>> {
         num: NUM,
     };
 
-    let (ck, S, pair1, pair2) =
-        prepare_trace(K, circuit1, circuit2, vec![], vec![], G1Affine::default())?;
+    let (ck, S, pair1, pair2) = prepare_trace(
+        K,
+        circuit1,
+        circuit2,
+        vec![vec![Fr::from(seq[0]), Fr::from(seq[0])]],
+        vec![vec![Fr::from(seq[0]), Fr::from(seq[0])]],
+        G1Affine::default(),
+    )?;
     fold_instances(&ck, &S, pair1, pair2, G1Affine::default())
 }


### PR DESCRIPTION
**Issue Link / Motivation**
Part of #316
First, we need to remove the nested format `RelaxedPlonkInstance` and add the accumulator field for the rest of the instances in the following PR

**Changes Overview**
- **Removed `inner` field** from `RelaxedPlonkInstance`.
- **Directly embedded fields**: `W_commitments`, `consistency_markers`, and
`challenges`.
- **Introduced `try_new` and `try_from` methods** for creating
`RelaxedPlonkInstance`.
- **Updated test cases** to align with the new structure.