### PR TITLE
feat(nifs): `Foldable` wrapper for trace

### DIFF
--- a/src/nifs/mod.rs
+++ b/src/nifs/mod.rs
@@ -13,7 +13,7 @@ use rayon::prelude::*;
 
 use crate::{
     commitment::{self, CommitmentKey},
-    plonk::{eval::Error as EvalError, PlonkInstance, PlonkStructure, PlonkTrace},
+    plonk::{eval::Error as EvalError, PlonkStructure},
     poseidon::ROTrait,
     sps::Error as SpsError,
 };
@@ -30,6 +30,14 @@ pub trait FoldingScheme<C: CurveAffine, const L: usize = 1> {
 
     /// Metadata for verifier including hash of public params
     type VerifierParam;
+
+    /// Type representing the constraint system execution trace
+    /// By default can use type [`crate::plonk::PlonkTrace`]
+    type Trace;
+
+    /// Type representing the constraint system instance
+    /// By default can use type [`crate::plonk::PlonkInstance`]
+    type Instance;
 
     /// Accumulator contains AccumulatorInstance and the corresponding Witness (e.g. [`RelaxedPlonkWitness`])
     type Accumulator;
@@ -51,7 +59,7 @@ pub trait FoldingScheme<C: CurveAffine, const L: usize = 1> {
         witness: &[Vec<C::ScalarExt>],
         pp: &Self::ProverParam,
         ro_nark: &mut impl ROTrait<C::Base>,
-    ) -> Result<PlonkTrace<C>, Self::Error>;
+    ) -> Result<Self::Trace, Self::Error>;
 
     /// Perform the folding operation as a prover.
     fn prove(
@@ -59,7 +67,7 @@ pub trait FoldingScheme<C: CurveAffine, const L: usize = 1> {
         pp: &Self::ProverParam,
         ro_acc: &mut impl ROTrait<C::Base>,
         accumulator: Self::Accumulator,
-        incoming: &[PlonkTrace<C>; L],
+        incoming: &[Self::Trace; L],
     ) -> Result<(Self::Accumulator, Self::Proof), Self::Error>;
 
     /// Perform the folding operation as a verifier.
@@ -68,7 +76,7 @@ pub trait FoldingScheme<C: CurveAffine, const L: usize = 1> {
         ro_nark: &mut impl ROTrait<C::Base>,
         ro_acc: &mut impl ROTrait<C::Base>,
         accumulator: &Self::AccumulatorInstance,
-        incoming: &[PlonkInstance<C>; L],
+        incoming: &[Self::Instance; L],
         proof: &Self::Proof,
     ) -> Result<Self::AccumulatorInstance, Self::Error>;
 }

--- a/src/nifs/protogalaxy/mod.rs
+++ b/src/nifs/protogalaxy/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     ff::PrimeField,
     halo2_proofs::arithmetic::{self, CurveAffine, Field},
     nifs::protogalaxy::poly::PolyContext,
-    plonk::{self, PlonkStructure, PlonkTrace, PlonkWitness},
+    plonk::{self, PlonkInstance, PlonkStructure, PlonkTrace, PlonkWitness},
     polynomial::{lagrange, sparse, univariate::UnivariatePoly},
     poseidon::AbsorbInRO,
     sps::{self, SpecialSoundnessVerifier},
@@ -222,6 +222,8 @@ impl<C: CurveAffine, const L: usize> FoldingScheme<C, L> for ProtoGalaxy<C, L> {
     type Error = Error;
     type ProverParam = ProverParam<C>;
     type VerifierParam = VerifierParam<C>;
+    type Trace = PlonkTrace<C>;
+    type Instance = PlonkInstance<C>;
     type Accumulator = Accumulator<C>;
     type AccumulatorInstance = AccumulatorInstance<C>;
     type Proof = ProtoGalaxyProof<C::ScalarExt>;
@@ -240,8 +242,6 @@ impl<C: CurveAffine, const L: usize> FoldingScheme<C, L> for ProtoGalaxy<C, L> {
         pp: &Self::ProverParam,
         ro_nark: &mut impl ROTrait<C::Base>,
     ) -> Result<PlonkTrace<C>, Error> {
-        assert!(instances.len() <= 1, "TODO #316");
-
         Ok(pp
             .S
             .run_sps_protocol(ck, instances, witness, ro_nark, pp.S.num_challenges)?)

--- a/src/nifs/vanilla/mod.rs
+++ b/src/nifs/vanilla/mod.rs
@@ -1,4 +1,4 @@
-use std::{marker::PhantomData, num::NonZeroUsize};
+use std::{iter, marker::PhantomData, num::NonZeroUsize};
 
 use count_to_non_zero::CountToNonZeroExt;
 use halo2_proofs::{
@@ -9,6 +9,7 @@ use itertools::Itertools;
 use some_to_err::ErrOr;
 use tracing::*;
 
+use self::accumulator::{FoldablePlonkInstance, FoldablePlonkTrace};
 use super::*;
 use crate::{
     commitment::CommitmentKey,
@@ -19,7 +20,7 @@ use crate::{
     plonk::{
         self,
         eval::{GetDataForEval, PlonkEvalDomain},
-        PlonkInstance, PlonkStructure, PlonkTrace, PlonkWitness,
+        PlonkInstance, PlonkStructure, PlonkWitness,
     },
     polynomial::{
         graph_evaluator::GraphEvaluator,
@@ -178,6 +179,8 @@ pub enum Error {
     Plonk(#[from] Halo2Error),
     #[error(transparent)]
     Commitment(#[from] commitment::Error),
+    #[error("In the traces that are folded by this scheme the first column with two elements is expected")]
+    NoConsistencyMarkers,
 }
 
 impl<C: CurveAffine> FoldingScheme<C> for VanillaFS<C>
@@ -189,18 +192,14 @@ where
     type VerifierParam = C;
     type Accumulator = RelaxedPlonkTrace<C>;
     type AccumulatorInstance = RelaxedPlonkInstance<C>;
+    type Trace = FoldablePlonkTrace<C>;
+    type Instance = FoldablePlonkInstance<C>;
     type Proof = CrossTermCommits<C>;
 
     fn setup_params(
         pp_digest: C,
         S: PlonkStructure<C::ScalarExt>,
     ) -> Result<(Self::ProverParam, Self::VerifierParam), Error> {
-        assert_eq!(
-            S.num_io.as_ref(),
-            &[2],
-            "TODO Until #316 is done completely"
-        );
-
         Ok((VanillaFSProverParam { S, pp_digest }, pp_digest))
     }
 
@@ -211,10 +210,10 @@ where
         witness: &[Vec<C::ScalarExt>],
         pp: &VanillaFSProverParam<C>,
         ro_nark: &mut impl ROTrait<C::Base>,
-    ) -> Result<PlonkTrace<C>, Error> {
-        Ok(pp
-            .S
-            .run_sps_protocol(ck, instances, witness, ro_nark, pp.S.num_challenges)?)
+    ) -> Result<FoldablePlonkTrace<C>, Error> {
+        pp.S.run_sps_protocol(ck, instances, witness, ro_nark, pp.S.num_challenges)
+            .map(FoldablePlonkTrace::new)?
+            .ok_or(Error::NoConsistencyMarkers)
     }
 
     /// Generates a proof of correct folding using the NIFS protocol.
@@ -238,7 +237,7 @@ where
         pp: &Self::ProverParam,
         ro_acc: &mut impl ROTrait<C::Base>,
         accumulator: Self::Accumulator,
-        incoming: &[PlonkTrace<C>; 1],
+        incoming: &[FoldablePlonkTrace<C>; 1],
     ) -> Result<(Self::Accumulator, Self::Proof), Error> {
         let incoming = &incoming[0];
 
@@ -280,7 +279,7 @@ where
         ro_nark: &mut impl ROTrait<C::Base>,
         ro_acc: &mut impl ROTrait<C::Base>,
         U1: &Self::AccumulatorInstance,
-        U2: &[PlonkInstance<C>; 1],
+        U2: &[FoldablePlonkInstance<C>; 1],
         cross_term_commits: &CrossTermCommits<C>,
     ) -> Result<Self::AccumulatorInstance, Error> {
         let U2 = &U2[0];
@@ -380,7 +379,8 @@ where
                 S.num_io
                     .iter()
                     .skip(1)
-                    .flat_map(|len| std::iter::repeat(C::ScalarExt::ZERO).take(*len)),
+                    // Use 0xfffffff only for easy debug
+                    .flat_map(|len| iter::repeat(C::ScalarExt::from_u128(0xfffffff)).take(*len)),
             )
         }
 
@@ -400,9 +400,15 @@ where
                 .into_iter()
                 .zip_eq(Z)
                 .enumerate()
-                .filter_map(|(row, (y, z))| C::ScalarExt::ZERO.ne(&(y - z)).then_some(row))
-                .inspect(|row| {
-                    warn!("permutation mismatch at {row}");
+                .filter(|(row, (y, z))| {
+                    let diff = *y - *z;
+
+                    if diff.is_zero().into() {
+                        false
+                    } else {
+                        warn!("permutation mismatch at {row} with: {y:?} - {z:?} = {diff:?}");
+                        true
+                    }
                 })
                 .count();
 
@@ -447,24 +453,21 @@ pub const CONSISTENCY_MARKERS_COUNT: usize = 2;
 ///     hash of the state at the end of previous folding step
 /// - X1 is a hash of the state at the end of the current folding step
 pub trait GetConsistencyMarkers<F> {
-    fn get_consistency_markers(&self) -> Option<[F; CONSISTENCY_MARKERS_COUNT]>;
+    fn get_consistency_markers(&self) -> [F; CONSISTENCY_MARKERS_COUNT];
 }
 
-impl<C: CurveAffine> GetConsistencyMarkers<C::ScalarExt> for PlonkInstance<C> {
-    fn get_consistency_markers(&self) -> Option<[C::ScalarExt; 2]> {
+impl<C: CurveAffine> GetConsistencyMarkers<C::ScalarExt> for FoldablePlonkInstance<C> {
+    fn get_consistency_markers(&self) -> [C::ScalarExt; 2] {
         match self.instances.first() {
-            Some(instance) if instance.len() == 2 => Some(instance.clone().try_into().unwrap()),
-            Some(instance) => {
-                panic!("wrong size of instances[0], can't use as consistency marker: {instance:?}")
-            }
-            None => None,
+            Some(instance) if instance.len() == 2 => instance.clone().try_into().unwrap(),
+            _ => unreachable!("folded plonk instancce always have markers"),
         }
     }
 }
 
 impl<C: CurveAffine> GetConsistencyMarkers<C::ScalarExt> for RelaxedPlonkInstance<C> {
-    fn get_consistency_markers(&self) -> Option<[C::ScalarExt; 2]> {
-        Some(self.consistency_markers)
+    fn get_consistency_markers(&self) -> [C::ScalarExt; 2] {
+        self.consistency_markers
     }
 }
 

--- a/src/nifs/vanilla/tests.rs
+++ b/src/nifs/vanilla/tests.rs
@@ -17,7 +17,7 @@ use crate::{
             VanillaFS,
         },
     },
-    plonk::{PlonkStructure, PlonkTrace},
+    plonk::PlonkStructure,
     table::CircuitRunner,
     util::create_ro,
 };
@@ -65,8 +65,8 @@ fn prepare_trace<C, F1, F2, CT>(
     (
         CommitmentKey<C>,
         PlonkStructure<F1>,
-        PlonkTrace<C>,
-        PlonkTrace<C>,
+        FoldablePlonkTrace<C>,
+        FoldablePlonkTrace<C>,
     ),
     Error<C>,
 >
@@ -141,8 +141,8 @@ where
 fn fold_instances<C, F1, F2>(
     ck: &CommitmentKey<C>,
     S: &PlonkStructure<F1>,
-    pair1: PlonkTrace<C>,
-    pair2: PlonkTrace<C>,
+    pair1: FoldablePlonkTrace<C>,
+    pair2: FoldablePlonkTrace<C>,
     pp_digest: C,
 ) -> Result<(), Error<C>>
 where
@@ -156,7 +156,7 @@ where
     const R_P: usize = 3;
 
     let mut f_tr = RelaxedPlonkTrace {
-        U: RelaxedPlonkInstance::try_new(&S.num_io, S.num_challenges, S.round_sizes.len()).unwrap(),
+        U: RelaxedPlonkInstance::new(S.num_challenges, S.round_sizes.len()),
         W: RelaxedPlonkWitness::new(S.k, &S.round_sizes),
     };
 


### PR DESCRIPTION
**Motivation**
During the implementation of #316 we added a condition that consistency tokens started to be collapsed differently than all other instances, which in fact added a constraint to `nifs::FS` that now only traces with two elements in the first instance column can be collapsed. Otherwise, the behavior is undefined. This PR solves the problem of checking this restriction

**Overview**
The newtype pattern was used to solve the problem in this way. An example of using such a pattern is the `NonZero<T>` wrapper from the standard library. Now, instead of checking in all functions that involve consistency tokens, we accept `vanilla::FoldablePlonkTrace` instead of `PlonkTrace`. This type can only be created with a single constructor, which performs the trace validity check at the point of creation.

For instance:

```rust
// Old way with PlonkTrace
fn old_function(trace: &PlonkTrace) -> Result<(), Error> {
    // Every use site needed to check preconditions
    if trace.instances.first().map(|x| x.len()) != Some(2) {
        return Err(Error::InvalidTrace);
    }
    // function body...
}

// New way with FoldablePlonkTrace
fn new_function(foldable_trace: &FoldablePlonkTrace) -> Result<(), Error> {
    // No need for precondition checks here
    // function body...
}
```

This pattern encapsulates the validation logic within the `FoldablePlonkTrace` type, ensuring that all instances of `FoldablePlonkTrace` are valid by construction. This approach significantly reduces verbosity and potential for error, improving both safety and readability of the code. Moreover, it ensures that the invariant (traces having two elements in the first instance column) is enforced in a single place, thus avoiding scattered checks throughout the codebase.

```rust
impl<C: CurveAffine> FoldablePlonkInstance<C> {
    pub fn new(pl: PlonkInstance<C>) -> Option<Self> {
        matches!(pl.instances.first(), Some(instance) if instance.len() == 2).then_some(Self(pl))
    }
}
```

Here, the `new` method of `FoldablePlonkInstance` ensures that it can only be instantiated if the `PlonkInstance` meets the specific requirement. This is less verbose than returning an error through multiple layers of modules and provides a more accurate check compared to panicking if an implicit invariant is violated.
