### PR TITLE
refactor(util): `ScalarToBase` + `BaseToScalar`

### DIFF
--- a/src/gadgets/ecc.rs
+++ b/src/gadgets/ecc.rs
@@ -396,7 +396,7 @@ mod tests {
         ff::Field,
         halo2curves::pasta::{pallas, EqAffine, Fp, Fq},
         run_mock_prover_test,
-        util::fe_to_fe_safe,
+        util::ScalarToBase,
     };
 
     #[derive(Clone, Debug)]
@@ -582,7 +582,7 @@ mod tests {
                         ctx.next();
                         ecc_chip.add(ctx, &a, &b)
                     } else {
-                        let lambda: C::Base = fe_to_fe_safe(&self.lambda).unwrap();
+                        let lambda: C::Base = C::scalar_to_base(&self.lambda).unwrap();
                         let bit_len =
                             NonZeroUsize::new(lambda.to_le_bits().len()).expect("Non Zero");
                         let lambda = ctx.assign_advice(

--- a/src/ivc/consistency_markers_computation.rs
+++ b/src/ivc/consistency_markers_computation.rs
@@ -12,7 +12,7 @@ use crate::{
     main_gate::{AssignedValue, MainGate, MainGateConfig, RegionCtx, WrapValue},
     nifs::sangria::accumulator::RelaxedPlonkInstance,
     poseidon::{AbsorbInRO, ROCircuitTrait, ROTrait},
-    util,
+    util::{self, ScalarToBase},
 };
 
 pub(crate) struct AssignedConsistencyMarkersComputation<
@@ -113,9 +113,9 @@ where
                             .flat_map(|bn| bn.limbs().iter())
                             .copied(),
                     )
-                    .absorb_field(util::fe_to_fe(self.u).unwrap())
+                    .absorb_field(C::scalar_to_base(self.u).unwrap())
                     .absorb_field(
-                        util::fe_to_fe(self.step_circuit_instances_hash_accumulator).unwrap(),
+                        C::scalar_to_base(self.step_circuit_instances_hash_accumulator).unwrap(),
                     );
             }
         }
@@ -136,7 +136,7 @@ where
                 .iter()
                 .map(|v| {
                     BigUint::from_f(
-                        &util::fe_to_fe(v).unwrap(),
+                        &C::scalar_to_base(v).unwrap(),
                         self.limb_width,
                         self.limbs_count,
                     )
@@ -147,7 +147,7 @@ where
                 .iter()
                 .map(|v| {
                     BigUint::from_f(
-                        &util::fe_to_fe(v).unwrap(),
+                        &C::scalar_to_base(v).unwrap(),
                         self.limb_width,
                         self.limbs_count,
                     )

--- a/src/ivc/public_params.rs
+++ b/src/ivc/public_params.rs
@@ -29,7 +29,7 @@ use crate::{
     plonk::PlonkStructure,
     poseidon::{random_oracle::ROTrait, ROPair},
     table::CircuitRunner,
-    util,
+    util::ScalarToBase,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -305,7 +305,7 @@ where
             );
 
             let secondary_consistenty_markers: [C2::Scalar; 2] = [
-                util::fe_to_fe(&secondary_initial_step_input.u.get_consistency_markers()[0])
+                C1::scalar_to_base(&secondary_initial_step_input.u.get_consistency_markers()[0])
                     .unwrap(),
                 ConsistencyMarkerComputation::<'_, A2, C1, RP2::OffCircuit> {
                     random_oracle_constant: secondary.ro_constant.clone(),

--- a/src/ivc/sangria/fold_relaxed_plonk_instance_chip.rs
+++ b/src/ivc/sangria/fold_relaxed_plonk_instance_chip.rs
@@ -1101,6 +1101,7 @@ mod tests {
         plonk::PlonkInstance,
         poseidon::{poseidon_circuit::PoseidonChip, PoseidonHash, ROTrait, Spec},
         table::WitnessCollector,
+        util::ScalarToBase,
     };
 
     type Base = <C1 as CurveAffine>::Base;
@@ -1318,7 +1319,7 @@ mod tests {
                     let assigned_r = ctx.assign_advice(
                         || "r",
                         config.state[0],
-                        Value::known(util::fe_to_fe(&r).unwrap()),
+                        Value::known(C1::scalar_to_base(&r).unwrap()),
                     )?;
 
                     let r = gate.le_num_to_bits(&mut ctx, assigned_r, MAX_BITS)?;
@@ -1404,7 +1405,7 @@ mod tests {
                     let assigned_r = ctx.assign_advice(
                         || "r",
                         config.state[0],
-                        Value::known(util::fe_to_fe(&r).unwrap()),
+                        Value::known(C1::scalar_to_base(&r).unwrap()),
                     )?;
 
                     let r =
@@ -1511,7 +1512,7 @@ mod tests {
                     }
 
                     let assigned_r = advice_columns_assigner
-                        .assign_next_advice(&mut ctx, || "r", util::fe_to_fe(&r).unwrap())
+                        .assign_next_advice(&mut ctx, || "r", C1::scalar_to_base(&r).unwrap())
                         .unwrap();
 
                     let assigned_consistency_markers = relaxed_plonk
@@ -1659,7 +1660,7 @@ mod tests {
                     }
 
                     let assigned_r = advice_columns_assigner
-                        .assign_next_advice(&mut ctx, || "r", util::fe_to_fe(&r).unwrap())
+                        .assign_next_advice(&mut ctx, || "r", C1::scalar_to_base(&r).unwrap())
                         .unwrap();
 
                     let assigned_fold_challenges = relaxed_plonk
@@ -1715,7 +1716,7 @@ mod tests {
                 .iter()
                 .map(|instance| {
                     BigUint::from_f(
-                        &util::fe_to_fe_safe::<ScalarExt, Base>(instance).unwrap(),
+                        &C1::scalar_to_base(instance).unwrap(),
                         LIMB_WIDTH,
                         LIMBS_COUNT,
                     )

--- a/src/ivc/sangria/incrementally_verifiable_computation.rs
+++ b/src/ivc/sangria/incrementally_verifiable_computation.rs
@@ -26,7 +26,7 @@ use crate::{
     poseidon::{random_oracle::ROTrait, ROPair},
     sps,
     table::CircuitRunner,
-    util,
+    util::ScalarToBase,
 };
 
 pub type Instances<F> = Vec<Vec<F>>;
@@ -225,7 +225,7 @@ where
         let primary_consistency_marker = {
             let _s = info_span!("generate_instance").entered();
             [
-                util::fe_to_fe(&secondary_pre_round_plonk_trace.u.get_consistency_markers()[1])
+                C2::scalar_to_base(&secondary_pre_round_plonk_trace.u.get_consistency_markers()[1])
                     .unwrap(),
                 ConsistencyMarkerComputation::<'_, A1, C2, RP1::OffCircuit> {
                     random_oracle_constant: pp.primary.params().ro_constant().clone(),
@@ -310,7 +310,7 @@ where
         let secondary_consistency_marker = {
             let _s = info_span!("generate_instance");
             [
-                util::fe_to_fe(&primary_plonk_trace.u.get_consistency_markers()[1]).unwrap(),
+                C1::scalar_to_base(&primary_plonk_trace.u.get_consistency_markers()[1]).unwrap(),
                 ConsistencyMarkerComputation::<'_, A2, C1, RP2::OffCircuit> {
                     random_oracle_constant: pp.secondary.params().ro_constant().clone(),
                     public_params_hash: &pp.digest_1(),
@@ -437,7 +437,8 @@ where
         let primary_consistency_marker = {
             let _s = info_span!("generate_instance").entered();
             [
-                util::fe_to_fe(&self.secondary_trace[0].u.get_consistency_markers()[1]).unwrap(),
+                C2::scalar_to_base(&self.secondary_trace[0].u.get_consistency_markers()[1])
+                    .unwrap(),
                 ConsistencyMarkerComputation::<'_, A1, C2, RP1::OffCircuit> {
                     random_oracle_constant: pp.primary.params().ro_constant().clone(),
                     public_params_hash: &pp.digest_2(),
@@ -524,7 +525,7 @@ where
         let secondary_consistency_marker = {
             let _s = info_span!("generate_instance");
             [
-                util::fe_to_fe(&primary_plonk_trace[0].u.get_consistency_markers()[1]).unwrap(),
+                C1::scalar_to_base(&primary_plonk_trace[0].u.get_consistency_markers()[1]).unwrap(),
                 ConsistencyMarkerComputation::<'_, A2, C1, RP2::OffCircuit> {
                     random_oracle_constant: pp.secondary.params().ro_constant().clone(),
                     public_params_hash: &pp.digest_1(),
@@ -639,7 +640,7 @@ where
         .generate_with_inspect::<C1::Scalar>(|buf| {
             debug!("primary X1 verify at {}-step: {buf:?}", self.step)
         })
-        .ne(&util::fe_to_fe(&self.secondary_trace[0].u.get_consistency_markers()[1]).unwrap())
+        .ne(&C2::scalar_to_base(&self.secondary_trace[0].u.get_consistency_markers()[1]).unwrap())
         .then(|| {
             errors.push(VerificationError::InstanceNotMatch {
                 index: 1,

--- a/src/nifs/protogalaxy/accumulator.rs
+++ b/src/nifs/protogalaxy/accumulator.rs
@@ -5,7 +5,7 @@ use crate::{
     halo2curves::CurveAffine,
     plonk::{self, PlonkInstance, PlonkTrace, PlonkWitness},
     poseidon::{AbsorbInRO, ROTrait},
-    util,
+    util::ScalarToBase,
 };
 
 /// Represents an accumulator for folding multiple instances into a single instance,
@@ -33,7 +33,7 @@ impl<C: CurveAffine, RO: ROTrait<C::Base>> AbsorbInRO<C::Base, RO> for Accumulat
             self.betas
                 .iter()
                 .chain(iter::once(&self.e))
-                .map(|b| util::fe_to_fe::<C::ScalarExt, C::Base>(b).unwrap()),
+                .map(|b| C::scalar_to_base(b).unwrap()),
         );
     }
 }
@@ -96,7 +96,7 @@ impl<C: CurveAffine, RO: ROTrait<C::Base>> AbsorbInRO<C::Base, RO> for Accumulat
             self.betas
                 .iter()
                 .chain(iter::once(&self.e))
-                .map(|b| util::fe_to_fe::<C::ScalarExt, C::Base>(b).unwrap()),
+                .map(|b| C::scalar_to_base(b).unwrap()),
         );
     }
 }

--- a/src/nifs/protogalaxy/mod.rs
+++ b/src/nifs/protogalaxy/mod.rs
@@ -15,7 +15,7 @@ use crate::{
     polynomial::{lagrange, sparse, univariate::UnivariatePoly},
     poseidon::AbsorbInRO,
     sps::{self, SpecialSoundnessVerifier},
-    util,
+    util::ScalarToBase,
 };
 
 mod accumulator;
@@ -301,11 +301,7 @@ impl<C: CurveAffine, const L: usize> FoldingScheme<C, L> for ProtoGalaxy<C, L> {
         )?;
 
         let alpha = ro_acc
-            .absorb_field_iter(
-                poly_F
-                    .iter()
-                    .map(|v| util::fe_to_fe::<C::ScalarExt, C::Base>(v).unwrap()),
-            )
+            .absorb_field_iter(poly_F.iter().map(|v| C::scalar_to_base(v).unwrap()))
             .squeeze::<C>(NUM_CHALLENGE_BITS);
 
         let betas_stroke = poly::PolyChallenges {
@@ -325,7 +321,7 @@ impl<C: CurveAffine, const L: usize> FoldingScheme<C, L> for ProtoGalaxy<C, L> {
         )?;
 
         let gamma = ro_acc
-            .absorb_field_iter(poly_K.iter().map(|v| util::fe_to_fe(v).unwrap()))
+            .absorb_field_iter(poly_K.iter().map(|v| C::scalar_to_base(v).unwrap()))
             .squeeze::<C>(NUM_CHALLENGE_BITS);
 
         let polys_L_in_gamma =
@@ -400,12 +396,7 @@ impl<C: CurveAffine, const L: usize> FoldingScheme<C, L> for ProtoGalaxy<C, L> {
 
         let delta = Self::generate_challenge(&vp.pp_digest, ro_acc, accumulator, incoming.iter());
         let alpha = ro_acc
-            .absorb_field_iter(
-                proof
-                    .poly_F
-                    .iter()
-                    .map(|v| util::fe_to_fe::<C::ScalarExt, C::Base>(v).unwrap()),
-            )
+            .absorb_field_iter(proof.poly_F.iter().map(|v| C::scalar_to_base(v).unwrap()))
             .squeeze::<C>(NUM_CHALLENGE_BITS);
 
         let betas_stroke = poly::PolyChallenges {
@@ -417,7 +408,7 @@ impl<C: CurveAffine, const L: usize> FoldingScheme<C, L> for ProtoGalaxy<C, L> {
         .collect::<Box<[_]>>();
 
         let gamma = ro_acc
-            .absorb_field_iter(proof.poly_K.iter().map(|v| util::fe_to_fe(v).unwrap()))
+            .absorb_field_iter(proof.poly_K.iter().map(|v| C::scalar_to_base(v).unwrap()))
             .squeeze::<C>(NUM_CHALLENGE_BITS);
 
         Ok(AccumulatorInstance {

--- a/src/nifs/sangria/accumulator.rs
+++ b/src/nifs/sangria/accumulator.rs
@@ -20,7 +20,7 @@ use crate::{
         self, GetChallenges, GetWitness, PlonkInstance, PlonkStructure, PlonkTrace, PlonkWitness,
     },
     poseidon::{AbsorbInRO, ROTrait},
-    util,
+    util::ScalarToBase,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -273,7 +273,7 @@ impl<C: CurveAffine, RO: ROTrait<C::Base>> AbsorbInRO<C::Base, RO> for RelaxedPl
                     .chain(challenges.iter())
                     .chain(iter::once(u))
                     .chain(iter::once(step_circuit_instances_hash_accumulator))
-                    .map(|m| util::fe_to_fe(m).unwrap()),
+                    .map(|m| C::scalar_to_base(m).unwrap()),
             );
     }
 }

--- a/src/plonk/mod.rs
+++ b/src/plonk/mod.rs
@@ -38,7 +38,7 @@ use crate::{
     },
     poseidon::{AbsorbInRO, ROTrait},
     sps::{Error as SpsError, SpecialSoundnessVerifier},
-    util::{concatenate_with_padding, fe_to_fe},
+    util::{concatenate_with_padding, ScalarToBase},
 };
 
 pub mod eval;
@@ -269,9 +269,13 @@ impl<C: CurveAffine, RO: ROTrait<C::Base>> AbsorbInRO<C::Base, RO> for PlonkInst
             .absorb_field_iter(
                 self.instances
                     .iter()
-                    .flat_map(|inst| inst.iter().map(|i| fe_to_fe(i).unwrap())),
+                    .flat_map(|inst| inst.iter().map(|i| C::scalar_to_base(i).unwrap())),
             )
-            .absorb_field_iter(self.challenges.iter().map(|cha| fe_to_fe(cha).unwrap()));
+            .absorb_field_iter(
+                self.challenges
+                    .iter()
+                    .map(|cha| C::scalar_to_base(cha).unwrap()),
+            );
     }
 }
 
@@ -482,7 +486,7 @@ impl<F: PrimeField> PlonkStructure<F> {
                 instances
                     .iter()
                     .flat_map(|instance| instance.iter())
-                    .map(|val| fe_to_fe(val).unwrap()),
+                    .map(|val| C::scalar_to_base(val).unwrap()),
             )
             .absorb_point_iter(plonk_instance.W_commitments.iter());
 
@@ -541,7 +545,7 @@ impl<F: PrimeField> PlonkStructure<F> {
                 instances
                     .iter()
                     .flat_map(|inst| inst.iter())
-                    .map(|val| fe_to_fe(val).unwrap()),
+                    .map(|val| C::scalar_to_base(val).unwrap()),
             )
             .absorb_point(&C1)
             .squeeze::<C>(NUM_CHALLENGE_BITS);
@@ -589,7 +593,7 @@ impl<F: PrimeField> PlonkStructure<F> {
             instances
                 .iter()
                 .flat_map(|i| i.iter())
-                .map(|inst| fe_to_fe(inst).unwrap()),
+                .map(|inst| C::scalar_to_base(inst).unwrap()),
         );
 
         let k_power_of_2 = 1 << self.k;

--- a/src/sps.rs
+++ b/src/sps.rs
@@ -5,7 +5,7 @@ use crate::{
     constants::NUM_CHALLENGE_BITS,
     plonk::{eval::Error as EvalError, PlonkInstance},
     poseidon::ROTrait,
-    util::fe_to_fe,
+    util::ScalarToBase,
 };
 
 #[derive(Debug, thiserror::Error, PartialEq)]
@@ -45,7 +45,7 @@ impl<C: CurveAffine, RO: ROTrait<C::Base>> SpecialSoundnessVerifier<C, RO> for P
             self.instances
                 .iter()
                 .flat_map(|inst| inst.iter())
-                .map(|val| fe_to_fe(val).unwrap()),
+                .map(|val| C::scalar_to_base(val).unwrap()),
         );
 
         for i in 0..num_challenges {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,7 +1,10 @@
 use std::{fmt, iter, num::NonZeroUsize};
 
 use halo2_proofs::{
-    halo2curves::ff::{FromUniformBytes, PrimeFieldBits},
+    halo2curves::{
+        ff::{FromUniformBytes, PrimeFieldBits},
+        CurveAffine,
+    },
     plonk::Assigned,
 };
 use itertools::Itertools;
@@ -83,6 +86,24 @@ pub fn fe_to_big<F: PrimeField>(fe: &F) -> BigUint {
 
 pub fn fe_to_fe<F1: PrimeField, F2: PrimeField>(fe: &F1) -> Option<F2> {
     fe_from_big(fe_to_big(fe) % modulus::<F2>())
+}
+
+pub trait ScalarToBase: CurveAffine {
+    fn scalar_to_base(input: &Self::Scalar) -> Option<Self::Base>;
+}
+impl<C: CurveAffine> ScalarToBase for C {
+    fn scalar_to_base(input: &C::Scalar) -> Option<C::Base> {
+        fe_to_fe(input)
+    }
+}
+
+pub trait BaseToScalar: CurveAffine {
+    fn base_to_scalar(input: &Self::Base) -> Option<Self::Scalar>;
+}
+impl<C: CurveAffine> BaseToScalar for C {
+    fn base_to_scalar(input: &Self::Base) -> Option<Self::Scalar> {
+        fe_to_fe(input)
+    }
 }
 
 pub fn fe_to_fe_safe<F1: PrimeField, F2: PrimeField>(fe: &F1) -> Option<F2> {


### PR DESCRIPTION
**Motivation**
We have a lot of distillations between base -> scalar. Perhaps within a cyclefold implementation this transformation would be optional, as there would be no curve cycle

**Overview**
For now, I've just labeled all these places through a separate API - `trait BaseToScalar: CurveAffine`. Also, if we have to support more curve, we can make this conversion between curves safer

No functional changes have been made