### PR TITLE
fix(nifs): protogalaxy initial acc

### DIFF
--- a/src/ivc/cyclefold/mod.rs
+++ b/src/ivc/cyclefold/mod.rs
@@ -24,7 +24,7 @@ pub const R_P: usize = 10;
 pub const DEFAULT_LIMB_WIDTH: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(64) };
 
 /// Safety: because 10 != 0
-pub const DEFAULT_LIMBS_COUNT_LIMIT: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(20) };
+pub const DEFAULT_LIMBS_COUNT: NonZeroUsize = unsafe { NonZeroUsize::new_unchecked(20) };
 
 pub fn ro_const<F: PrimeFieldBits + FromUniformBytes<64>>() -> Spec<F, T, RATE> {
     Spec::<F, T, RATE>::new(R_F, R_P)

--- a/src/ivc/cyclefold/sfc/input/assigned.rs
+++ b/src/ivc/cyclefold/sfc/input/assigned.rs
@@ -12,7 +12,7 @@ use crate::{
     halo2_proofs::plonk::Error as Halo2PlonkError,
     ivc::{
         self,
-        cyclefold::{ro_chip, DEFAULT_LIMBS_COUNT_LIMIT, DEFAULT_LIMB_WIDTH},
+        cyclefold::{ro_chip, DEFAULT_LIMBS_COUNT, DEFAULT_LIMB_WIDTH},
     },
     main_gate::{self, AdviceCyclicAssignor, AssignedValue, MainGate, RegionCtx, WrapValue},
     poseidon::ROCircuitTrait,
@@ -656,7 +656,7 @@ impl<const A: usize, F: PrimeField> Input<A, F> {
         let bn_chip = BigUintMulModChip::new(
             main_gate_config.into_smaller_size().unwrap(),
             DEFAULT_LIMB_WIDTH,
-            DEFAULT_LIMBS_COUNT_LIMIT,
+            DEFAULT_LIMBS_COUNT,
         );
 
         let mg = MainGate::new(main_gate_config.clone());
@@ -703,12 +703,26 @@ impl<const A: usize, F: PrimeField> Input<A, F> {
                 .zip_eq(expected_l1.iter())
                 .try_for_each(|(l, r)| region.constrain_equal(l.cell(), r.cell()))?;
 
-            BigUintPoint::constrain_equal(region, acc_W, &BigUintPoint { x: x0, y: y0 })?;
-            BigUintPoint::constrain_equal(region, incoming_W, &BigUintPoint { x: x1, y: y1 })?;
+            BigUintPoint::constrain_equal(
+                region,
+                acc_W,
+                &BigUintPoint {
+                    x: x0.try_into().unwrap(),
+                    y: y0.try_into().unwrap(),
+                },
+            )?;
+            BigUintPoint::constrain_equal(
+                region,
+                incoming_W,
+                &BigUintPoint {
+                    x: x1.try_into().unwrap(),
+                    y: y1.try_into().unwrap(),
+                },
+            )?;
 
             *new_acc_W = BigUintPoint {
-                x: expected_x,
-                y: expected_y,
+                x: expected_x.try_into().unwrap(),
+                y: expected_y.try_into().unwrap(),
             };
         }
 

--- a/src/ivc/cyclefold/sfc/input/mod.rs
+++ b/src/ivc/cyclefold/sfc/input/mod.rs
@@ -1,6 +1,6 @@
 use std::{array, ops::Deref};
 
-use super::super::{DEFAULT_LIMBS_COUNT_LIMIT, DEFAULT_LIMB_WIDTH};
+use super::super::{DEFAULT_LIMBS_COUNT, DEFAULT_LIMB_WIDTH};
 pub use crate::ivc::protogalaxy::verify_chip::BigUintPoint;
 use crate::{
     gadgets::nonnative::bn::big_uint::BigUint,
@@ -85,7 +85,7 @@ impl<F: PrimeField> PairedPlonkInstance<F> {
                             BigUint::from_different_field(
                                 value,
                                 DEFAULT_LIMB_WIDTH,
-                                DEFAULT_LIMBS_COUNT_LIMIT,
+                                DEFAULT_LIMBS_COUNT,
                             )
                             .unwrap()
                         })
@@ -95,12 +95,8 @@ impl<F: PrimeField> PairedPlonkInstance<F> {
             challenges: challenges
                 .iter()
                 .map(|cha| {
-                    BigUint::from_different_field(
-                        cha,
-                        DEFAULT_LIMB_WIDTH,
-                        DEFAULT_LIMBS_COUNT_LIMIT,
-                    )
-                    .unwrap()
+                    BigUint::from_different_field(cha, DEFAULT_LIMB_WIDTH, DEFAULT_LIMBS_COUNT)
+                        .unwrap()
                 })
                 .collect(),
         }
@@ -213,9 +209,10 @@ impl<F: PrimeField> SelfTrace<F> {
                 .collect(),
             challenges: vec![F::ZERO; challenges_len],
         };
-        let betas_len = nifs::protogalaxy::poly::get_count_of_valuation(native_plonk_structure)
-            .unwrap()
-            .get();
+        let betas_len =
+            nifs::protogalaxy::poly::get_count_of_valuation_with_padding(native_plonk_structure)
+                .unwrap()
+                .get();
         let proof_len = betas_len.ilog2() as usize;
 
         SelfTrace {
@@ -273,7 +270,7 @@ impl<F: PrimeField> SangriaAccumulatorInstance<F> {
                         BigUint::from_different_field(
                             instance,
                             DEFAULT_LIMB_WIDTH,
-                            DEFAULT_LIMBS_COUNT_LIMIT,
+                            DEFAULT_LIMBS_COUNT,
                         )
                         .unwrap()
                     })
@@ -281,12 +278,8 @@ impl<F: PrimeField> SangriaAccumulatorInstance<F> {
                 challenges: challenges
                     .iter()
                     .map(|cha| {
-                        BigUint::from_different_field(
-                            cha,
-                            DEFAULT_LIMB_WIDTH,
-                            DEFAULT_LIMBS_COUNT_LIMIT,
-                        )
-                        .unwrap()
+                        BigUint::from_different_field(cha, DEFAULT_LIMB_WIDTH, DEFAULT_LIMBS_COUNT)
+                            .unwrap()
                     })
                     .collect(),
             },
@@ -390,7 +383,7 @@ impl<F: PrimeField> PairedTrace<F> {
                             BigUint::from_different_field(
                                 value,
                                 DEFAULT_LIMB_WIDTH,
-                                DEFAULT_LIMBS_COUNT_LIMIT,
+                                DEFAULT_LIMBS_COUNT,
                             )
                             .unwrap()
                         })
@@ -401,12 +394,8 @@ impl<F: PrimeField> PairedTrace<F> {
                 .challenges
                 .iter()
                 .map(|value| {
-                    BigUint::from_different_field(
-                        value,
-                        DEFAULT_LIMB_WIDTH,
-                        DEFAULT_LIMBS_COUNT_LIMIT,
-                    )
-                    .unwrap()
+                    BigUint::from_different_field(value, DEFAULT_LIMB_WIDTH, DEFAULT_LIMBS_COUNT)
+                        .unwrap()
                 })
                 .collect(),
         };
@@ -467,7 +456,7 @@ impl<const ARITY: usize, F: PrimeField> Input<ARITY, F> {
             BigUint::from_f(
                 &gen.next().unwrap(),
                 DEFAULT_LIMB_WIDTH,
-                DEFAULT_LIMBS_COUNT_LIMIT,
+                DEFAULT_LIMBS_COUNT,
             )
             .expect("Failed to create BigUint from limbs")
         }
@@ -480,8 +469,8 @@ impl<const ARITY: usize, F: PrimeField> Input<ARITY, F> {
             input_accumulator: ProtoGalaxyAccumulatorInstance {
                 ins: NativePlonkInstance {
                     W_commitments: vec![BigUintPoint {
-                        x: random_big_uint(&mut gen).limbs().to_vec(),
-                        y: random_big_uint(&mut gen).limbs().to_vec(),
+                        x: random_big_uint(&mut gen).limbs().try_into().unwrap(),
+                        y: random_big_uint(&mut gen).limbs().try_into().unwrap(),
                     }],
                     instances: vec![
                         vec![gen.next().unwrap(); 10]; // 5 instances each with 10 field elements
@@ -494,8 +483,8 @@ impl<const ARITY: usize, F: PrimeField> Input<ARITY, F> {
             },
             incoming: NativePlonkInstance {
                 W_commitments: vec![BigUintPoint {
-                    x: random_big_uint(&mut gen).limbs().to_vec(),
-                    y: random_big_uint(&mut gen).limbs().to_vec(),
+                    x: random_big_uint(&mut gen).limbs().try_into().unwrap(),
+                    y: random_big_uint(&mut gen).limbs().try_into().unwrap(),
                 }],
                 instances: vec![
                     vec![gen.next().unwrap(); 10]; // 10 instances each with 10 field elements
@@ -639,14 +628,11 @@ impl<const ARITY: usize, F: PrimeField> Input<ARITY, F> {
                         .instances
                         .iter()
                         .map(|v| {
-                            vec![
-                                BigUint::zero(DEFAULT_LIMB_WIDTH, DEFAULT_LIMBS_COUNT_LIMIT);
-                                v.len()
-                            ]
+                            vec![BigUint::zero(DEFAULT_LIMB_WIDTH, DEFAULT_LIMBS_COUNT); v.len()]
                         })
                         .collect(),
                     challenges: vec![
-                        BigUint::zero(DEFAULT_LIMB_WIDTH, DEFAULT_LIMBS_COUNT_LIMIT);
+                        BigUint::zero(DEFAULT_LIMB_WIDTH, DEFAULT_LIMBS_COUNT);
                         self.paired_trace.input_accumulator.ins.challenges.len()
                     ],
                 },
@@ -669,16 +655,13 @@ impl<const ARITY: usize, F: PrimeField> Input<ARITY, F> {
                             .iter()
                             .map(|v| {
                                 vec![
-                                    BigUint::zero(DEFAULT_LIMB_WIDTH, DEFAULT_LIMBS_COUNT_LIMIT);
+                                    BigUint::zero(DEFAULT_LIMB_WIDTH, DEFAULT_LIMBS_COUNT);
                                     v.len()
                                 ]
                             })
                             .collect(),
                         challenges: vec![
-                            BigUint::zero(
-                                DEFAULT_LIMB_WIDTH,
-                                DEFAULT_LIMBS_COUNT_LIMIT
-                            );
+                            BigUint::zero(DEFAULT_LIMB_WIDTH, DEFAULT_LIMBS_COUNT);
                             incoming.instance.challenges.len()
                         ],
                     },

--- a/src/ivc/cyclefold/sfc/sangria_adapter.rs
+++ b/src/ivc/cyclefold/sfc/sangria_adapter.rs
@@ -17,7 +17,7 @@ use crate::{
         plonk::Error as Halo2PlonkError,
     },
     ivc::{
-        cyclefold::{ro_chip, DEFAULT_LIMBS_COUNT_LIMIT, DEFAULT_LIMB_WIDTH},
+        cyclefold::{ro_chip, DEFAULT_LIMBS_COUNT, DEFAULT_LIMB_WIDTH},
         fold_relaxed_plonk_instance_chip::{self, BigUintView, FoldRelaxedPlonkInstanceChip},
     },
     main_gate::{MainGate, MainGateConfig, RegionCtx},
@@ -29,7 +29,7 @@ fn bn_chip<F: PrimeField>(main_gate_config: MainGateConfig<MAIN_GATE_T>) -> BigU
     BigUintMulModChip::new(
         main_gate_config.into_smaller_size().unwrap(),
         DEFAULT_LIMB_WIDTH,
-        DEFAULT_LIMBS_COUNT_LIMIT,
+        DEFAULT_LIMBS_COUNT,
     )
 }
 
@@ -49,7 +49,7 @@ fn module_as_bn<F1: PrimeField, F2: PrimeField>() -> Result<BigUint<F1>, big_uin
         )
         .unwrap(),
         DEFAULT_LIMB_WIDTH,
-        DEFAULT_LIMBS_COUNT_LIMIT,
+        DEFAULT_LIMBS_COUNT,
     )
 }
 

--- a/src/nifs/protogalaxy/accumulator.rs
+++ b/src/nifs/protogalaxy/accumulator.rs
@@ -1,10 +1,9 @@
 use std::{iter, ops::Deref};
 
-use halo2_proofs::halo2curves::ff::PrimeField;
-
 use crate::{
     ff::Field,
     halo2curves::CurveAffine,
+    ivc::protogalaxy::verify_chip::BigUintPoint,
     plonk::{self, PlonkInstance, PlonkTrace, PlonkWitness},
     poseidon::{AbsorbInRO, ROTrait},
 };
@@ -17,15 +16,15 @@ use crate::{
 pub struct Accumulator<C: CurveAffine> {
     /// `φ`: Represents the combined state of all instances & witnesses. It is a summary that
     /// captures the essential data and relationships from the instances being merged.
-    pub(super) trace: PlonkTrace<C>,
+    pub(crate) trace: PlonkTrace<C>,
 
     /// `β`: A random value used in the folding process. It helps ensure the unique
     /// and secure combination of instances, preventing manipulation.
-    pub(super) betas: Box<[C::ScalarExt]>,
+    pub(crate) betas: Box<[C::ScalarExt]>,
 
     /// `e`: an accumulated value that encapsulates the result of the folding operation. it serves
     /// as a concise representation of the correctness and properties of the folded instances.
-    pub(super) e: C::ScalarExt,
+    pub(crate) e: C::ScalarExt,
 }
 
 impl<C: CurveAffine> Deref for Accumulator<C> {
@@ -35,14 +34,9 @@ impl<C: CurveAffine> Deref for Accumulator<C> {
     }
 }
 
-impl<C: CurveAffine, F: PrimeField, RO: ROTrait<F>> AbsorbInRO<F, RO> for Accumulator<C> {
+impl<C: CurveAffine, RO: ROTrait<C::ScalarExt>> AbsorbInRO<C::ScalarExt, RO> for Accumulator<C> {
     fn absorb_into(&self, ro: &mut RO) {
-        ro.absorb(&self.trace.u).absorb_field_iter(
-            self.betas
-                .iter()
-                .chain(iter::once(&self.e))
-                .map(|b| crate::util::fe_to_fe(b).unwrap()),
-        );
+        AccumulatorInstance::from(self.clone()).absorb_into(ro);
     }
 }
 
@@ -51,7 +45,8 @@ pub type AccumulatorArgs = plonk::PlonkTraceArgs;
 impl<C: CurveAffine> Accumulator<C> {
     pub fn new(args: AccumulatorArgs, count_of_evaluation: usize) -> Self {
         Self {
-            betas: vec![C::ScalarExt::ZERO; count_of_evaluation].into_boxed_slice(),
+            betas: vec![C::ScalarExt::ZERO; count_of_evaluation.ilog2() as usize]
+                .into_boxed_slice(),
             e: C::ScalarExt::ZERO,
             trace: PlonkTrace::new(args),
         }
@@ -106,7 +101,29 @@ impl<C: CurveAffine, RO: ROTrait<C::ScalarExt>> AbsorbInRO<C::ScalarExt, RO>
     for AccumulatorInstance<C>
 {
     fn absorb_into(&self, ro: &mut RO) {
-        ro.absorb(&self.ins)
-            .absorb_field_iter(self.betas.iter().chain(iter::once(&self.e)).copied());
+        let PlonkInstance {
+            W_commitments,
+            instances,
+            challenges,
+        } = &self.ins;
+
+        ro.absorb_field_iter(
+            W_commitments
+                .iter()
+                .flat_map(|W_commitment| {
+                    let BigUintPoint { x, y } = BigUintPoint::new(W_commitment).unwrap();
+                    x.into_iter().chain(y)
+                })
+                .chain(
+                    instances
+                        .iter()
+                        .flat_map(|instance| instance.iter())
+                        .copied(),
+                )
+                .chain(challenges.iter().copied())
+                .chain(self.betas.iter().copied())
+                .chain(iter::once(self.e))
+                .map(|b| crate::util::fe_to_fe(&b).unwrap()),
+        );
     }
 }

--- a/src/nifs/protogalaxy/poly/mod.rs
+++ b/src/nifs/protogalaxy/poly/mod.rs
@@ -127,10 +127,7 @@ pub(crate) fn compute_F<F: PrimeField>(
     let evaluated = plonk::iter_evaluate_witness::<F>(ctx.S, trace)
         .chain(iter::repeat(Ok(F::ZERO)))
         .take(count_of_evaluation.get())
-        .map(|result_with_evaluated_gate| {
-            debug!("witness row: {:?}", result_with_evaluated_gate);
-            result_with_evaluated_gate.map(Node::Leaf)
-        })
+        .map(|result_with_evaluated_gate| result_with_evaluated_gate.map(Node::Leaf))
         // TODO #324 Migrate to a parallel algorithm
         // TODO #324 Implement `try_tree_reduce` to stop on the first error
         .tree_reduce(|left_w, right_w| {
@@ -195,16 +192,13 @@ pub struct PolyContext<'s, F: PrimeField> {
 }
 
 impl<'s, F: PrimeField> PolyContext<'s, F> {
-    pub fn new(
-        S: &'s PlonkStructure<F>,
-        traces: &[(impl Sync + GetChallenges<F> + GetWitness<F>)],
-    ) -> Self {
+    pub fn new(S: &'s PlonkStructure<F>, traces_len: usize) -> Self {
         let count_of_evaluation = get_count_of_valuation_with_padding(S).unwrap().get();
 
-        let instances_to_fold = traces.len() + 1;
+        let instances_to_fold = traces_len + 1;
         assert!(instances_to_fold.is_power_of_two());
 
-        let fft_points_count_G = get_points_count(S, traces.len());
+        let fft_points_count_G = get_points_count(S, traces_len);
 
         Self {
             S,
@@ -220,6 +214,10 @@ impl<'s, F: PrimeField> PolyContext<'s, F> {
 
     pub fn fft_points_count_F(&self) -> usize {
         (self.betas_count() + 1).next_power_of_two()
+    }
+
+    pub fn fft_points_count_K(&self) -> usize {
+        1 << self.fft_log_domain_size_K()
     }
 
     pub fn fft_log_domain_size_G(&self) -> u32 {
@@ -436,14 +434,14 @@ fn compute_K_from_G<F: WithSmallOrderMulGroup<3>>(
     )
 }
 
-pub fn get_count_of_valuation<F: PrimeField>(S: &PlonkStructure<F>) -> Option<NonZeroUsize> {
+fn get_count_of_valuation<F: PrimeField>(S: &PlonkStructure<F>) -> Option<NonZeroUsize> {
     let count_of_rows = 2usize.pow(S.k as u32);
     let count_of_gates = S.gates.len();
 
     NonZeroUsize::new(count_of_rows * count_of_gates)
 }
 
-fn get_count_of_valuation_with_padding<F: PrimeField>(
+pub fn get_count_of_valuation_with_padding<F: PrimeField>(
     S: &PlonkStructure<F>,
 ) -> Option<NonZeroUsize> {
     get_count_of_valuation(S).and_then(|v| v.checked_next_power_of_two())
@@ -567,7 +565,7 @@ mod test {
         });
 
         let traces = [trace];
-        let ctx = PolyContext::new(&S, &traces);
+        let ctx = PolyContext::new(&S, traces.len());
 
         let delta = gen.by_ref().next().unwrap();
         let betas = gen.by_ref().take(ctx.betas_count()).collect::<Box<[_]>>();
@@ -623,7 +621,7 @@ mod test {
         .take(3)
         .collect::<Box<[_]>>();
 
-        let ctx = PolyContext::new(&S, &traces);
+        let ctx = PolyContext::new(&S, traces.len());
 
         let beta_stroke = gen.by_ref().take(ctx.betas_count()).collect::<Box<[_]>>();
 
@@ -688,7 +686,7 @@ mod test {
 
         debug!("start compute F");
         assert!(super::compute_F(
-            &super::PolyContext::new(&S, &traces),
+            &super::PolyContext::new(&S, traces.len()),
             iter::repeat_with(move || Field::random(&mut rnd)),
             delta,
             &traces[0],
@@ -715,7 +713,7 @@ mod test {
 
         assert_ne!(
             super::compute_F(
-                &super::PolyContext::new(&S, &traces),
+                &super::PolyContext::new(&S, traces.len()),
                 iter::repeat_with(|| Field::random(&mut rnd)),
                 delta,
                 &traces[0],
@@ -734,7 +732,7 @@ mod test {
 
         let traces = [trace];
         assert!(super::compute_G(
-            &super::PolyContext::new(&S, &traces),
+            &super::PolyContext::new(&S, traces.len()),
             iter::repeat_with(|| Field::random(&mut rnd)),
             &traces[0].clone(),
             &traces
@@ -758,7 +756,7 @@ mod test {
         let traces = [trace];
         assert_ne!(
             super::compute_G(
-                &super::PolyContext::new(&S, &traces),
+                &super::PolyContext::new(&S, traces.len()),
                 iter::repeat_with(|| Field::random(&mut rnd)),
                 &traces[0].clone(),
                 &traces


### PR DESCRIPTION
**Motivation**
ProtoGalaxy accumulator was created immediately by `!is_sat`, which prevents folding in #373

**Overview**
- The protogalaxy accumulator logic has been changed
- AssignedBigUint within ivc::protogalaxy is now an array. This generated a certain number of try_into().unwrap(), however, these will be cleaned up soon
- Changed the order of absorption in ro, for consistency with cyclefold
