### PR TITLE
feat(ivc): accumulation of step circuit instances

### DIFF
--- a/src/ivc/incrementally_verifiable_computation.rs
+++ b/src/ivc/incrementally_verifiable_computation.rs
@@ -107,6 +107,8 @@ where
     C2: CurveAffine<Base = <C1 as PrimeCurveAffine>::Scalar>,
     SC1: StepCircuit<A1, C1::Scalar>,
     SC2: StepCircuit<A2, C2::Scalar>,
+    C1::Scalar: PrimeFieldBits + FromUniformBytes<64>,
+    C2::Scalar: PrimeFieldBits + FromUniformBytes<64>,
 {
     primary: StepCircuitContext<A1, C1, SC1>,
     secondary: StepCircuitContext<A2, C2, SC2>,


### PR DESCRIPTION
**Motivation**
Practically complete realization of task #316

**Overview**
Impl of accumulation of step circuit instances

- Addition of a `step_circuit_instances_hash_accumulator` to the `RelaxedPlonkInstance` structure.
- Implementation of methods to fold and conditionally select step circuit instances.
- Modification of existing methods to incorporate the new accumulator.
- Update to testing modules to cover the changes.