### PR TITLE
fix(gadgets): additional unsafe checks

### DIFF
--- a/src/ivc/sangria/fold_relaxed_plonk_instance_chip.rs
+++ b/src/ivc/sangria/fold_relaxed_plonk_instance_chip.rs
@@ -1177,7 +1177,7 @@ mod tests {
     /// as the number of required rows in the table grows.
     const NUM_OF_FOLD_ROUNDS: usize = 3;
     /// 2 ^ K is count of table rows in [`TableData`]
-    const K: u32 = 20;
+    const K: u32 = 21;
 
     const LIMB_WIDTH: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(64) };
     const LIMBS_COUNT: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(10) };
@@ -1292,7 +1292,7 @@ mod tests {
 
         let mut layouter = SingleChipLayouter::new(&mut ws, vec![]).unwrap();
 
-        let spec = Spec::<Base, T, 5>::new(10, 10);
+        let spec = Spec::<Base, T, { T - 1 }>::new(10, 10);
 
         for _round in 0..=NUM_OF_FOLD_ROUNDS {
             let plonk = generate_random_plonk_instance(&mut rnd);
@@ -1814,8 +1814,6 @@ mod tests {
     #[traced_test]
     #[test]
     fn fold_all() {
-        const T: usize = 6;
-
         let Fixture {
             mut ws,
             config,


### PR DESCRIPTION
**Motivation**
During implementation #373, it was discovered that the ecc gadget does not work correctly when multiplying zero points

The point is that unsafe methods were called that were unsafe for some inputs, but it was implied that their result was not used in case of a match. However, this led to incorrect witness (verification errors), because the logic should be the opposite - the verification should go before the call.

**Overview**
- Nonnull checks are performed BEFORE unsafe blocks are called
- Added tests
- For tests with ecc `K_TABLE_SIZE` was increased, because additional lines for non-zero checks

<!-- Please read https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr for general guidance -->
<!-- The most simplified version of Conventional Commits for PR titles. -->
<!-- allowed prefixes: `feat`, `fix`, `chore`, `ci`, `docs`, `test` -->
<!-- module names: the full name of the top-level module whose modifications were the reason for creating the PR or an accepted abbreviation, which should be specified in the rustdoc of the corresponding module -->

**Issue Link / Motivation**
<!-- Link to the related issue(s). If there's no issue, briefly explain the need for this change. -->

**Changes Overview**
<!-- Concisely describe the changes and their impact on the project, point out anything you want reviewers to scrutinize -->

<!-- Optional Sections -->
<!-- **Implementation Details** -->
<!-- For non-trivial changes, provide context on the approach taken, focusing on the rationale behind key decisions. -->

<!-- **Testing plan** -->
<!-- Detail the testing performed to ensure reliability and performance. -->
