### PR TITLE
feat(ivc): `cyclefold::consistency_marker`

### DIFF
--- a/src/gadgets/ecc/mod.rs
+++ b/src/gadgets/ecc/mod.rs
@@ -371,6 +371,25 @@ pub(crate) mod tests {
         y: C::Base,
         is_inf: bool,
     }
+    impl<C: CurveAffine> From<C> for Point<C> {
+        fn from(value: C) -> Self {
+            let c = value.coordinates().unwrap();
+
+            Self {
+                x: *c.x(),
+                y: *c.y(),
+                is_inf: value.is_identity().into(),
+            }
+        }
+    }
+
+    impl<C: CurveAffine> Point<C> {
+        pub fn into_curve(self) -> C {
+            let Self { x, y, is_inf: _ } = self;
+            C::from_xy(x, y).unwrap()
+        }
+    }
+
     impl<C: CurveAffine> Point<C> {
         fn default() -> Self {
             Self {
@@ -441,7 +460,7 @@ pub(crate) mod tests {
             }
         }
 
-        fn scalar_mul<F: PrimeFieldBits>(&self, scalar: &F) -> Self {
+        pub fn scalar_mul<F: PrimeFieldBits>(&self, scalar: &F) -> Self {
             let mut res = Self {
                 x: C::Base::ZERO,
                 y: C::Base::ZERO,

--- a/src/gadgets/util.rs
+++ b/src/gadgets/util.rs
@@ -96,6 +96,17 @@ impl<F: PrimeField, const T: usize> MainGate<F, T> {
         Ok(r)
     }
 
+    pub fn is_not_zero_term(
+        &self,
+        ctx: &mut RegionCtx<'_, F>,
+        a: AssignedValue<F>,
+    ) -> Result<AssignedValue<F>, Error> {
+        let is_zero = self.is_zero_term(ctx, a)?;
+
+        let lhs = self.mul_by_const(ctx, &is_zero, -F::ONE)?;
+        self.add_with_const(ctx, &lhs, F::ONE)
+    }
+
     pub fn is_equal_term(
         &self,
         ctx: &mut RegionCtx<'_, F>,

--- a/src/ivc/cyclefold/sfc/mod.rs
+++ b/src/ivc/cyclefold/sfc/mod.rs
@@ -60,7 +60,12 @@ where
     /// For the initial iteration, we will give the same accumulators that we take from the input
     pub fn initial_instances(&self) -> Vec<Vec<CMain::ScalarExt>> {
         let mut input = self.input.clone();
-        input.step += 1;
+        assert_eq!(
+            input.step, 0,
+            "this method can only be called for step == 0"
+        );
+
+        input.step = 1;
         let out_marker = cyclefold::ro().absorb(&input).output(
             NonZeroUsize::new(<CMain::ScalarExt as PrimeField>::NUM_BITS as usize).unwrap(),
         );

--- a/src/ivc/cyclefold/sfc/mod.rs
+++ b/src/ivc/cyclefold/sfc/mod.rs
@@ -59,12 +59,14 @@ where
 {
     /// For the initial iteration, we will give the same accumulators that we take from the input
     pub fn initial_instances(&self) -> Vec<Vec<CMain::ScalarExt>> {
-        let marker = cyclefold::ro().absorb(&self.input).output(
+        let mut input = self.input.clone();
+        input.step += 1;
+        let out_marker = cyclefold::ro().absorb(&input).output(
             NonZeroUsize::new(<CMain::ScalarExt as PrimeField>::NUM_BITS as usize).unwrap(),
         );
 
         let mut instances = self.sc.instances();
-        instances.insert(0, vec![marker]);
+        instances.insert(0, vec![out_marker]);
         instances
     }
 


### PR DESCRIPTION
**Motivation**
We need to have consistency checks between steps for sfc under #369

**Overview**
The input is checked via access to `self_trace.incoming` The output is checked via constraint system at the current step

Only pairing connection & tests for sfc left in #369