### PR TITLE
feat(ivc): impl tiny-gate-ecc

### DIFF
--- a/src/gadgets/util.rs
+++ b/src/gadgets/util.rs
@@ -63,13 +63,12 @@ impl<F: PrimeField, const T: usize> MainGate<F, T> {
         ctx: &mut RegionCtx<'_, F>,
         a: AssignedValue<F>,
     ) -> Result<(AssignedValue<F>, AssignedValue<F>), Error> {
-        let (one, zero) = (F::ONE, F::ZERO);
         let (r, a_inv) = a
             .value()
             .map(|a| {
                 Option::from(a.invert())
-                    .map(|a_inverted| (zero, a_inverted))
-                    .unwrap_or_else(|| (one, one))
+                    .map(|a_inverted| (F::ZERO, a_inverted))
+                    .unwrap_or_else(|| (F::ONE, F::ONE))
             })
             .unzip();
 

--- a/src/ivc/cyclefold/support_circuit/tiny_gate.rs
+++ b/src/ivc/cyclefold/support_circuit/tiny_gate.rs
@@ -87,11 +87,11 @@ impl<F: PrimeField> Gate<F> {
             ..
         } = self.config();
 
-        ctx.assign_fixed(|| "", *mul, F::ONE)?;
-        let l = ctx.assign_advice_from(|| "", *state0, lhs)?;
-        let r = ctx.assign_advice_from(|| "", *state1, rhs)?;
+        ctx.assign_fixed(|| "one", *mul, F::ONE)?;
+        let l = ctx.assign_advice_from(|| "mul.lhs", *state0, lhs)?;
+        let r = ctx.assign_advice_from(|| "mul.rhs", *state1, rhs)?;
 
-        let res = ctx.assign_advice(|| "", *output, l.value().copied() * r.value());
+        let res = ctx.assign_advice(|| "mul.out", *output, l.value().copied() * r.value());
 
         ctx.next();
 
@@ -113,12 +113,16 @@ impl<F: PrimeField> Gate<F> {
             ..
         } = self.config();
 
-        ctx.assign_fixed(|| "", *sum0, *lhs_coeff)?;
+        ctx.assign_fixed(|| "add_with_const.lhs_coeff", *sum0, *lhs_coeff)?;
 
-        let l = ctx.assign_advice_from(|| "", *state0, lhs)?;
-        let r = ctx.assign_fixed(|| "", *rc, *rhs)?;
+        let l = ctx.assign_advice_from(|| "add_with_const.lhs", *state0, lhs)?;
+        let r = ctx.assign_fixed(|| "add_with_const.rc", *rc, *rhs)?;
 
-        let res = ctx.assign_advice(|| "", *output, l.value().copied() + r.value());
+        let res = ctx.assign_advice(
+            || "add_with_const.out",
+            *output,
+            l.value().copied() + r.value(),
+        );
 
         ctx.next();
 
@@ -138,13 +142,13 @@ impl<F: PrimeField> Gate<F> {
             ..
         } = self.config();
 
-        ctx.assign_fixed(|| "", *sum0, F::ONE)?;
-        ctx.assign_fixed(|| "", *sum1, F::ONE)?;
+        ctx.assign_fixed(|| "add.sum0", *sum0, F::ONE)?;
+        ctx.assign_fixed(|| "add.sum1", *sum1, F::ONE)?;
 
-        let l = ctx.assign_advice_from(|| "", *state0, lhs)?;
-        let r = ctx.assign_advice_from(|| "", *state1, rhs)?;
+        let l = ctx.assign_advice_from(|| "add.lhs", *state0, lhs)?;
+        let r = ctx.assign_advice_from(|| "add.rhs", *state1, rhs)?;
 
-        let res = ctx.assign_advice(|| "", *output, l.value().copied() + r.value());
+        let res = ctx.assign_advice(|| "add.out", *output, l.value().copied() + r.value());
 
         ctx.next();
 
@@ -164,13 +168,13 @@ impl<F: PrimeField> Gate<F> {
             ..
         } = self.config();
 
-        ctx.assign_fixed(|| "", *sum0, F::ONE)?;
-        ctx.assign_fixed(|| "", *sum1, -F::ONE)?;
+        ctx.assign_fixed(|| "sub.sum0", *sum0, F::ONE)?;
+        ctx.assign_fixed(|| "sub.sum1", *sum1, -F::ONE)?;
 
-        let l = ctx.assign_advice_from(|| "", *state0, lhs)?;
-        let r = ctx.assign_advice_from(|| "", *state1, rhs)?;
+        let l = ctx.assign_advice_from(|| "sub.lhs", *state0, lhs)?;
+        let r = ctx.assign_advice_from(|| "sub.rhs", *state1, rhs)?;
 
-        let res = ctx.assign_advice(|| "", *output, l.value().copied() + r.value());
+        let res = ctx.assign_advice(|| "sub.out", *output, l.value().copied() + r.value());
 
         ctx.next();
 
@@ -188,8 +192,8 @@ impl<F: PrimeField> Gate<F> {
             ..
         } = self.config();
 
-        ctx.assign_advice_from(|| "", *state0, value)?;
-        ctx.assign_fixed(|| "", *sum0, F::ONE)?;
+        ctx.assign_advice_from(|| "check_zero.state0", *state0, value)?;
+        ctx.assign_fixed(|| "check_zero.sum0", *sum0, F::ONE)?;
 
         ctx.next();
 
@@ -215,7 +219,7 @@ impl<F: PrimeField> Gate<F> {
         let mut result = Vec::with_capacity(values.len());
         for chunk in values.chunks(advice.len()) {
             for (value, col) in chunk.iter().zip(advice.iter()) {
-                result.push(ctx.assign_advice_from(|| "", *col, value.clone())?);
+                result.push(ctx.assign_advice_from(|| "assign_value.val", *col, value.clone())?);
             }
             ctx.next();
         }

--- a/src/ivc/cyclefold/support_circuit/tiny_gate.rs
+++ b/src/ivc/cyclefold/support_circuit/tiny_gate.rs
@@ -9,19 +9,19 @@ use crate::{
         halo2curves::{ff::PrimeField, CurveAffine},
         plonk::{Advice, Column, Error as Halo2PlonkError, Fixed},
     },
-    main_gate::{AssignedValue, RegionCtx},
+    main_gate::{AssignAdviceFrom, AssignedValue, RegionCtx},
 };
 
 #[derive(Clone, Debug)]
-struct Config {
+pub struct Config {
     state: [Column<Advice>; 2],
     mul: Column<Fixed>,
     sum: [Column<Fixed>; 2],
     output: Column<Advice>,
-    output_coeff: Column<Fixed>,
+    rc: Column<Fixed>,
 }
 
-struct Gate<F: PrimeField> {
+pub struct Gate<F: PrimeField> {
     config: Config,
     _p: PhantomData<F>,
 }
@@ -41,29 +41,32 @@ impl<F: PrimeField> Gate<F> {
                 meta.enable_equality(c);
                 c
             },
-            output_coeff: meta.fixed_column(),
+            rc: meta.fixed_column(),
         };
 
         meta.create_gate(
-            "s[0] * s[1] * mul + s[0] * sum[0] + s[1] * sum[1] - output = 0",
+            "s[0] * s[1] * mul + s[0] * sum[0] + s[1] * sum[1] + rc - output = 0",
             |meta| {
                 let Config {
                     state,
                     mul,
                     sum,
                     output,
-                    output_coeff,
+                    rc,
                 } = config.clone();
 
                 let [state0, state1] = state.map(|c| meta.query_advice(c, Rotation::cur()));
                 let mul = meta.query_fixed(mul, Rotation::cur());
                 let [sum0, sum1] = sum.map(|c| meta.query_fixed(c, Rotation::cur()));
                 let output = meta.query_advice(output, Rotation::cur());
-                let output_coeff = meta.query_fixed(output_coeff, Rotation::cur());
+                let rc = meta.query_fixed(rc, Rotation::cur());
 
                 [
-                    (state0.clone() * state1.clone() * mul) + (state0 * sum0) + (state1 * sum1)
-                        - (output * output_coeff),
+                    (state0.clone() * state1.clone() * mul)
+                        + (state0 * sum0)
+                        + (state1 * sum1)
+                        + rc
+                        - output,
                 ]
             },
         );
@@ -71,17 +74,16 @@ impl<F: PrimeField> Gate<F> {
         config
     }
 
-    fn mul(
+    fn mul<'a>(
         &self,
-        ctx: &mut RegionCtx<'_, F>,
-        lhs: &AssignedValue<F>,
-        rhs: &AssignedValue<F>,
+        ctx: &mut RegionCtx<'a, F>,
+        lhs: impl AssignAdviceFrom<'a, F>,
+        rhs: impl AssignAdviceFrom<'a, F>,
     ) -> Result<AssignedValue<F>, Halo2PlonkError> {
         let Config {
             state: [state0, state1],
             mul,
             output,
-            output_coeff,
             ..
         } = self.config();
 
@@ -89,8 +91,34 @@ impl<F: PrimeField> Gate<F> {
         let l = ctx.assign_advice_from(|| "", *state0, lhs)?;
         let r = ctx.assign_advice_from(|| "", *state1, rhs)?;
 
-        ctx.assign_fixed(|| "", *output_coeff, -F::ONE)?;
         let res = ctx.assign_advice(|| "", *output, l.value().copied() * r.value());
+
+        ctx.next();
+
+        res
+    }
+
+    fn add_with_const(
+        &self,
+        ctx: &mut RegionCtx<'_, F>,
+        lhs: &AssignedValue<F>,
+        lhs_coeff: &F,
+        rhs: &F,
+    ) -> Result<AssignedValue<F>, Halo2PlonkError> {
+        let Config {
+            state: [state0, _],
+            sum: [sum0, _],
+            output,
+            rc,
+            ..
+        } = self.config();
+
+        ctx.assign_fixed(|| "", *sum0, *lhs_coeff)?;
+
+        let l = ctx.assign_advice_from(|| "", *state0, lhs)?;
+        let r = ctx.assign_fixed(|| "", *rc, *rhs)?;
+
+        let res = ctx.assign_advice(|| "", *output, l.value().copied() + r.value());
 
         ctx.next();
 
@@ -107,7 +135,6 @@ impl<F: PrimeField> Gate<F> {
             state: [state0, state1],
             sum: [sum0, sum1],
             output,
-            output_coeff,
             ..
         } = self.config();
 
@@ -117,12 +144,172 @@ impl<F: PrimeField> Gate<F> {
         let l = ctx.assign_advice_from(|| "", *state0, lhs)?;
         let r = ctx.assign_advice_from(|| "", *state1, rhs)?;
 
-        ctx.assign_fixed(|| "", *output_coeff, -F::ONE)?;
         let res = ctx.assign_advice(|| "", *output, l.value().copied() + r.value());
 
         ctx.next();
 
         res
+    }
+
+    fn sub(
+        &self,
+        ctx: &mut RegionCtx<'_, F>,
+        lhs: &AssignedValue<F>,
+        rhs: &AssignedValue<F>,
+    ) -> Result<AssignedValue<F>, Halo2PlonkError> {
+        let Config {
+            state: [state0, state1],
+            sum: [sum0, sum1],
+            output,
+            ..
+        } = self.config();
+
+        ctx.assign_fixed(|| "", *sum0, F::ONE)?;
+        ctx.assign_fixed(|| "", *sum1, -F::ONE)?;
+
+        let l = ctx.assign_advice_from(|| "", *state0, lhs)?;
+        let r = ctx.assign_advice_from(|| "", *state1, rhs)?;
+
+        let res = ctx.assign_advice(|| "", *output, l.value().copied() + r.value());
+
+        ctx.next();
+
+        res
+    }
+
+    fn check_zero(
+        &self,
+        ctx: &mut RegionCtx<'_, F>,
+        value: &AssignedValue<F>,
+    ) -> Result<(), Halo2PlonkError> {
+        let Config {
+            state: [state0, ..],
+            sum: [sum0, ..],
+            ..
+        } = self.config();
+
+        ctx.assign_advice_from(|| "", *state0, value)?;
+        ctx.assign_fixed(|| "", *sum0, F::ONE)?;
+
+        ctx.next();
+
+        Ok(())
+    }
+
+    fn is_zero(
+        &self,
+        ctx: &mut RegionCtx<'_, F>,
+        value: &AssignedValue<F>,
+    ) -> Result<AssignedValue<F>, Halo2PlonkError> {
+        Ok(self.invert_with_flag(ctx, value)?.0)
+    }
+
+    fn assign_values<'a, const L: usize>(
+        &self,
+        ctx: &mut RegionCtx<'a, F>,
+        values: &[impl Clone + AssignAdviceFrom<'a, F>; L],
+    ) -> Result<[AssignedValue<F>; L], Halo2PlonkError> {
+        let mut advice = self.config().state.to_vec();
+        advice.push(self.config().output);
+
+        let mut result = Vec::with_capacity(values.len());
+        for chunk in values.chunks(advice.len()) {
+            for (value, col) in chunk.iter().zip(advice.iter()) {
+                result.push(ctx.assign_advice_from(|| "", *col, value.clone())?);
+            }
+            ctx.next();
+        }
+
+        Ok(result.try_into().unwrap())
+    }
+
+    fn assign_bit<'a>(
+        &self,
+        ctx: &mut RegionCtx<'a, F>,
+        a: impl AssignAdviceFrom<'a, F>,
+    ) -> Result<AssignedValue<F>, Halo2PlonkError> {
+        let Config {
+            state: [state0, state1],
+            mul,
+            output,
+            ..
+        } = self.config();
+
+        // s0*s1 - out = 0
+        let a = ctx.assign_advice_from(|| "bit", *state0, a)?;
+        ctx.assign_advice_from(|| "bit", *state1, &a)?;
+        ctx.assign_fixed(|| "one", *mul, F::ONE)?;
+
+        let out = ctx.assign_advice_from(|| "bit", *output, &a)?;
+
+        ctx.next();
+        Ok(out)
+    }
+
+    fn invert_with_flag(
+        &self,
+        ctx: &mut RegionCtx<'_, F>,
+        a: &AssignedValue<F>,
+    ) -> Result<(AssignedValue<F>, AssignedValue<F>), Halo2PlonkError> {
+        let a_inv = a.value().unwrap().and_then(|v| v.invert().into());
+
+        let is_zero = self.assign_bit(ctx, if a_inv.is_some() { F::ZERO } else { F::ONE })?;
+        let [a_inv] = self.assign_values(ctx, &[a_inv.unwrap_or(F::ONE)])?;
+
+        // a * a' = 1 - r
+        let left = self.mul(ctx, a, &a_inv)?.cell();
+        let right = self
+            .add_with_const(ctx, &is_zero, &-F::ONE, &F::ONE)?
+            .cell();
+        ctx.constrain_equal(left, right)?;
+
+        // r * a' = r
+        let left = self.mul(ctx, &is_zero, &a_inv)?.cell();
+        ctx.constrain_equal(left, is_zero.cell())?;
+
+        Ok((is_zero, a_inv))
+    }
+
+    pub fn divide(
+        &self,
+        ctx: &mut RegionCtx<'_, F>,
+        a: &AssignedValue<F>,
+        b: &AssignedValue<F>,
+    ) -> Result<AssignedValue<F>, Halo2PlonkError> {
+        let (is_zero, b_inv) = self.invert_with_flag(ctx, &b.clone())?;
+        self.check_zero(ctx, &is_zero)?;
+        self.mul(ctx, a, &b_inv)
+    }
+
+    pub fn square(
+        &self,
+        ctx: &mut RegionCtx<'_, F>,
+        a: &AssignedValue<F>,
+    ) -> Result<AssignedValue<F>, Halo2PlonkError> {
+        self.mul(ctx, a, a)
+    }
+
+    pub fn mul_with_const(
+        &self,
+        ctx: &mut RegionCtx<'_, F>,
+        lhs: &AssignedValue<F>,
+        rhs: F,
+    ) -> Result<AssignedValue<F>, Halo2PlonkError> {
+        let Config {
+            state: [state0, ..],
+            sum: [sum0, ..],
+            output,
+            ..
+        } = self.config();
+
+        // s0*s1 - out = 0
+        let a = ctx.assign_advice_from(|| "bit", *state0, lhs)?;
+        ctx.assign_fixed(|| "one", *sum0, rhs)?;
+
+        let out = ctx.assign_advice(|| "bit", *output, a.value().copied() * Value::known(rhs))?;
+
+        ctx.next();
+        Ok(out)
     }
 }
 
@@ -158,17 +345,10 @@ impl<F: PrimeField> EccGate<F> for Gate<F> {
             None => (Value::unknown(), Value::unknown()),
         };
 
-        let x = ctx.assign_advice(
-            || format!("{}.x", annotation().into()),
-            self.config().state[0],
-            x,
-        )?;
+        let [state0, state1] = self.config().state;
 
-        let y = ctx.assign_advice(
-            || format!("{}.y", annotation().into()),
-            self.config().state[1],
-            y,
-        )?;
+        let x = ctx.assign_advice(|| format!("{}.x", annotation().into()), state0, x)?;
+        let y = ctx.assign_advice(|| format!("{}.y", annotation().into()), state1, y)?;
 
         ctx.next();
 
@@ -183,25 +363,7 @@ impl<F: PrimeField> EccGate<F> for Gate<F> {
         condition: &AssignedValue<F>,
     ) -> Result<AssignedValue<F>, Halo2PlonkError> {
         // 1 - condition
-        let one_sub_cond = {
-            let Config {
-                state: [state0, state1],
-                sum: [sum0, sum1],
-                output,
-                output_coeff,
-                ..
-            } = self.config();
-
-            ctx.assign_fixed(|| "", *sum0, -F::ONE)?;
-            ctx.assign_fixed(|| "", *sum1, F::ONE)?;
-            ctx.assign_fixed(|| "", *output_coeff, -F::ONE)?;
-
-            ctx.assign_advice_from(|| "", *state0, condition)?;
-            ctx.assign_advice(|| "", *state1, Value::known(F::ONE))?;
-
-            ctx.assign_advice(|| "", *output, Value::known(F::ONE) - condition.value())?
-        };
-        ctx.next();
+        let one_sub_cond = self.add_with_const(ctx, condition, &-F::ONE, &F::ONE)?;
 
         // rhs * (1 - condition)
         let rhs_mul_mcond = self.mul(ctx, rhs, &one_sub_cond)?;
@@ -213,44 +375,78 @@ impl<F: PrimeField> EccGate<F> for Gate<F> {
 
     fn is_infinity_point(
         &self,
-        _ctx: &mut RegionCtx<'_, F>,
-        _x: &AssignedValue<F>,
-        _y: &AssignedValue<F>,
+        ctx: &mut RegionCtx<'_, F>,
+        x: &AssignedValue<F>,
+        y: &AssignedValue<F>,
     ) -> Result<AssignedValue<F>, Halo2PlonkError> {
-        todo!()
+        let is_x_zero = self.is_zero(ctx, x)?;
+        let is_y_zero = self.is_zero(ctx, y)?;
+        self.mul(ctx, is_x_zero, is_y_zero)
     }
 
     fn is_equal_term(
         &self,
-        _ctx: &mut RegionCtx<'_, F>,
-        _a: &AssignedValue<F>,
-        _b: &AssignedValue<F>,
+        ctx: &mut RegionCtx<'_, F>,
+        a: &AssignedValue<F>,
+        b: &AssignedValue<F>,
     ) -> Result<AssignedValue<F>, Halo2PlonkError> {
-        todo!()
+        let diff = self.sub(ctx, a, b)?;
+        self.is_zero(ctx, &diff)
     }
 
-    unsafe fn unchecked_add<C: halo2_proofs::halo2curves::CurveAffine<Base = F>>(
+    /// # Safety
+    /// The proof will be invalid if `p.x` & `q.x` not equal
+    unsafe fn unchecked_add<C: CurveAffine<Base = F>>(
         &self,
-        _ctx: &mut RegionCtx<'_, C::Base>,
-        _p: &AssignedPoint<C>,
-        _q: &AssignedPoint<C>,
+        ctx: &mut RegionCtx<'_, C::Base>,
+        p: &AssignedPoint<C>,
+        q: &AssignedPoint<C>,
     ) -> Result<AssignedPoint<C>, Halo2PlonkError> {
-        todo!()
+        let yd = self.sub(ctx, &p.y, &q.y)?;
+        let xd = self.sub(ctx, &p.x, &q.x)?;
+        let lambda = self.divide(ctx, &yd, &xd)?;
+        let lambda2 = self.square(ctx, &lambda)?;
+        let tmp1 = self.sub(ctx, &lambda2, &p.x)?;
+        let xr = self.sub(ctx, &tmp1, &q.x)?;
+        let tmp2 = self.sub(ctx, &p.x, &xr)?;
+        let tmp3 = self.mul(ctx, &lambda, &tmp2)?;
+        let yr = self.sub(ctx, &tmp3, &p.y)?;
+        Ok(AssignedPoint { x: xr, y: yr })
     }
 
-    unsafe fn unchecked_double<C: halo2_proofs::halo2curves::CurveAffine<Base = F>>(
+    // assume a = 0 in weierstrass curve y^2 = x^3 + ax + b
+    //
+    // # Safety:
+    // The proof will be invalid if `p.y == 0`.
+    unsafe fn unchecked_double<C: CurveAffine<Base = F>>(
         &self,
-        _ctx: &mut RegionCtx<'_, C::Base>,
-        _p: &AssignedPoint<C>,
+        ctx: &mut RegionCtx<'_, C::Base>,
+        p: &AssignedPoint<C>,
     ) -> Result<AssignedPoint<C>, Halo2PlonkError> {
-        todo!()
+        let xp2 = self.square(ctx, &p.x)?;
+        let lnum = self.mul_with_const(ctx, &xp2, C::Base::from(3))?;
+        let lden = self.add(ctx, &p.y, &p.y)?;
+        let lambda = self.divide(ctx, &lnum, &lden)?;
+        let lambda2 = self.square(ctx, &lambda)?;
+
+        let tmp1 = self.sub(ctx, &lambda2, &p.x)?;
+        let xr = self.sub(ctx, &tmp1, &p.x)?;
+        let tmp2 = self.sub(ctx, &p.x, &xr)?;
+        let tmp3 = self.mul(ctx, &lambda, &tmp2)?;
+        let yr = self.sub(ctx, &tmp3, &p.y)?;
+        Ok(AssignedPoint { x: xr, y: yr })
     }
 
     fn negate<C: CurveAffine<Base = F>>(
         &self,
-        _ctx: &mut RegionCtx<'_, F>,
-        _p: &AssignedPoint<C>,
+        ctx: &mut RegionCtx<'_, F>,
+        p: &AssignedPoint<C>,
     ) -> Result<AssignedPoint<C>, Halo2PlonkError> {
-        todo!()
+        let AssignedPoint { x, y } = p;
+
+        Ok(AssignedPoint {
+            x: x.clone(),
+            y: self.mul_with_const(ctx, y, -F::ONE)?,
+        })
     }
 }


### PR DESCRIPTION
**Motivation**
We need to implement an ecc operations for #371 within the second curve

**Overview**
The logic of ecc-gate based on main-gate is almost completely repeated

The tests will be part of the higher-level logic associated with the ecc-circuit