### PR TITLE
feat(ivc): sangria consistency markers len

### DIFF
--- a/src/ivc/cyclefold/sfc/sangria_adapter.rs
+++ b/src/ivc/cyclefold/sfc/sangria_adapter.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     halo2_proofs::plonk::Error as Halo2PlonkError,
     ivc::{
-        cyclefold::{ro_chip, DEFAULT_LIMBS_COUNT_LIMIT, DEFAULT_LIMB_WIDTH},
+        cyclefold::{ro_chip, support_circuit, DEFAULT_LIMBS_COUNT_LIMIT, DEFAULT_LIMB_WIDTH},
         fold_relaxed_plonk_instance_chip::{self, BigUintView, FoldRelaxedPlonkInstanceChip},
     },
     main_gate::{MainGate, MainGateConfig, RegionCtx},
@@ -88,7 +88,11 @@ where
             u: acc_u,
         } = &mut acc;
 
-        *acc_W_commitments = FoldRelaxedPlonkInstanceChip::<MAIN_GATE_T, CSup>::fold_W(
+        *acc_W_commitments = FoldRelaxedPlonkInstanceChip::<
+            MAIN_GATE_T,
+            CSup,
+            { support_circuit::INSTANCES_LEN },
+        >::fold_W(
             region,
             &config,
             &acc_W_commitments
@@ -135,7 +139,11 @@ where
                 },
             )?;
 
-        *acc_challenges = FoldRelaxedPlonkInstanceChip::<MAIN_GATE_T, CSup>::fold_challenges(
+        *acc_challenges = FoldRelaxedPlonkInstanceChip::<
+            MAIN_GATE_T,
+            CSup,
+            { support_circuit::INSTANCES_LEN },
+        >::fold_challenges(
             region,
             &bn_chip,
             input_challenges.to_vec(),

--- a/src/ivc/public_params.rs
+++ b/src/ivc/public_params.rs
@@ -294,9 +294,19 @@ where
             );
 
             let secondary_consistenty_markers: [C2::Scalar; 2] = [
-                C1::scalar_to_base(&secondary_initial_step_input.u.get_consistency_markers()[0])
-                    .unwrap(),
-                ConsistencyMarkerComputation::<'_, A2, C1, RP2::OffCircuit> {
+                C1::scalar_to_base(
+                    &GetConsistencyMarkers::<CONSISTENCY_MARKERS_COUNT, _>::get_consistency_markers(
+                        &secondary_initial_step_input.u,
+                    )[1],
+                )
+                .unwrap(),
+                ConsistencyMarkerComputation::<
+                    '_,
+                    A2,
+                    C1,
+                    RP2::OffCircuit,
+                    { CONSISTENCY_MARKERS_COUNT },
+                > {
                     random_oracle_constant: secondary.ro_constant.clone(),
                     public_params_hash: &secondary_initial_step_input.public_params_hash,
                     step: 1,
@@ -324,13 +334,18 @@ where
             );
 
             let secondary_S = secondary_cr.try_collect_plonk_structure()?;
-            let secondary_initial_plonk_trace = VanillaFS::generate_plonk_trace(
-                secondary.commitment_key,
-                &secondary_instances,
-                &secondary_cr.try_collect_witness()?,
-                &VanillaFS::setup_params(C2::identity(), secondary_S.clone())?.0,
-                &mut RP1::OffCircuit::new(primary.ro_constant.clone()),
-            )?;
+            let secondary_initial_plonk_trace =
+                VanillaFS::<_, { CONSISTENCY_MARKERS_COUNT }>::generate_plonk_trace(
+                    secondary.commitment_key,
+                    &secondary_instances,
+                    &secondary_cr.try_collect_witness()?,
+                    &VanillaFS::<_, { CONSISTENCY_MARKERS_COUNT }>::setup_params(
+                        C2::identity(),
+                        secondary_S.clone(),
+                    )?
+                    .0,
+                    &mut RP1::OffCircuit::new(primary.ro_constant.clone()),
+                )?;
 
             Result::<_, Error>::Ok((secondary_S, secondary_initial_plonk_trace))
         }?;

--- a/src/ivc/sangria/step_folding_circuit.rs
+++ b/src/ivc/sangria/step_folding_circuit.rs
@@ -517,20 +517,26 @@ where
                     )?;
                     ctx.next();
 
-                    let expected_X0 =
-                        AssignedConsistencyMarkersComputation::<'_, RO, ARITY, T, C> {
-                            random_oracle_constant: self.input.step_pp.ro_constant.clone(),
-                            public_params_hash: &w.public_params_hash,
-                            step: &assigned_step,
-                            z_0: &assigned_z_0,
-                            z_i: &assigned_z_i,
-                            relaxed: &w.assigned_relaxed,
-                        }
-                        .generate_with_inspect(
-                            &mut ctx,
-                            config.main_gate_config.clone(),
-                            |buf| debug!("expected X0 {buf:?}"),
-                        )?;
+                    let expected_X0 = AssignedConsistencyMarkersComputation::<
+                        '_,
+                        RO,
+                        ARITY,
+                        T,
+                        C,
+                        { sangria::CONSISTENCY_MARKERS_COUNT },
+                    > {
+                        random_oracle_constant: self.input.step_pp.ro_constant.clone(),
+                        public_params_hash: &w.public_params_hash,
+                        step: &assigned_step,
+                        z_0: &assigned_z_0,
+                        z_i: &assigned_z_i,
+                        relaxed: &w.assigned_relaxed,
+                    }
+                    .generate_with_inspect(
+                        &mut ctx,
+                        config.main_gate_config.clone(),
+                        |buf| debug!("expected X0 {buf:?}"),
+                    )?;
 
                     debug!("expected X0: {expected_X0:?}");
                     debug!(
@@ -583,7 +589,10 @@ where
                     let assigned_is_zero_step =
                         gate.is_zero_term(&mut region, assigned_step.clone())?;
 
-                    let new_U = AssignedRelaxedPlonkInstance::<C>::conditional_select(
+                    let new_U = AssignedRelaxedPlonkInstance::<
+                        C,
+                        { sangria::CONSISTENCY_MARKERS_COUNT },
+                    >::conditional_select(
                         &mut region,
                         &config.main_gate_config,
                         &U_new_base,
@@ -631,7 +640,14 @@ where
                 |region| {
                     let _s = debug_span!("generate output hash").entered();
 
-                    AssignedConsistencyMarkersComputation::<'_, RO, ARITY, T, C> {
+                    AssignedConsistencyMarkersComputation::<
+                        '_,
+                        RO,
+                        ARITY,
+                        T,
+                        C,
+                        { sangria::CONSISTENCY_MARKERS_COUNT },
+                    > {
                         random_oracle_constant: self.input.step_pp.ro_constant.clone(),
                         public_params_hash: &assigned_input_witness.public_params_hash,
                         step: &assigned_next_step,

--- a/src/nifs/protogalaxy/accumulator.rs
+++ b/src/nifs/protogalaxy/accumulator.rs
@@ -1,4 +1,4 @@
-use std::iter;
+use std::{iter, ops::Deref};
 
 use halo2_proofs::halo2curves::ff::PrimeField;
 
@@ -28,6 +28,13 @@ pub struct Accumulator<C: CurveAffine> {
     pub(super) e: C::ScalarExt,
 }
 
+impl<C: CurveAffine> Deref for Accumulator<C> {
+    type Target = PlonkTrace<C>;
+    fn deref(&self) -> &Self::Target {
+        &self.trace
+    }
+}
+
 impl<C: CurveAffine, F: PrimeField, RO: ROTrait<F>> AbsorbInRO<F, RO> for Accumulator<C> {
     fn absorb_into(&self, ro: &mut RO) {
         ro.absorb(&self.trace.u).absorb_field_iter(
@@ -48,6 +55,10 @@ impl<C: CurveAffine> Accumulator<C> {
             e: C::ScalarExt::ZERO,
             trace: PlonkTrace::new(args),
         }
+    }
+
+    pub fn W_commitment_len(&self) -> usize {
+        self.trace.u.W_commitments.len()
     }
 }
 

--- a/src/nifs/protogalaxy/mod.rs
+++ b/src/nifs/protogalaxy/mod.rs
@@ -327,7 +327,7 @@ impl<C: CurveAffine, const L: usize> ProtoGalaxy<C, L> {
     ///
     /// 7. **Fold the Trace:**
     ///     - [`ProtoGalaxy::fold_witness`] & [`ProtoGalaxy::fold_instance`]
-    fn prove(
+    pub fn prove(
         _ck: &CommitmentKey<C>,
         pp: &ProverParam<C>,
         ro_acc: &mut impl ROTrait<C::ScalarExt>,

--- a/src/nifs/sangria/tests.rs
+++ b/src/nifs/sangria/tests.rs
@@ -93,14 +93,24 @@ where
     let mut ro_nark_prepare = create_ro::<C::Base, T, RATE, R_F, R_P>();
     let mut ro_nark_decider = create_ro::<C::Base, T, RATE, R_F, R_P>();
 
-    let (pp, _vp) = VanillaFS::setup_params(pp_digest, S.clone())?;
+    let (pp, _vp) = VanillaFS::<_, 2>::setup_params(pp_digest, S.clone())?;
 
-    let pair1 =
-        VanillaFS::generate_plonk_trace(&ck, &public_inputs1, &W1, &pp, &mut ro_nark_prepare)?;
+    let pair1 = VanillaFS::<_, 2>::generate_plonk_trace(
+        &ck,
+        &public_inputs1,
+        &W1,
+        &pp,
+        &mut ro_nark_prepare,
+    )?;
     let pair1_relaxed = RelaxedPlonkTrace::from_regular(pair1.clone(), S.k);
 
-    let pair2 =
-        VanillaFS::generate_plonk_trace(&ck, &public_inputs2, &W2, &pp, &mut ro_nark_prepare)?;
+    let pair2 = VanillaFS::<_, 2>::generate_plonk_trace(
+        &ck,
+        &public_inputs2,
+        &W2,
+        &pp,
+        &mut ro_nark_prepare,
+    )?;
     let pair2_relaxed = RelaxedPlonkTrace::from_regular(pair2.clone(), S.k);
 
     let mut errors = Vec::new();
@@ -108,13 +118,13 @@ where
     if let Err(err) = S.is_sat(&ck, &mut ro_nark_decider, &pair1.u, &pair1.w) {
         errors.push(("is_sat_pair1", err.into()));
     }
-    if let Err(err) = VanillaFS::is_sat_permutation(&S, &pair1_relaxed) {
+    if let Err(err) = VanillaFS::<_, 2>::is_sat_permutation(&S, &pair1_relaxed) {
         errors.push(("is_sat_perm_pair1", err));
     }
     if let Err(err) = S.is_sat(&ck, &mut ro_nark_decider, &pair2.u, &pair2.w) {
         errors.push(("is_sat_pair2", err.into()));
     }
-    if let Err(err) = VanillaFS::is_sat_permutation(&S, &pair2_relaxed) {
+    if let Err(err) = VanillaFS::<_, 2>::is_sat_permutation(&S, &pair2_relaxed) {
         errors.push(("is_sat_perm_pair2", err));
     }
 
@@ -166,13 +176,13 @@ where
     let mut ro_acc_prover = create_ro::<C::Base, T, RATE, R_F, R_P>();
     let mut ro_acc_verifier = create_ro::<C::Base, T, RATE, R_F, R_P>();
 
-    let (pp, vp) = VanillaFS::setup_params(pp_digest, S.clone())?;
+    let (pp, vp) = VanillaFS::<_, 2>::setup_params(pp_digest, S.clone())?;
 
     let pair1 = [pair1];
     let (RelaxedPlonkTrace { U: U_from_prove, W }, cross_term_commits) =
         VanillaFS::prove(ck, &pp, &mut ro_acc_prover, f_tr.clone(), &pair1)?;
 
-    let U_from_verify = VanillaFS::verify(
+    let U_from_verify = VanillaFS::<_, 2>::verify(
         &vp,
         &mut ro_nark_verifier,
         &mut ro_acc_verifier,
@@ -209,7 +219,7 @@ where
         &pair2,
     )?;
 
-    let U_from_verify = VanillaFS::verify(
+    let U_from_verify = VanillaFS::<_, 2>::verify(
         &vp,
         &mut ro_nark_verifier,
         &mut ro_acc_verifier,
@@ -222,7 +232,7 @@ where
     f_tr.U = U_from_verify;
     f_tr.W = _W;
 
-    if let Err(err) = VanillaFS::is_sat(ck, S, &f_tr, &all_instances) {
+    if let Err(err) = VanillaFS::<_, 2>::is_sat(ck, S, &f_tr, &all_instances) {
         errors.extend(err.into_iter().map(|err| ("f_tr", err)));
     }
 


### PR DESCRIPTION
**Motivation**
For cyclefold (#369) we must use the number of markers (first column) equal to nine, not two, to insert the data we need there (W_commitments)

**Overview**
We add the `MARKER_LEN` generic parameter wherever it is needed to use the sangria protocol
