### PR TITLE
feat(ivc): generate assigned challanges

### DIFF
--- a/src/nifs/protogalaxy/mod.rs
+++ b/src/nifs/protogalaxy/mod.rs
@@ -6,7 +6,7 @@ use tracing::{debug, instrument, warn};
 use super::*;
 use crate::{
     commitment::CommitmentKey,
-    constants::{MAX_BITS, NUM_CHALLENGE_BITS},
+    constants::MAX_BITS,
     ff::PrimeField,
     halo2_proofs::arithmetic::{self, CurveAffine, Field},
     nifs::protogalaxy::poly::PolyContext,
@@ -358,7 +358,7 @@ impl<C: CurveAffine, const L: usize> FoldingScheme<C, L> for ProtoGalaxy<C, L> {
 
         let alpha = ro_acc
             .absorb_field_iter(poly_F.iter().map(|v| C::scalar_to_base(v).unwrap()))
-            .squeeze::<C>(NUM_CHALLENGE_BITS);
+            .squeeze::<C>(MAX_BITS);
 
         let betas_stroke = poly::PolyChallenges {
             betas: accumulator.betas.clone(),
@@ -378,7 +378,7 @@ impl<C: CurveAffine, const L: usize> FoldingScheme<C, L> for ProtoGalaxy<C, L> {
 
         let gamma = ro_acc
             .absorb_field_iter(poly_K.iter().map(|v| C::scalar_to_base(v).unwrap()))
-            .squeeze::<C>(NUM_CHALLENGE_BITS);
+            .squeeze::<C>(MAX_BITS);
 
         debug!(
             "

--- a/src/nifs/protogalaxy/tests.rs
+++ b/src/nifs/protogalaxy/tests.rs
@@ -167,10 +167,7 @@ impl<C: Circuit<Scalar>> Mock<C> {
 
         let accumulator_inst_from_prove = AccumulatorInstance::from(accumulator_from_prove);
 
-        assert_eq!(
-            accumulator_inst_from_prove,
-            accumulator_from_verify,
-        );
+        assert_eq!(accumulator_inst_from_prove, accumulator_from_verify,);
     }
 }
 

--- a/src/nifs/protogalaxy/tests.rs
+++ b/src/nifs/protogalaxy/tests.rs
@@ -168,11 +168,9 @@ impl<C: Circuit<Scalar>> Mock<C> {
         let accumulator_inst_from_prove = AccumulatorInstance::from(accumulator_from_prove);
 
         assert_eq!(
-            accumulator_inst_from_prove.betas,
-            accumulator_from_verify.betas,
+            accumulator_inst_from_prove,
+            accumulator_from_verify,
         );
-        assert_eq!(accumulator_inst_from_prove.e, accumulator_from_verify.e,);
-        assert_eq!(accumulator_inst_from_prove.ins, accumulator_from_verify.ins);
     }
 }
 

--- a/src/polynomial/univariate.rs
+++ b/src/polynomial/univariate.rs
@@ -6,7 +6,7 @@ use std::{
 
 use halo2_proofs::halo2curves::ff::{PrimeField, WithSmallOrderMulGroup};
 
-use crate::{ff::Field, fft};
+use crate::{ff::Field, fft, util};
 
 /// Represents a univariate polynomial
 ///
@@ -153,6 +153,14 @@ impl<F: PrimeField> UnivariatePoly<F> {
     pub fn ifft(mut input: Box<[F]>) -> Self {
         fft::ifft(&mut input);
         Self(input)
+    }
+
+    pub fn fe_to_fe<F2: PrimeField>(&self) -> Option<UnivariatePoly<F2>> {
+        self.0
+            .iter()
+            .map(|coeff| util::fe_to_fe(coeff))
+            .collect::<Option<Box<[_]>>>()
+            .map(UnivariatePoly)
     }
 }
 

--- a/src/poseidon/poseidon_circuit.rs
+++ b/src/poseidon/poseidon_circuit.rs
@@ -71,6 +71,10 @@ impl<F: PrimeFieldBits + FromUniformBytes<64>, const T: usize, const RATE: usize
             Ok(res)
         }
     }
+
+    fn squeeze(&mut self, ctx: &mut RegionCtx<'_, F>) -> Result<AssignedValue<F>, Error> {
+        self.squeeze(ctx)
+    }
 }
 
 impl<F: PrimeField + PrimeFieldBits, const T: usize, const RATE: usize> PoseidonChip<F, T, RATE> {

--- a/src/poseidon/poseidon_hash.rs
+++ b/src/poseidon/poseidon_hash.rs
@@ -1,4 +1,4 @@
-use std::{iter, mem, num::NonZeroUsize};
+use std::{iter, num::NonZeroUsize};
 
 use halo2_proofs::{arithmetic::CurveAffine, halo2curves::ff::PrimeFieldBits};
 use poseidon::{self, SparseMDSMatrix};
@@ -180,7 +180,8 @@ where
     }
 
     pub fn output<F1: PrimeField>(&mut self, num_bits: NonZeroUsize) -> F1 {
-        let buf = mem::take(&mut self.buf);
+        let buf = self.buf.clone();
+
         debug!("Off circuit input of hash: {buf:?}");
 
         let exact = buf.len() % RATE == 0;
@@ -193,6 +194,8 @@ where
         }
 
         let output = self.state.inner[1];
+        self.state = State::new(poseidon::State::default().words());
+
         let mut bits = fe_to_bits_le(&output);
         if bits.len() < num_bits.get() {
             bits.resize(num_bits.get(), false);

--- a/src/poseidon/random_oracle.rs
+++ b/src/poseidon/random_oracle.rs
@@ -4,7 +4,7 @@ use halo2_proofs::{arithmetic::CurveAffine, plonk::Error};
 
 use crate::{
     ff::{FromUniformBytes, PrimeField, PrimeFieldBits},
-    main_gate::{AssignedBit, RegionCtx, WrapValue},
+    main_gate::{AssignedBit, AssignedValue, RegionCtx, WrapValue},
 };
 
 /// A helper trait to obsorb different objects into RO
@@ -119,6 +119,9 @@ pub trait ROCircuitTrait<F: PrimeFieldBits + FromUniformBytes<64>> {
         ctx: &mut RegionCtx<'_, F>,
         num_bits: NonZeroUsize,
     ) -> Result<Vec<AssignedBit<F>>, Error>;
+
+    /// Returns a challenge of `num_bits` by hashing the internal state
+    fn squeeze(&mut self, ctx: &mut RegionCtx<'_, F>) -> Result<AssignedValue<F>, Error>;
 }
 
 /// Random Oracle is represented as a pair of on-circuit & off-circuit types,


### PR DESCRIPTION
**Motivation**
Part of #361

**Overview**
- Implementation of the same generation challanges as in `nifs::protogalaxy` mod
- Consistency test added for challenges generation at {on,off}-circuit env
- Corrected the number of bits generated for challenges (`MAX_BITS` will now be used)

**Fix poseidon off-circuit hash**
Previously, a successive on-circuit poseidon circuit call would cause the old buffer to be reused and the exact same successive off-circuit call would not reuse the previous buffer. Now the behavior has been brought to a uniform standard.