### PR TITLE
feat(ivc): support_circuit::p_out calc

### DIFF
--- a/src/ivc/cyclefold/incrementally_verifiable_computation/public_params.rs
+++ b/src/ivc/cyclefold/incrementally_verifiable_computation/public_params.rs
@@ -83,7 +83,6 @@ where
                 l0: CMain::Base::ZERO,
                 p1: CMain::identity(),
                 l1: CMain::Base::ZERO,
-                p_out: CMain::identity(),
             }
             .into_instance();
 


### PR DESCRIPTION
**Motivation**
Within #371 we have taken the column instance calculations outside, but for error tracking it is more convenient for the support circuit to perform them itself

**Overview**
Before `instances[0].p_out` was argument, now it's calculated with `sirius::gadgets::ecc::Point` structure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced advanced elliptic curve cryptography capabilities, including enhanced point operations such as addition, doubling, and scalar multiplication for improved performance.

- **Refactor**
  - Streamlined the instance creation process in our computation circuits by dynamically deriving output point values, resulting in a more efficient and cohesive workflow.

- **Tests**
  - Updated internal tests to validate the new cryptographic operations and circuit refinements for robust system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->