### PR TITLE
feat(ivc): impl protogalaxy verify circuit mod-blank

### DIFF
--- a/src/ivc/mod.rs
+++ b/src/ivc/mod.rs
@@ -5,6 +5,8 @@ pub use sangria::{
     fold_relaxed_plonk_instance_chip, incrementally_verifiable_computation, step_folding_circuit,
 };
 
+pub mod protogalaxy;
+
 mod consistency_markers_computation;
 pub mod instances_accumulator_computation;
 mod public_params;

--- a/src/ivc/protogalaxy/mod.rs
+++ b/src/ivc/protogalaxy/mod.rs
@@ -1,43 +1,138 @@
 mod verify_chip {
-    use halo2_proofs::halo2curves::{
-        ff::{FromUniformBytes, PrimeField, PrimeFieldBits},
-        CurveAffine,
+    use halo2_proofs::{
+        halo2curves::{
+            ff::{FromUniformBytes, PrimeField, PrimeFieldBits},
+            CurveAffine,
+        },
+        plonk::Error as Halo2PlonkError,
     };
 
     use crate::{
         gadgets::ecc::AssignedPoint,
-        main_gate::{AssignedValue, RegionCtx},
+        main_gate::{AdviceCyclicAssignor, AssignedValue, MainGateConfig, RegionCtx},
         nifs::protogalaxy,
         plonk::PlonkInstance,
         poseidon::ROCircuitTrait,
+        util::ScalarToBase,
     };
 
     #[derive(Debug, thiserror::Error)]
-    pub enum Error {}
+    pub enum Error {
+        #[error("Error while assign {annotation}: {err:?}")]
+        Assign {
+            annotation: &'static str,
+            err: Halo2PlonkError,
+        },
+    }
 
     /// Assigned version of [`crate::plonk::PlonkInstance`]
     pub struct AssignedPlonkInstance<C: CurveAffine> {
         W_commitments: Vec<AssignedPoint<C>>,
-        instances: Vec<Vec<AssignedValue<C::ScalarExt>>>,
-        challenges: Vec<AssignedValue<C::ScalarExt>>,
+        instances: Vec<Vec<AssignedValue<C::Base>>>,
+        challenges: Vec<AssignedValue<C::Base>>,
     }
 
     impl<C: CurveAffine> AssignedPlonkInstance<C> {
-        pub fn assign(_pi: PlonkInstance<C>) -> Result<Self, Error> {
-            todo!()
+        pub fn assign<const T: usize>(
+            region: &mut RegionCtx<C::Base>,
+            main_gate_config: MainGateConfig<T>,
+            pi: PlonkInstance<C>,
+        ) -> Result<Self, Error> {
+            let PlonkInstance {
+                W_commitments,
+                instances,
+                challenges,
+            } = pi;
+
+            let mut assigner = main_gate_config.advice_cycle_assigner();
+
+            let W_commitments = W_commitments
+                .iter()
+                .enumerate()
+                .map(|(i, W_commitment)| {
+                    assigner.assign_next_advice_point(
+                        region,
+                        || format!("W_commitments[{i}]"),
+                        W_commitment,
+                    )
+                })
+                .collect::<Result<Vec<_>, _>>();
+
+            let instances = instances
+                .iter()
+                .map(|instance| {
+                    assigner.assign_all_advice(
+                        region,
+                        || "instance",
+                        instance.iter().map(|i| C::scalar_to_base(i).unwrap()),
+                    )
+                })
+                .collect::<Result<Vec<_>, _>>();
+
+            let challenges = assigner.assign_all_advice(
+                region,
+                || "challenges",
+                challenges.iter().map(|i| C::scalar_to_base(i).unwrap()),
+            );
+
+            let map_err = |err| Error::Assign {
+                annotation: "PlonkInstance",
+                err,
+            };
+
+            Ok(Self {
+                W_commitments: W_commitments.map_err(map_err)?,
+                instances: instances.map_err(map_err)?,
+                challenges: challenges.map_err(map_err)?,
+            })
         }
     }
 
     /// Assigned version of [`crate::nifs::protogalaxy::accumulator::AccumulatorInstance`]
     pub struct AssignedAccumulatorInstance<C: CurveAffine> {
         ins: AssignedPlonkInstance<C>,
-        betas: Box<[AssignedValue<C::ScalarExt>]>,
-        e: AssignedValue<C::ScalarExt>,
+        betas: Box<[AssignedValue<C::Base>]>,
+        e: AssignedValue<C::Base>,
     }
 
     impl<C: CurveAffine> AssignedAccumulatorInstance<C> {
-        pub fn assign(_acc: protogalaxy::AccumulatorInstance<C>) -> Result<Self, Error> {
-            todo!()
+        pub fn assign<const T: usize>(
+            region: &mut RegionCtx<C::Base>,
+            main_gate_config: MainGateConfig<T>,
+            acc: protogalaxy::AccumulatorInstance<C>,
+        ) -> Result<Self, Error> {
+            let protogalaxy::AccumulatorInstance { ins, betas, e } = acc;
+
+            let ins = AssignedPlonkInstance::assign(region, main_gate_config.clone(), ins)?;
+
+            let mut assigner = main_gate_config.advice_cycle_assigner();
+
+            // Convert and assign `betas`
+            let betas = betas
+                .iter()
+                .map(|beta| {
+                    assigner.assign_next_advice(
+                        region,
+                        || "beta",
+                        C::scalar_to_base(beta).unwrap(), // assuming conversion to base field is needed
+                    )
+                })
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|err| Error::Assign {
+                    annotation: "AccumulatorInstance::betas",
+                    err,
+                })?
+                .into_boxed_slice();
+
+            // Convert and assign `e`
+            let e = assigner
+                .assign_next_advice(region, || "e", C::scalar_to_base(&e).unwrap())
+                .map_err(|err| Error::Assign {
+                    annotation: "AccumulatorInstance::e",
+                    err,
+                })?;
+
+            Ok(Self { ins, betas, e })
         }
     }
 
@@ -47,17 +142,65 @@ mod verify_chip {
     }
 
     impl<F: PrimeField> AssignedProof<F> {
-        pub fn assign(_proof: protogalaxy::Proof<F>) -> Result<Self, Error> {
-            todo!()
+        pub fn assign<const T: usize>(
+            region: &mut RegionCtx<F>,
+            main_gate_config: MainGateConfig<T>,
+            proof: protogalaxy::Proof<F>,
+        ) -> Result<Self, Error> {
+            let protogalaxy::Proof { poly_K, poly_F } = proof;
+
+            let mut assigner = main_gate_config.advice_cycle_assigner();
+
+            Ok(Self {
+                poly_F: assigner
+                    .assign_all_advice(region, || "poly_F", poly_F.iter().copied())
+                    .map_err(|err| Error::Assign {
+                        annotation: "proof::poly_F",
+                        err,
+                    })?
+                    .into_boxed_slice(),
+                poly_K: assigner
+                    .assign_all_advice(region, || "poly_K", poly_K.iter().copied())
+                    .map_err(|err| Error::Assign {
+                        annotation: "proof::poly_k",
+                        err,
+                    })?
+                    .into_boxed_slice(),
+            })
+        }
+    }
+
+    pub struct AssignedVerifierParam<C: CurveAffine> {
+        pp_digest: AssignedPoint<C>,
+    }
+
+    impl<C: CurveAffine> AssignedVerifierParam<C> {
+        pub fn assign<const T: usize>(
+            region: &mut RegionCtx<C::Base>,
+            main_gate_config: MainGateConfig<T>,
+            vp: protogalaxy::VerifierParam<C>,
+        ) -> Result<Self, Error> {
+            let protogalaxy::VerifierParam { pp_digest } = vp;
+
+            Ok(Self {
+                pp_digest: main_gate_config
+                    .advice_cycle_assigner::<C::Base>()
+                    .assign_next_advice_point(region, || "pp_digest", &pp_digest)
+                    .map_err(|err| Error::Assign {
+                        annotation: "VerifierParam",
+                        err,
+                    })?,
+            })
         }
     }
 
     /// Assigned version of `fn verify` logic from [`crate::nifs::protogalaxy::ProtoGalaxy`].
-    pub fn verify<C: CurveAffine>(
+    pub fn verify<C: CurveAffine, const L: usize>(
         _region: &mut RegionCtx<C::Base>,
         _ro_circuit: impl ROCircuitTrait<C::ScalarExt>,
+        _vp: protogalaxy::VerifierParam<C>,
         _accumulator: AssignedAccumulatorInstance<C>,
-        _incoming: &[PlonkInstance<C>],
+        _incoming: &[AssignedPlonkInstance<C>],
         _proof: AssignedProof<C::ScalarExt>,
     ) -> Result<AssignedAccumulatorInstance<C>, Error>
     where

--- a/src/ivc/protogalaxy/mod.rs
+++ b/src/ivc/protogalaxy/mod.rs
@@ -1,0 +1,68 @@
+mod verify_chip {
+    use halo2_proofs::halo2curves::{
+        ff::{FromUniformBytes, PrimeField, PrimeFieldBits},
+        CurveAffine,
+    };
+
+    use crate::{
+        gadgets::ecc::AssignedPoint,
+        main_gate::{AssignedValue, RegionCtx},
+        nifs::protogalaxy,
+        plonk::PlonkInstance,
+        poseidon::ROCircuitTrait,
+    };
+
+    #[derive(Debug, thiserror::Error)]
+    pub enum Error {}
+
+    /// Assigned version of [`crate::plonk::PlonkInstance`]
+    pub struct AssignedPlonkInstance<C: CurveAffine> {
+        W_commitments: Vec<AssignedPoint<C>>,
+        instances: Vec<Vec<AssignedValue<C::ScalarExt>>>,
+        challenges: Vec<AssignedValue<C::ScalarExt>>,
+    }
+
+    impl<C: CurveAffine> AssignedPlonkInstance<C> {
+        pub fn assign(_pi: PlonkInstance<C>) -> Result<Self, Error> {
+            todo!()
+        }
+    }
+
+    /// Assigned version of [`crate::nifs::protogalaxy::accumulator::AccumulatorInstance`]
+    pub struct AssignedAccumulatorInstance<C: CurveAffine> {
+        ins: AssignedPlonkInstance<C>,
+        betas: Box<[AssignedValue<C::ScalarExt>]>,
+        e: AssignedValue<C::ScalarExt>,
+    }
+
+    impl<C: CurveAffine> AssignedAccumulatorInstance<C> {
+        pub fn assign(_acc: protogalaxy::AccumulatorInstance<C>) -> Result<Self, Error> {
+            todo!()
+        }
+    }
+
+    pub struct AssignedProof<F: PrimeField> {
+        poly_F: Box<[AssignedValue<F>]>,
+        poly_K: Box<[AssignedValue<F>]>,
+    }
+
+    impl<F: PrimeField> AssignedProof<F> {
+        pub fn assign(_proof: protogalaxy::Proof<F>) -> Result<Self, Error> {
+            todo!()
+        }
+    }
+
+    /// Assigned version of `fn verify` logic from [`crate::nifs::protogalaxy::ProtoGalaxy`].
+    pub fn verify<C: CurveAffine>(
+        _region: &mut RegionCtx<C::Base>,
+        _ro_circuit: impl ROCircuitTrait<C::ScalarExt>,
+        _accumulator: AssignedAccumulatorInstance<C>,
+        _incoming: &[PlonkInstance<C>],
+        _proof: AssignedProof<C::ScalarExt>,
+    ) -> Result<AssignedAccumulatorInstance<C>, Error>
+    where
+        C::ScalarExt: FromUniformBytes<64> + PrimeFieldBits,
+    {
+        todo!()
+    }
+}

--- a/src/nifs/protogalaxy/accumulator.rs
+++ b/src/nifs/protogalaxy/accumulator.rs
@@ -56,15 +56,15 @@ impl<C: CurveAffine> Accumulator<C> {
 pub struct AccumulatorInstance<C: CurveAffine> {
     /// `φ`: Represents the combined state of all instances. It is a summary that captures the
     /// essential data and relationships from the instances being merged.
-    pub(super) ins: PlonkInstance<C>,
+    pub(crate) ins: PlonkInstance<C>,
 
     /// `β`: A random value used in the folding process. It helps ensure the unique
     /// and secure combination of instances, preventing manipulation.
-    pub(super) betas: Box<[C::ScalarExt]>,
+    pub(crate) betas: Box<[C::ScalarExt]>,
 
     /// `e`: an accumulated value that encapsulates the result of the folding operation. it serves
     /// as a concise representation of the correctness and properties of the folded instances.
-    pub(super) e: C::ScalarExt,
+    pub(crate) e: C::ScalarExt,
 }
 
 impl<C: CurveAffine> AccumulatorInstance<C> {

--- a/src/nifs/protogalaxy/mod.rs
+++ b/src/nifs/protogalaxy/mod.rs
@@ -199,7 +199,7 @@ pub struct ProverParam<C: CurveAffine> {
 
 pub struct VerifierParam<C: CurveAffine> {
     /// Digest of public parameter of IVC circuit
-    pp_digest: C,
+    pub(crate) pp_digest: C,
 }
 
 pub struct Proof<F: PrimeField> {

--- a/src/nifs/protogalaxy/mod.rs
+++ b/src/nifs/protogalaxy/mod.rs
@@ -3,7 +3,6 @@ use std::{iter, marker::PhantomData};
 use itertools::Itertools;
 use tracing::{instrument, warn};
 
-use self::accumulator::AccumulatorInstance;
 use super::*;
 use crate::{
     commitment::CommitmentKey,
@@ -21,7 +20,7 @@ use crate::{
 mod accumulator;
 pub(crate) mod poly;
 
-pub use accumulator::{Accumulator, AccumulatorArgs};
+pub use accumulator::{Accumulator, AccumulatorArgs, AccumulatorInstance};
 
 /// ProtoGalaxy: Non-Interactive Folding Scheme that implements the main protocol defined in the
 /// paper [protogalaxy.pdf](https://eprint.iacr.org/2023/1106).
@@ -203,7 +202,7 @@ pub struct VerifierParam<C: CurveAffine> {
     pp_digest: C,
 }
 
-pub struct ProtoGalaxyProof<F: PrimeField> {
+pub struct Proof<F: PrimeField> {
     pub poly_F: UnivariatePoly<F>,
     pub poly_K: UnivariatePoly<F>,
 }
@@ -226,7 +225,7 @@ impl<C: CurveAffine, const L: usize> FoldingScheme<C, L> for ProtoGalaxy<C, L> {
     type Instance = PlonkInstance<C>;
     type Accumulator = Accumulator<C>;
     type AccumulatorInstance = AccumulatorInstance<C>;
-    type Proof = ProtoGalaxyProof<C::ScalarExt>;
+    type Proof = Proof<C::ScalarExt>;
 
     fn setup_params(
         pp_digest: C,
@@ -352,7 +351,7 @@ impl<C: CurveAffine, const L: usize> FoldingScheme<C, L> for ProtoGalaxy<C, L> {
                     ),
                 },
             },
-            ProtoGalaxyProof { poly_F, poly_K },
+            Proof { poly_F, poly_K },
         ))
     }
 


### PR DESCRIPTION
**Motivation**
First part of #361

**Overview**
Implemented `ivc::protogalaxy::verify_chip` module blank and signature of the verification fn, together with assignment logic
