### PR TITLE
feat(ivc): cyclefold::sfc ro_absorb

### DIFF
--- a/examples/sha256/table16/compression/compression_gates.rs
+++ b/examples/sha256/table16/compression/compression_gates.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::type_complexity)]
+
 use std::marker::PhantomData;
 
 use halo2_proofs::plonk::{Constraint, Constraints, Expression};

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,1 +1,1 @@
-toolchain.channel = "1.82"
+toolchain.channel = "1.83.0"

--- a/src/ivc/consistency_markers_computation.rs
+++ b/src/ivc/consistency_markers_computation.rs
@@ -33,8 +33,8 @@ pub(crate) struct AssignedConsistencyMarkersComputation<
     pub relaxed: &'l AssignedRelaxedPlonkInstance<C>,
 }
 
-impl<'l, const A: usize, const T: usize, C: CurveAffine, RO>
-    AssignedConsistencyMarkersComputation<'l, RO, A, T, C>
+impl<const A: usize, const T: usize, C: CurveAffine, RO>
+    AssignedConsistencyMarkersComputation<'_, RO, A, T, C>
 where
     C::Base: FromUniformBytes<64> + PrimeFieldBits,
     RO: ROCircuitTrait<C::Base, Config = MainGateConfig<T>>,
@@ -80,7 +80,7 @@ where
     pub limbs_count: NonZeroUsize,
 }
 
-impl<'l, C, RP, const A: usize> ConsistencyMarkerComputation<'l, A, C, RP>
+impl<C, RP, const A: usize> ConsistencyMarkerComputation<'_, A, C, RP>
 where
     RP: ROTrait<C::Base>,
     C: CurveAffine + Serialize,
@@ -95,8 +95,8 @@ where
             pub(crate) step_circuit_instances_hash_accumulator: &'l C::ScalarExt,
         }
 
-        impl<'l, C: CurveAffine, RO: ROTrait<C::Base>> AbsorbInRO<C::Base, RO>
-            for RelaxedPlonkInstanceBigUintView<'l, C>
+        impl<C: CurveAffine, RO: ROTrait<C::Base>> AbsorbInRO<C::Base, RO>
+            for RelaxedPlonkInstanceBigUintView<'_, C>
         {
             fn absorb_into(&self, ro: &mut RO) {
                 ro.absorb_point_iter(self.W_commitments.iter())

--- a/src/ivc/cyclefold/sfc/mod.rs
+++ b/src/ivc/cyclefold/sfc/mod.rs
@@ -30,16 +30,16 @@ pub struct StepFoldingCircuit<
     pub input: Input<ARITY, C::ScalarExt>,
 }
 
-impl<'sc, const ARITY: usize, C: CurveAffine, SC: StepCircuit<ARITY, C::ScalarExt>>
-    StepFoldingCircuit<'sc, ARITY, C, SC>
+impl<const ARITY: usize, C: CurveAffine, SC: StepCircuit<ARITY, C::ScalarExt>>
+    StepFoldingCircuit<'_, ARITY, C, SC>
 {
     pub fn instances(&self) -> Vec<Vec<C::ScalarExt>> {
         todo!()
     }
 }
 
-impl<'sc, const ARITY: usize, C: CurveAffine, SC: StepCircuit<ARITY, C::ScalarExt>>
-    Circuit<C::ScalarExt> for StepFoldingCircuit<'sc, ARITY, C, SC>
+impl<const ARITY: usize, C: CurveAffine, SC: StepCircuit<ARITY, C::ScalarExt>> Circuit<C::ScalarExt>
+    for StepFoldingCircuit<'_, ARITY, C, SC>
 {
     type Config = Config<SC::Config>;
     type FloorPlanner = SimpleFloorPlanner;

--- a/src/ivc/protogalaxy/mod.rs
+++ b/src/ivc/protogalaxy/mod.rs
@@ -381,7 +381,7 @@ mod verify_chip {
 
                     assigned_output.map(Some)
                 })?
-                .ok_or_else(|| Halo2PlonkError::Synthesis)
+                .ok_or(Halo2PlonkError::Synthesis)
         }
     }
 

--- a/src/ivc/public_params.rs
+++ b/src/ivc/public_params.rs
@@ -77,8 +77,8 @@ where
     }
 }
 
-impl<'key, const ARITY: usize, const MAIN_GATE_T: usize, C, RP> fmt::Debug
-    for CircuitPublicParams<'key, ARITY, MAIN_GATE_T, C, RP>
+impl<const ARITY: usize, const MAIN_GATE_T: usize, C, RP> fmt::Debug
+    for CircuitPublicParams<'_, ARITY, MAIN_GATE_T, C, RP>
 where
     C: fmt::Debug + CurveAffine,
     C::Base: PrimeFieldBits + FromUniformBytes<64> + Serialize,
@@ -157,18 +157,8 @@ pub struct PublicParams<
     digest_2: C2,
 }
 
-impl<
-        'key,
-        const A1: usize,
-        const A2: usize,
-        const MAIN_GATE_T: usize,
-        C1,
-        C2,
-        SC1,
-        SC2,
-        RP1,
-        RP2,
-    > fmt::Debug for PublicParams<'key, A1, A2, MAIN_GATE_T, C1, C2, SC1, SC2, RP1, RP2>
+impl<const A1: usize, const A2: usize, const MAIN_GATE_T: usize, C1, C2, SC1, SC2, RP1, RP2>
+    fmt::Debug for PublicParams<'_, A1, A2, MAIN_GATE_T, C1, C2, SC1, SC2, RP1, RP2>
 where
     C1: CurveAffine<Base = <C2 as PrimeCurveAffine>::Scalar> + Serialize,
     C2: CurveAffine<Base = <C1 as PrimeCurveAffine>::Scalar> + Serialize,
@@ -417,7 +407,7 @@ where
     secondary_params: &'l StepParams<C2::Scalar, RP2::OnCircuit>,
 }
 
-impl<'l, C1, C2, RP1, RP2> PublicParamsDigestWrapper<'l, C1, C2, RP1, RP2>
+impl<C1, C2, RP1, RP2> PublicParamsDigestWrapper<'_, C1, C2, RP1, RP2>
 where
     C1: CurveAffine<Base = <C2 as PrimeCurveAffine>::Scalar> + Serialize,
     C2: CurveAffine<Base = <C1 as PrimeCurveAffine>::Scalar> + Serialize,

--- a/src/ivc/sangria/step_folding_circuit.rs
+++ b/src/ivc/sangria/step_folding_circuit.rs
@@ -106,7 +106,7 @@ where
     pub step_circuit_instances: Vec<Vec<C::Base>>,
 }
 
-impl<'link, const ARITY: usize, C: fmt::Debug, RO> fmt::Debug for StepInputs<'link, ARITY, C, RO>
+impl<const ARITY: usize, C: fmt::Debug, RO> fmt::Debug for StepInputs<'_, ARITY, C, RO>
 where
     C::Base: PrimeFieldBits + FromUniformBytes<64>,
     C: CurveAffine,
@@ -262,8 +262,7 @@ where
     pub input: StepInputs<'link, ARITY, C, RO>,
 }
 
-impl<'link, const ARITY: usize, C, SC, RO, const T: usize>
-    StepFoldingCircuit<'link, ARITY, C, SC, RO, T>
+impl<const ARITY: usize, C, SC, RO, const T: usize> StepFoldingCircuit<'_, ARITY, C, SC, RO, T>
 where
     C: CurveAffine,
     C::Base: PrimeFieldBits + FromUniformBytes<64>,
@@ -278,8 +277,8 @@ where
     }
 }
 
-impl<'link, const ARITY: usize, C, SC, RO, const T: usize> Circuit<C::Base>
-    for StepFoldingCircuit<'link, ARITY, C, SC, RO, T>
+impl<const ARITY: usize, C, SC, RO, const T: usize> Circuit<C::Base>
+    for StepFoldingCircuit<'_, ARITY, C, SC, RO, T>
 where
     C: CurveAffine,
     C::Base: PrimeFieldBits + FromUniformBytes<64>,

--- a/src/util/mock_prover.rs
+++ b/src/util/mock_prover.rs
@@ -48,8 +48,8 @@ impl<const A: usize, F: PrimeField, SC: StepCircuit<A, F>> Clone for StepCircuit
     }
 }
 
-impl<'sc, const A: usize, F: PrimeField, SC: StepCircuit<A, F>> Circuit<F>
-    for StepCircuitWrapper<'sc, A, F, SC>
+impl<const A: usize, F: PrimeField, SC: StepCircuit<A, F>> Circuit<F>
+    for StepCircuitWrapper<'_, A, F, SC>
 {
     type Config = StepCircuitConfig<A, F, SC>;
     type FloorPlanner = SimpleFloorPlanner;
@@ -133,7 +133,7 @@ pub struct MockProver<'a, const A: usize, F: Field> {
     last_z_out: [Value<F>; A],
 }
 
-impl<'a, const A: usize, F: Field> MockProver<'a, A, F> {
+impl<const A: usize, F: Field> MockProver<'_, A, F> {
     /// Runs the step circuit with the provided initial input and returns
     /// a `MockProver` instance containing the resulting outputs.
     ///

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -404,7 +404,7 @@ impl<'l, F: PrimeField> From<&'l [AssignedValue<F>]> for CellsValuesView<'l, F> 
         Self { cells: value }
     }
 }
-impl<'l, F: PrimeField> fmt::Debug for CellsValuesView<'l, F> {
+impl<F: PrimeField> fmt::Debug for CellsValuesView<'_, F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Cells: [")?;
 


### PR DESCRIPTION
**Motivation**
Within #369 and cyclfold in general we need to count consistency markers, for this we need to be able to absorb sfc::input

**Overview**
Just implementation of `AbsorbInRO` trait for all sfc::input types
