### PR TITLE
refactor(nifs): remaster permutation in `PlonkStructure`

### DIFF
--- a/examples/instances.rs
+++ b/examples/instances.rs
@@ -20,7 +20,7 @@ use sirius::{
 use tracing::debug;
 use tracing_subscriber::{filter::LevelFilter, fmt::format::FmtSpan, EnvFilter};
 
-const INSTANCES_LEN: usize = 2;
+const INSTANCES_LEN: usize = 1;
 
 /// Number of folding steps
 const FOLD_STEP_COUNT: usize = 1;

--- a/src/ivc/incrementally_verifiable_computation.rs
+++ b/src/ivc/incrementally_verifiable_computation.rs
@@ -107,6 +107,8 @@ where
     C2: CurveAffine<Base = <C1 as PrimeCurveAffine>::Scalar>,
     SC1: StepCircuit<A1, C1::Scalar>,
     SC2: StepCircuit<A2, C2::Scalar>,
+    C1::Scalar: PrimeFieldBits + FromUniformBytes<64>,
+    C2::Scalar: PrimeFieldBits + FromUniformBytes<64>,
 {
     primary: StepCircuitContext<A1, C1, SC1>,
     secondary: StepCircuitContext<A2, C2, SC2>,

--- a/src/ivc/instances_accumulator_computation.rs
+++ b/src/ivc/instances_accumulator_computation.rs
@@ -1,0 +1,227 @@
+/// Module name acronym `instances_accumulator_computation` -> `inst_acc_comp`
+use std::{iter, num::NonZeroUsize};
+
+use halo2_proofs::{
+    halo2curves::{
+        ff::{FromUniformBytes, PrimeField, PrimeFieldBits},
+        CurveAffine,
+    },
+    plonk::Error as Halo2PlonkError,
+};
+use tracing::{debug, instrument};
+
+use crate::{
+    main_gate::{AssignedValue, MainGateConfig, RegionCtx},
+    poseidon::{
+        poseidon_circuit::PoseidonChip, random_oracle::ROCircuitTrait, PoseidonHash, ROTrait, Spec,
+    },
+    util,
+};
+
+/// Default value for use in [`Spec`] in this module
+pub const T: usize = 5;
+
+/// Default value for use in [`Spec`] in this module
+pub const RATE: usize = T - 1;
+
+/// Default value for use in [`Spec`] in this module
+pub const R_F: usize = 10;
+
+/// Default value for use in [`Spec`] in this module
+pub const R_P: usize = 10;
+
+fn default_spec<F: FromUniformBytes<64>>() -> Spec<F, T, RATE> {
+    Spec::new(R_F, R_P)
+}
+
+#[instrument(skip_all)]
+pub fn fold_step_circuit_instances_hash_accumulator<C: CurveAffine>(
+    instances_hash_accumulator: &C::ScalarExt,
+    instances: &[Vec<C::ScalarExt>],
+) -> C::ScalarExt
+where
+    C::Base: PrimeFieldBits + FromUniformBytes<64>,
+{
+    let num_bits = NonZeroUsize::new(<C::Base as PrimeField>::NUM_BITS as usize)
+        .expect("unattainably: num_bits can't be zero");
+
+    let hash_in_base: C::Base = PoseidonHash::<C::Base, T, RATE>::new(default_spec())
+        .absorb_field_iter(
+            iter::once(instances_hash_accumulator)
+                .chain(instances.iter().flat_map(|instance| instance.iter()))
+                .map(|i| util::fe_to_fe(i).unwrap()),
+        )
+        .inspect(|buf| debug!("off-circuit buf of instances: {buf:?}"))
+        .output::<C::Base>(num_bits);
+
+    util::fe_to_fe(&hash_in_base).unwrap()
+}
+
+#[instrument(skip_all)]
+pub fn fold_assign_step_circuit_instances_hash_accumulator<F>(
+    ctx: &mut RegionCtx<'_, F>,
+    config: MainGateConfig<T>,
+    folded_instances: &AssignedValue<F>,
+    input_instances: &[AssignedValue<F>],
+) -> Result<AssignedValue<F>, Halo2PlonkError>
+where
+    F: PrimeFieldBits + FromUniformBytes<64>,
+{
+    PoseidonChip::<F, T, RATE>::new(config, default_spec())
+        .absorb_base(folded_instances.into())
+        .absorb_iter(input_instances.iter())
+        .inspect(|buf| debug!("on-circuit buf of instances: {buf:?}"))
+        .squeeze(ctx)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{array, ops::Deref};
+
+    use halo2_proofs::{
+        arithmetic::Field,
+        circuit::{Layouter, SimpleFloorPlanner},
+        dev::MockProver,
+        halo2curves::{bn256, CurveAffine},
+        plonk::{Circuit, Column, ConstraintSystem, Error as Halo2PlonkError, Instance},
+    };
+
+    use super::*;
+    use crate::main_gate::{AdviceCyclicAssignor, MainGate};
+
+    #[derive(Debug, Clone)]
+    struct ConsistencyCheckCircuit<F: PrimeField> {
+        instances_hash_accumulator: F,
+        instances: Box<[Vec<F>]>,
+    }
+
+    impl<F: PrimeField> ConsistencyCheckCircuit<F> {
+        fn new<F2: PrimeField>(instances_hash_accumulator: F2, instances: &[Vec<F2>]) -> Self {
+            Self {
+                instances_hash_accumulator: util::fe_to_fe(&instances_hash_accumulator).unwrap(),
+                instances: instances
+                    .iter()
+                    .map(|col| col.iter().map(|v| util::fe_to_fe(v).unwrap()).collect())
+                    .collect(),
+            }
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct ConsistencyCheckConfig {
+        main_gate_config: MainGateConfig<T>,
+        instance: Column<Instance>,
+    }
+
+    impl Deref for ConsistencyCheckConfig {
+        type Target = MainGateConfig<T>;
+        fn deref(&self) -> &Self::Target {
+            &self.main_gate_config
+        }
+    }
+
+    impl<F> Circuit<F> for ConsistencyCheckCircuit<F>
+    where
+        F: PrimeFieldBits + FromUniformBytes<64>,
+    {
+        /// This is a configuration object that stores things like columns.
+        type Config = ConsistencyCheckConfig;
+        type FloorPlanner = SimpleFloorPlanner;
+
+        fn without_witnesses(&self) -> Self {
+            unreachable!("with using of `SimpleFloorPlanner` this fn not needed")
+        }
+
+        /// Configure the step circuit. This method initializes necessary
+        /// fixed columns and advice columns
+        fn configure(cs: &mut ConstraintSystem<F>) -> Self::Config {
+            let instance = cs.instance_column();
+            cs.enable_equality(instance);
+
+            Self::Config {
+                main_gate_config: MainGate::configure(cs),
+                instance,
+            }
+        }
+
+        /// Sythesize the circuit for a computation step and return variable
+        /// that corresponds to the output of the step z_{i+1}
+        /// this method will be called when we synthesize the IVC_Circuit
+        ///
+        /// Return `z_out` result
+        fn synthesize(
+            &self,
+            config: Self::Config,
+            mut layouter: impl Layouter<F>,
+        ) -> Result<(), Halo2PlonkError> {
+            let (instances_hash_accumulator, instances) = layouter.assign_region(
+                || "assign",
+                |region| {
+                    let mut assigner = config.advice_cycle_assigner();
+
+                    let Self {
+                        instances_hash_accumulator,
+                        instances,
+                    } = self;
+
+                    let mut region = RegionCtx::new(region, 0);
+
+                    let assigned_instances_hash_accumulator = assigner.assign_next_advice(
+                        &mut region,
+                        || "instances_hash_accumulator",
+                        *instances_hash_accumulator,
+                    )?;
+
+                    let assigned_instances = assigner.assign_all_advice(
+                        &mut region,
+                        || "instances_hash_accumulator",
+                        instances.iter().flat_map(|col| col.iter()).copied(),
+                    )?;
+
+                    Ok((assigned_instances_hash_accumulator, assigned_instances))
+                },
+            )?;
+
+            let new_instances_hash_accumulator = layouter.assign_region(
+                || "fold",
+                |region| {
+                    fold_assign_step_circuit_instances_hash_accumulator(
+                        &mut RegionCtx::new(region, 0),
+                        config.main_gate_config.clone(),
+                        &instances_hash_accumulator,
+                        &instances,
+                    )
+                },
+            )?;
+
+            layouter.constrain_instance(
+                new_instances_hash_accumulator.cell(),
+                config.instance,
+                0,
+            )?;
+
+            Ok(())
+        }
+    }
+
+    type C = bn256::G1Affine;
+    type Scalar = <C as CurveAffine>::ScalarExt;
+    type Base = <C as CurveAffine>::Base;
+
+    #[test]
+    fn consistency() {
+        let mut rand = rand::thread_rng();
+        let [acc, i1, i2, i3] = array::from_fn(|_| Scalar::random(&mut rand));
+
+        let expected = fold_step_circuit_instances_hash_accumulator::<C>(&acc, &[vec![i1, i2, i3]]);
+
+        MockProver::run(
+            10,
+            &ConsistencyCheckCircuit::<Base>::new(acc, &[vec![i1, i2, i3]]),
+            vec![vec![util::fe_to_fe(&expected).unwrap()]],
+        )
+        .unwrap()
+        .verify()
+        .unwrap();
+    }
+}

--- a/src/ivc/mod.rs
+++ b/src/ivc/mod.rs
@@ -5,6 +5,7 @@ pub mod step_folding_circuit;
 mod consistency_markers_computation;
 mod fold_relaxed_plonk_instance_chip;
 mod incrementally_verifiable_computation;
+pub mod instances_accumulator_computation;
 mod public_params;
 
 pub use halo2_proofs::circuit::SimpleFloorPlanner;

--- a/src/nifs/protogalaxy/mod.rs
+++ b/src/nifs/protogalaxy/mod.rs
@@ -507,7 +507,7 @@ impl<C: CurveAffine, const L: usize> VerifyAccumulation<C, L> for ProtoGalaxy<C,
             .copied()
             .collect::<Vec<_>>();
 
-        let mismatch_count = sparse::matrix_multiply(&S.permutation_matrix, &Z)
+        let mismatch_count = sparse::matrix_multiply(&S.permutation_matrix(), &Z)
             .into_iter()
             .zip_eq(Z)
             .enumerate()

--- a/src/nifs/vanilla/mod.rs
+++ b/src/nifs/vanilla/mod.rs
@@ -1,7 +1,10 @@
 use std::{marker::PhantomData, num::NonZeroUsize};
 
 use count_to_non_zero::CountToNonZeroExt;
-use halo2_proofs::arithmetic::CurveAffine;
+use halo2_proofs::{
+    arithmetic::CurveAffine,
+    halo2curves::ff::{FromUniformBytes, PrimeField, PrimeFieldBits},
+};
 use itertools::Itertools;
 use some_to_err::ErrOr;
 use tracing::*;
@@ -18,7 +21,10 @@ use crate::{
         eval::{GetDataForEval, PlonkEvalDomain},
         PlonkInstance, PlonkStructure, PlonkTrace, PlonkWitness,
     },
-    polynomial::{graph_evaluator::GraphEvaluator, sparse},
+    polynomial::{
+        graph_evaluator::GraphEvaluator,
+        sparse::{self, SparseMatrix},
+    },
     poseidon::ROTrait,
     sps::SpecialSoundnessVerifier,
 };
@@ -58,7 +64,10 @@ pub struct VanillaFSProverParam<C: CurveAffine> {
     pp_digest: C,
 }
 
-impl<C: CurveAffine> VanillaFS<C> {
+impl<C: CurveAffine> VanillaFS<C>
+where
+    C::Base: PrimeFieldBits + FromUniformBytes<64>,
+{
     /// Commits to the cross terms between two Plonk instance-witness pairs.
     ///
     /// This method calculates the cross terms and their commitments, which
@@ -171,7 +180,10 @@ pub enum Error {
     Commitment(#[from] commitment::Error),
 }
 
-impl<C: CurveAffine> FoldingScheme<C> for VanillaFS<C> {
+impl<C: CurveAffine> FoldingScheme<C> for VanillaFS<C>
+where
+    C::Base: PrimeFieldBits + FromUniformBytes<64>,
+{
     type Error = Error;
     type ProverParam = VanillaFSProverParam<C>;
     type VerifierParam = C;
@@ -281,7 +293,10 @@ impl<C: CurveAffine> FoldingScheme<C> for VanillaFS<C> {
     }
 }
 
-impl<C: CurveAffine> VerifyAccumulation<C> for VanillaFS<C> {
+impl<C: CurveAffine> VerifyAccumulation<C> for VanillaFS<C>
+where
+    C::Base: PrimeFieldBits + FromUniformBytes<64>,
+{
     type VerifyError = plonk::Error;
 
     fn is_sat_accumulation(
@@ -339,25 +354,57 @@ impl<C: CurveAffine> VerifyAccumulation<C> for VanillaFS<C> {
         S: &PlonkStructure<C::ScalarExt>,
         acc: &<Self as FoldingScheme<C>>::Accumulator,
     ) -> Result<(), Self::VerifyError> {
+        /// Under this collapsing scheme, `instance` columns other than consistency markers are not
+        /// foldeded, but accumulated using hash. Therefore, they need to be cut out for
+        /// `is_sat_permutation`.
+        ///
+        /// To account for these permutations in the `Relaxed` version, we add them to StepFoldingCircuit
+        /// as a copy constraint with private input (witness)
+        fn permutation_data_without_step_circuit_instances<F: PrimeField>(
+            S: &PlonkStructure<F>,
+        ) -> SparseMatrix<F> {
+            S.permutation_data
+                .clone()
+                .rm_copy_constraints(1..S.num_io.len())
+                .matrix(S.k, &S.num_io, S.num_advice_columns)
+        }
+
+        /// While checking permutations, we need to line up all instance columns one after the other, but
+        /// since we cut out all instance columns except the null column (consistency_marker) for the
+        /// `Relaxed*` version we need to augment them based on [`PlonkStructure::num_io`].
+        fn iter_flat_instances_with_padding<'b, C: CurveAffine>(
+            U: &'b RelaxedPlonkInstance<C>,
+            S: &'b PlonkStructure<C::ScalarExt>,
+        ) -> impl 'b + Iterator<Item = C::ScalarExt> {
+            U.consistency_markers.iter().copied().chain(
+                S.num_io
+                    .iter()
+                    .skip(1)
+                    .flat_map(|len| std::iter::repeat(C::ScalarExt::ZERO).take(*len)),
+            )
+        }
+
         let RelaxedPlonkTrace { U, W } = acc;
 
-        let Z = U
-            .instances()
-            .iter()
-            .flat_map(|i| i.iter())
-            .chain(W.W[0].iter().take((1 << S.k) * S.num_advice_columns))
-            .copied()
+        let Z = iter_flat_instances_with_padding(U, S)
+            .chain(
+                W.W[0]
+                    .iter()
+                    .take((1 << S.k) * S.num_advice_columns)
+                    .copied(),
+            )
             .collect::<Vec<_>>();
 
-        let mismatch_count = sparse::matrix_multiply(&S.permutation_matrix(), &Z)
-            .into_iter()
-            .zip_eq(Z)
-            .enumerate()
-            .filter_map(|(row, (y, z))| C::ScalarExt::ZERO.ne(&(y - z)).then_some(row))
-            .inspect(|row| {
-                warn!("permutation mismatch at {row}");
-            })
-            .count();
+        let mismatch_count =
+            sparse::matrix_multiply(&permutation_data_without_step_circuit_instances(S), &Z)
+                .into_iter()
+                .zip_eq(Z)
+                .enumerate()
+                .filter_map(|(row, (y, z))| C::ScalarExt::ZERO.ne(&(y - z)).then_some(row))
+                .inspect(|row| {
+                    warn!("permutation mismatch at {row}");
+                })
+                .count();
 
         if mismatch_count == 0 {
             Ok(())
@@ -418,6 +465,16 @@ impl<C: CurveAffine> GetConsistencyMarkers<C::ScalarExt> for PlonkInstance<C> {
 impl<C: CurveAffine> GetConsistencyMarkers<C::ScalarExt> for RelaxedPlonkInstance<C> {
     fn get_consistency_markers(&self) -> Option<[C::ScalarExt; 2]> {
         Some(self.consistency_markers)
+    }
+}
+
+pub trait GetStepCircuitInstances<F> {
+    fn get_step_circuit_instances(&self) -> &[Vec<F>];
+}
+
+impl<C: CurveAffine> GetStepCircuitInstances<C::ScalarExt> for PlonkInstance<C> {
+    fn get_step_circuit_instances(&self) -> &[Vec<C::ScalarExt>] {
+        &self.instances[1..]
     }
 }
 

--- a/src/nifs/vanilla/mod.rs
+++ b/src/nifs/vanilla/mod.rs
@@ -349,7 +349,7 @@ impl<C: CurveAffine> VerifyAccumulation<C> for VanillaFS<C> {
             .copied()
             .collect::<Vec<_>>();
 
-        let mismatch_count = sparse::matrix_multiply(&S.permutation_matrix, &Z)
+        let mismatch_count = sparse::matrix_multiply(&S.permutation_matrix(), &Z)
             .into_iter()
             .zip_eq(Z)
             .enumerate()

--- a/src/plonk/mod.rs
+++ b/src/plonk/mod.rs
@@ -19,6 +19,7 @@ use serde::Serialize;
 use some_to_err::*;
 use tracing::{debug, error, info, info_span, instrument, warn};
 
+use self::permutation::PermutationData;
 use crate::{
     commitment::CommitmentKey,
     concat_vec,
@@ -156,7 +157,7 @@ pub struct PlonkStructure<F: PrimeField> {
     #[serde(skip_serializing)]
     pub(crate) gates: Vec<Expression<F>>,
 
-    pub(crate) permutation_matrix: SparseMatrix<F>,
+    pub(crate) permutation_data: PermutationData,
     pub(crate) lookup_arguments: Option<lookup::Arguments<F>>,
 }
 
@@ -655,6 +656,11 @@ impl<F: PrimeField> PlonkStructure<F> {
                 W: vec![W1, W2, W3],
             },
         })
+    }
+
+    pub fn permutation_matrix(&self) -> SparseMatrix<F> {
+        self.permutation_data
+            .matrix(self.k, &self.num_io, self.num_advice_columns)
     }
 }
 

--- a/src/plonk/mod.rs
+++ b/src/plonk/mod.rs
@@ -133,6 +133,7 @@ impl<F: PrimeField> CompressedGates<F> {
 pub struct PlonkStructure<F: PrimeField> {
     /// k is a parameter such that 2^k is the total number of rows
     pub(crate) k: usize,
+    /// Instance columns lengths
     pub(crate) num_io: Box<[usize]>,
     pub(crate) selectors: Vec<Vec<bool>>,
     pub(crate) fixed_columns: Vec<Vec<F>>,

--- a/src/plonk/permutation.rs
+++ b/src/plonk/permutation.rs
@@ -129,6 +129,79 @@ impl PermutationData {
             &self.mapping,
         )
     }
+
+    #[instrument(level = "debug", skip_all)]
+    /// Removes copy constraints for specific instance columns from the permutation mapping.
+    ///
+    /// # Parameters
+    ///
+    /// - `instance_columns_to_remove`: An iterator over the indices of instance columns
+    ///   for which copy constraints need to be removed.
+    ///
+    /// # Returns
+    ///
+    /// A new `PermutationData` object with the specified copy constraints removed.
+    ///
+    /// # Algorithm
+    ///
+    /// 1. Identify the indices of all instance columns in the permutation and collect them in `instance_columns`.
+    /// 2. Filter out and sort the indices to be removed that match the instance columns into `columns_to_remove_set`.
+    /// 3. Iterate through each column in the permutation:
+    ///    - If the column is in `columns_to_remove_set`:
+    ///      - Reset its permutation by setting each of its mapping cells to the identity (i.e., `(column_index, row_index)`).
+    ///    - Otherwise, for each row in the column:
+    ///      - Traverse the cycle starting from the current cell. If a cycle includes a row in the columns to remove, bypass that row.
+    ///      - Update the mapping to link directly to the next cell in the cycle that is not in the columns to remove.
+    /// 4. Return the updated `PermutationData` object.
+    pub(crate) fn rm_copy_constraints(
+        mut self,
+        instance_columns_to_remove: impl Iterator<Item = usize>,
+    ) -> Self {
+        let instance_columns = self
+            .columns
+            .iter()
+            .filter(|column| column.column_type().eq(&Any::Instance))
+            .map(|column| column.index())
+            .collect::<Box<[_]>>();
+
+        let mut columns_to_remove_set = instance_columns_to_remove
+            .filter(|index| instance_columns.binary_search(index).is_ok())
+            .collect::<Box<[_]>>();
+
+        columns_to_remove_set.sort();
+
+        for (column_index, column) in self.columns.iter().enumerate() {
+            if columns_to_remove_set.binary_search(&column.index()).is_ok() {
+                debug!("completely clearing all permutations for column {column:?}");
+                for (row_index, mapping_cell) in self.mapping[column_index].iter_mut().enumerate() {
+                    *mapping_cell = (column_index, row_index);
+                }
+            } else {
+                let row_count = self.mapping[column_index].len();
+
+                for row_index in 0..row_count {
+                    let (mut next_i, mut next_j) = self.mapping[column_index][row_index];
+
+                    let start = (column_index, row_index);
+                    while (next_i, next_j) != start
+                        && columns_to_remove_set
+                            .binary_search(&self.columns[next_i].index())
+                            .is_ok()
+                    {
+                        (next_i, next_j) = if (next_i, next_j) == self.mapping[next_i][next_j] {
+                            start
+                        } else {
+                            self.mapping[next_i][next_j]
+                        };
+                    }
+
+                    self.mapping[column_index][row_index] = (next_i, next_j);
+                }
+            }
+        }
+
+        self
+    }
 }
 
 impl Serialize for PermutationData {


### PR DESCRIPTION
**Motivation**
As part of #316, we will need to remove some copy constraints before checking for correctness. To achieve this, I saved the information needed to build the matrix and built it on demand.

Next PR will add copy constraint cutout

**Overview**
This PR refactors the `PlonkStructure` by introducing the `PermutationData` struct to manage permutation matrix data. It replaces direct usage of `SparseMatrix` with a method to construct the permutation matrix on demand.