### PR TITLE
feat(ivc): impl `cyclefold::sfc`

### DIFF
--- a/src/ivc/cyclefold/sfc/input/assigned.rs
+++ b/src/ivc/cyclefold/sfc/input/assigned.rs
@@ -1,18 +1,18 @@
-use std::iter;
+use std::{fmt, iter};
 
-use halo2_proofs::{
-    circuit::Value,
-    halo2curves::ff::{FromUniformBytes, PrimeField, PrimeFieldBits},
-};
 use itertools::Itertools;
-use tracing::error;
+use tracing::{error, info, info_span, instrument, trace};
 
 use crate::{
     gadgets::nonnative::bn::big_uint_mul_mod_chip::BigUintMulModChip,
-    halo2_proofs::plonk::Error as Halo2PlonkError,
+    halo2_proofs::{
+        circuit::Value,
+        halo2curves::ff::{FromUniformBytes, PrimeField, PrimeFieldBits},
+        plonk::Error as Halo2PlonkError,
+    },
     ivc::{
         self,
-        cyclefold::{ro_chip, DEFAULT_LIMBS_COUNT, DEFAULT_LIMB_WIDTH},
+        cyclefold::{ro_chip, support_circuit, DEFAULT_LIMBS_COUNT, DEFAULT_LIMB_WIDTH},
     },
     main_gate::{self, AdviceCyclicAssignor, AssignedValue, MainGate, RegionCtx, WrapValue},
     poseidon::ROCircuitTrait,
@@ -20,10 +20,13 @@ use crate::{
 
 pub type MainGateConfig = main_gate::MainGateConfig<{ super::super::MAIN_GATE_T }>;
 
-pub type BigUint<F> = Vec<F>;
+pub type BigUint<F> = [F; DEFAULT_LIMBS_COUNT.get()];
 
 pub type BigUintPoint<F> = ivc::protogalaxy::verify_chip::BigUintPoint<F>;
 pub type NativePlonkInstance<F> = ivc::protogalaxy::verify_chip::AssignedPlonkInstance<F>;
+
+const W_COMMITMENTS_MAX_LEN: usize = 3;
+const W_CHALLENGES_MAX_LEN: usize = 3;
 
 impl<F: PrimeField> NativePlonkInstance<F> {
     pub fn assign_advice_from_native(
@@ -31,17 +34,33 @@ impl<F: PrimeField> NativePlonkInstance<F> {
         original: &super::NativePlonkInstance<F>,
         main_gate_config: &MainGateConfig,
     ) -> Result<Self, Halo2PlonkError> {
+        let _s = info_span!("native_plonk_instance").entered();
+        let start_offset = region.offset();
+
+        trace!("start assign at {start_offset}");
+
         let super::NativePlonkInstance {
             W_commitments,
             instances,
             challenges,
         } = original;
 
+        trace!(
+            "W_commitments_len: {}, instances_len: {}, challenges_len: {}",
+            W_commitments.len(),
+            instances.len(),
+            challenges.len()
+        );
+
         let W_commitments = W_commitments
             .iter()
             .cloned()
             .map(|p| p.assign(region, main_gate_config))
             .collect::<Result<Vec<_>, _>>()?;
+
+        iter::repeat(BigUintPoint::identity())
+            .take(W_COMMITMENTS_MAX_LEN.saturating_sub(W_commitments.len()))
+            .try_for_each(|p| p.assign(region, main_gate_config).map(|_| ()))?;
 
         let mut assigner = main_gate_config.advice_cycle_assigner();
 
@@ -55,6 +74,17 @@ impl<F: PrimeField> NativePlonkInstance<F> {
         let challenges =
             assigner.assign_all_advice(region, || "challenges", challenges.iter().cloned())?;
 
+        assigner.assign_all_advice(
+            region,
+            || "zero",
+            iter::repeat(F::ZERO).take(W_CHALLENGES_MAX_LEN.saturating_sub(challenges.len())),
+        )?;
+
+        trace!(
+            "took {} rows total, finish at {}",
+            region.offset() - start_offset,
+            region.offset()
+        );
         region.next();
 
         Ok(Self {
@@ -74,9 +104,15 @@ impl<F: PrimeField> ProtoGalaxyAccumulatorInstance<F> {
         original: &super::ProtoGalaxyAccumulatorInstance<F>,
         main_gate_config: &MainGateConfig,
     ) -> Result<Self, Halo2PlonkError> {
+        let _s = info_span!("protogalaxy_accumulator_instance").entered();
+        let start_offset = region.offset();
+
+        trace!("start assign at {start_offset}");
+
         let super::ProtoGalaxyAccumulatorInstance { ins, betas, e } = original;
         let ins = NativePlonkInstance::assign_advice_from_native(region, ins, main_gate_config)?;
 
+        trace!("len of betas: {}", betas.len());
         let mut assigner = main_gate_config.advice_cycle_assigner();
         let self_ = Self {
             ins,
@@ -86,6 +122,7 @@ impl<F: PrimeField> ProtoGalaxyAccumulatorInstance<F> {
             e: assigner.assign_next_advice(region, || "e", *e)?,
         };
 
+        trace!("took {} rows total", region.offset() - start_offset);
         region.next();
 
         Ok(self_)
@@ -131,8 +168,15 @@ impl<F: PrimeField> ProtogalaxyProof<F> {
         original: &super::nifs::protogalaxy::Proof<F>,
         main_gate_config: &MainGateConfig,
     ) -> Result<Self, Halo2PlonkError> {
+        let _s = info_span!("protogalaxy_proof").entered();
+        let start_offset = region.offset();
+
+        trace!("start assign at {start_offset}");
+
         let mut assigner = main_gate_config.advice_cycle_assigner();
         let super::nifs::protogalaxy::Proof { poly_F, poly_K } = original;
+
+        trace!("poly_F_len: {}, poly_K_len: {}", poly_F.len(), poly_K.len());
 
         let self_ = Self {
             poly_F: assigner
@@ -143,6 +187,10 @@ impl<F: PrimeField> ProtogalaxyProof<F> {
                 .into(),
         };
 
+        trace!(
+            "`ProtogalaxyProof` took {} rows",
+            region.offset() - start_offset
+        );
         region.next();
 
         Ok(self_)
@@ -161,6 +209,7 @@ impl<F: PrimeField> ProtogalaxyProof<F> {
 }
 
 /// Recursive trace of the circuit itself
+#[derive(Debug)]
 pub struct SelfTrace<F: PrimeField> {
     pub input_accumulator: ProtoGalaxyAccumulatorInstance<F>,
     pub incoming: NativePlonkInstance<F>,
@@ -173,13 +222,18 @@ impl<F: PrimeField> SelfTrace<F> {
         original: &super::SelfTrace<F>,
         main_gate_config: &MainGateConfig,
     ) -> Result<Self, Halo2PlonkError> {
+        let start_offset = region.offset();
+        let _s = info_span!("self_trace").entered();
+
+        trace!("start assign at {start_offset}");
+
         let super::SelfTrace {
             input_accumulator,
             incoming,
             proof,
         } = original;
 
-        Ok(Self {
+        let self_ = Self {
             input_accumulator: ProtoGalaxyAccumulatorInstance::assign_advice_from_native(
                 region,
                 input_accumulator,
@@ -191,7 +245,11 @@ impl<F: PrimeField> SelfTrace<F> {
                 main_gate_config,
             )?,
             proof: ProtogalaxyProof::assign_advice_from(region, proof, main_gate_config)?,
-        })
+        };
+
+        trace!("`SelfTrace` took {} rows", region.offset() - start_offset);
+
+        Ok(self_)
     }
 
     fn iter_wrap_values(&self) -> impl '_ + Iterator<Item = WrapValue<F>> {
@@ -208,25 +266,70 @@ impl<F: PrimeField> SelfTrace<F> {
     }
 }
 
+type BigUintView<F> = (AssignedValue<F>, BigUint<AssignedValue<F>>);
+
 #[derive(Clone)]
-pub struct PairedPlonkInstance<F: PrimeField> {
+pub struct SupportPlonkInstance<F: PrimeField> {
     pub(crate) W_commitments: Vec<(AssignedValue<F>, AssignedValue<F>)>,
-    pub(crate) instances: Vec<Vec<BigUint<AssignedValue<F>>>>,
-    pub(crate) challenges: Vec<BigUint<AssignedValue<F>>>,
+    pub(crate) instances: Vec<Vec<BigUintView<F>>>,
+    pub(crate) challenges: Vec<BigUintView<F>>,
 }
 
-impl<F: PrimeField> PairedPlonkInstance<F> {
+impl<F: PrimeField + fmt::Debug> fmt::Debug for SupportPlonkInstance<F> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        #[derive(Debug)]
+        pub struct SupportPlonkInstanceValue<'l, F: PrimeField> {
+            pub(crate) W_commitments: Vec<(Value<&'l F>, Value<&'l F>)>,
+            pub(crate) instances: Vec<Vec<(Value<F>, BigUint<Value<F>>)>>,
+            pub(crate) challenges: Vec<(Value<F>, BigUint<Value<F>>)>,
+        }
+
+        SupportPlonkInstanceValue {
+            W_commitments: self
+                .W_commitments
+                .iter()
+                .map(|(x, y)| (x.value(), y.value()))
+                .collect(),
+            instances: self
+                .instances
+                .iter()
+                .map(|instance| {
+                    instance
+                        .iter()
+                        .map(|(v, bn)| (v.value().copied(), bn.clone().map(|v| v.value().copied())))
+                        .collect()
+                })
+                .collect(),
+            challenges: self
+                .challenges
+                .iter()
+                .map(|(cha, bn)| (cha.value().copied(), bn.clone().map(|v| v.value().copied())))
+                .collect(),
+        }
+        .fmt(f)
+    }
+}
+
+impl<F: PrimeField> SupportPlonkInstance<F> {
     fn assign_advice_from(
         region: &mut RegionCtx<'_, F>,
-        original: &super::PairedPlonkInstance<F>,
+        original: &super::SupportPlonkInstance<F>,
         main_gate_config: &MainGateConfig,
     ) -> Result<Self, Halo2PlonkError> {
-        let super::PairedPlonkInstance {
+        let _s = info_span!("support_plonk_instance").entered();
+        let start_offset = region.offset();
+
+        trace!("start assign at {}", start_offset);
+
+        let super::SupportPlonkInstance {
             W_commitments,
             instances,
             challenges,
         } = original;
+
         let mut assigner = main_gate_config.advice_cycle_assigner();
+
+        trace!("begin cycle is {}", region.offset());
 
         let W_commitments = W_commitments
             .iter()
@@ -237,34 +340,79 @@ impl<F: PrimeField> PairedPlonkInstance<F> {
             })
             .collect::<Result<Vec<_>, Halo2PlonkError>>()?;
 
+        iter::repeat((F::ZERO, F::ZERO))
+            .take(W_COMMITMENTS_MAX_LEN - W_commitments.len())
+            .try_for_each(|(x, y)| -> Result<(), Halo2PlonkError> {
+                let _x = assigner.assign_next_advice(region, || "W_commitments_x", x)?;
+                let _y = assigner.assign_next_advice(region, || "W_commitments_y", y)?;
+
+                Ok(())
+            })?;
+
         let instances = instances
             .iter()
             .map(|instance| {
+                assigner.assign_all_advice(region, || "instance", instance.iter().copied())
+            })
+            .collect::<Result<Vec<_>, Halo2PlonkError>>()?;
+
+        let challenges =
+            assigner.assign_all_advice(region, || "instance", challenges.iter().copied())?;
+
+        assigner.assign_all_advice(
+            region,
+            || "",
+            iter::repeat(F::ZERO).take(W_CHALLENGES_MAX_LEN - challenges.len()),
+        )?;
+
+        trace!("after cycle is {}", region.offset());
+        region.next();
+
+        let bn_chip = super::super::bn_chip(main_gate_config.clone());
+
+        let instances: Vec<Vec<BigUintView<F>>> = instances
+            .into_iter()
+            .map(|instance| {
                 instance
-                    .iter()
+                    .into_iter()
                     .map(|value| {
-                        assigner.assign_all_advice(
-                            region,
-                            || "instances",
-                            value.limbs().iter().copied(),
-                        )
+                        Ok((
+                            value.clone(),
+                            bn_chip
+                                .from_assigned_value_to_limbs(region, &value)
+                                .map_err(|err| {
+                                    error!("bn error: {err:?}");
+                                    Halo2PlonkError::Synthesis
+                                })?
+                                .try_into()
+                                .unwrap(),
+                        ))
                     })
-                    .collect::<Result<Vec<_>, _>>()
+                    .collect::<Result<Vec<_>, Halo2PlonkError>>()
             })
             .collect::<Result<Vec<_>, Halo2PlonkError>>()?;
 
         let challenges = challenges
-            .iter()
-            .map(|challenge| {
-                assigner.assign_all_advice(
-                    region,
-                    || "challenges",
-                    challenge.limbs().iter().cloned(),
-                )
+            .into_iter()
+            .map(|value| {
+                Ok((
+                    value.clone(),
+                    bn_chip
+                        .from_assigned_value_to_limbs(region, &value)
+                        .map_err(|err| {
+                            error!("bn error: {err:?}");
+                            Halo2PlonkError::Synthesis
+                        })?
+                        .try_into()
+                        .unwrap(),
+                ))
             })
             .collect::<Result<Vec<_>, Halo2PlonkError>>()?;
 
-        region.next();
+        trace!(
+            "`SupportPlonkInstance` took {} rows",
+            region.offset() - start_offset
+        );
 
         Ok(Self {
             W_commitments,
@@ -309,12 +457,18 @@ impl<F: PrimeField> PairedPlonkInstance<F> {
                 l_instance
                     .iter()
                     .zip_eq(r_instance.iter())
-                    .map(|(l_val, r_val)| {
-                        l_val
+                    .map(|((l_val, l_bn), (r_val, r_bn))| {
+                        let bn = l_bn
                             .iter()
-                            .zip_eq(r_val.iter())
+                            .zip_eq(r_bn.iter())
                             .map(|(l, r)| mg.conditional_select(region, l, r, cond))
-                            .collect()
+                            .collect::<Result<Vec<_>, _>>()?
+                            .try_into()
+                            .unwrap();
+
+                        let val = mg.conditional_select(region, l_val, r_val, cond)?;
+
+                        Ok((val, bn))
                     })
                     .collect::<Result<Vec<_>, _>>()
             })
@@ -323,11 +477,18 @@ impl<F: PrimeField> PairedPlonkInstance<F> {
         let challenges = lhs_challenges
             .iter()
             .zip(rhs_challenges.iter())
-            .map(|(lbn, rbn)| {
-                lbn.iter()
-                    .zip_eq(rbn.iter())
+            .map(|((l_val, l_bn), (r_val, r_bn))| {
+                let bn = l_bn
+                    .iter()
+                    .zip_eq(r_bn.iter())
                     .map(|(l, r)| mg.conditional_select(region, l, r, cond))
-                    .collect()
+                    .collect::<Result<Vec<_>, _>>()?
+                    .try_into()
+                    .unwrap();
+
+                let val = mg.conditional_select(region, l_val, r_val, cond)?;
+
+                Ok((val, bn))
             })
             .collect::<Result<Vec<_>, Halo2PlonkError>>()?;
 
@@ -351,18 +512,20 @@ impl<F: PrimeField> PairedPlonkInstance<F> {
             .chain(
                 instances
                     .iter()
-                    .flat_map(|big_uint| big_uint.iter().flatten()),
+                    .flat_map(|instance| instance.iter().map(|(value, _bn)| value)),
             )
-            .chain(challenges.iter().flat_map(|big_uint| big_uint.iter()))
+            .chain(challenges.iter().map(|(value, _bn)| value))
             .map(|v| WrapValue::Assigned(v.clone()))
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct SangriaAccumulatorInstance<F: PrimeField> {
-    pub(crate) ins: PairedPlonkInstance<F>,
+    pub(crate) ins: SupportPlonkInstance<F>,
     pub(crate) E_commitment: (AssignedValue<F>, AssignedValue<F>),
     pub(crate) u: AssignedValue<F>,
+    // always zero for the support circuit
+    pub(crate) step_circuit_instances_hash_accumulator: AssignedValue<F>,
 }
 
 impl<F: PrimeField> SangriaAccumulatorInstance<F> {
@@ -371,9 +534,18 @@ impl<F: PrimeField> SangriaAccumulatorInstance<F> {
         original: &super::SangriaAccumulatorInstance<F>,
         main_gate_config: &MainGateConfig,
     ) -> Result<Self, Halo2PlonkError> {
-        let ins = PairedPlonkInstance::assign_advice_from(region, &original.ins, main_gate_config)?;
+        let _s = info_span!("sangria_accumulator_instance").entered();
+
+        let start_offset = region.offset();
+        trace!("start assign at {}", region.offset());
+
+        let ins =
+            SupportPlonkInstance::assign_advice_from(region, &original.ins, main_gate_config)?;
 
         let mut assigner = main_gate_config.advice_cycle_assigner();
+
+        let step_circuit_instances_hash_accumulator =
+            assigner.assign_next_advice(region, || "", F::ZERO)?;
 
         let self_ = Self {
             ins,
@@ -390,7 +562,13 @@ impl<F: PrimeField> SangriaAccumulatorInstance<F> {
                 )?,
             ),
             u: assigner.assign_next_advice(region, || "u", original.u)?,
+            step_circuit_instances_hash_accumulator,
         };
+
+        trace!(
+            "`SangriaAccumulatorInstance` took {} rows",
+            region.offset() - start_offset
+        );
 
         region.next();
 
@@ -408,14 +586,16 @@ impl<F: PrimeField> SangriaAccumulatorInstance<F> {
             ins: lhs_ins,
             E_commitment: lhs_E_commitment,
             u: lhs_u,
+            step_circuit_instances_hash_accumulator,
         } = lhs;
         let Self {
             ins: rhs_ins,
             E_commitment: rhs_E_commitment,
             u: rhs_u,
+            step_circuit_instances_hash_accumulator: _,
         } = rhs;
 
-        let ins = PairedPlonkInstance::conditional_select(region, mg, lhs_ins, rhs_ins, cond)?;
+        let ins = SupportPlonkInstance::conditional_select(region, mg, lhs_ins, rhs_ins, cond)?;
 
         let E_commitment = (
             mg.conditional_select(region, &lhs_E_commitment.0, &rhs_E_commitment.0, cond)?,
@@ -428,6 +608,8 @@ impl<F: PrimeField> SangriaAccumulatorInstance<F> {
             ins,
             E_commitment,
             u,
+            step_circuit_instances_hash_accumulator: step_circuit_instances_hash_accumulator
+                .clone(),
         })
     }
 
@@ -436,33 +618,42 @@ impl<F: PrimeField> SangriaAccumulatorInstance<F> {
             ins,
             E_commitment,
             u,
+            step_circuit_instances_hash_accumulator,
         } = self;
 
         ins.iter_wrap_values().chain(
-            [E_commitment.0.clone(), E_commitment.1.clone()]
-                .into_iter()
-                .chain(iter::once(u.clone()))
-                .map(|v| WrapValue::Assigned(v)),
+            [
+                u.clone(),
+                E_commitment.0.clone(),
+                E_commitment.1.clone(),
+                step_circuit_instances_hash_accumulator.clone(),
+            ]
+            .into_iter()
+            .map(|v| WrapValue::Assigned(v)),
         )
     }
 }
 
 pub type SangriaCrossTermCommits<F> = Vec<(AssignedValue<F>, AssignedValue<F>)>;
 
-pub struct PairedIncoming<F: PrimeField> {
-    pub instance: PairedPlonkInstance<F>,
+#[derive(Debug)]
+pub struct SupportIncoming<F: PrimeField> {
+    pub instance: SupportPlonkInstance<F>,
     pub proof: SangriaCrossTermCommits<F>,
 }
 
-impl<F: PrimeField> PairedIncoming<F> {
+impl<F: PrimeField> SupportIncoming<F> {
     fn assign_advice_from(
         region: &mut RegionCtx<'_, F>,
-        original: &super::PairedIncoming<F>,
+        original: &super::SupportIncoming<F>,
         main_gate_config: &MainGateConfig,
     ) -> Result<Self, Halo2PlonkError> {
-        let super::PairedIncoming { instance, proof } = original;
+        let start_offset = region.offset();
 
-        let instance = PairedPlonkInstance::assign_advice_from(region, instance, main_gate_config)?;
+        let super::SupportIncoming { instance, proof } = original;
+
+        let instance =
+            SupportPlonkInstance::assign_advice_from(region, instance, main_gate_config)?;
 
         let mut assigner = main_gate_config.advice_cycle_assigner();
 
@@ -477,6 +668,10 @@ impl<F: PrimeField> PairedIncoming<F> {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
+        trace!(
+            "`SupportIncoming` took {} rows",
+            region.offset() - start_offset
+        );
         region.next();
 
         Ok(Self { instance, proof })
@@ -493,19 +688,24 @@ impl<F: PrimeField> PairedIncoming<F> {
     }
 }
 
-pub struct PairedTrace<F: PrimeField> {
+#[derive(Debug)]
+pub struct SupportTrace<F: PrimeField> {
     pub input_accumulator: SangriaAccumulatorInstance<F>,
     // The size from one to three
     // Depdend on `W_commitments_len`
-    pub incoming: Box<[PairedIncoming<F>]>,
+    pub incoming: Box<[SupportIncoming<F>]>,
 }
 
-impl<F: PrimeField> PairedTrace<F> {
+impl<F: PrimeField> SupportTrace<F> {
     fn assign_advice_from(
         region: &mut RegionCtx<'_, F>,
-        original: &super::PairedTrace<F>,
+        original: &super::SupportTrace<F>,
         main_gate_config: &MainGateConfig,
     ) -> Result<Self, Halo2PlonkError> {
+        let _s = info_span!("support_trace");
+
+        trace!("start assign at {}", region.offset());
+
         let input_accumulator = SangriaAccumulatorInstance::assign_advice_from(
             region,
             &original.input_accumulator,
@@ -515,11 +715,26 @@ impl<F: PrimeField> PairedTrace<F> {
         let incoming = original
             .incoming
             .iter()
-            .map(|paired_plonk_instance| {
-                PairedIncoming::assign_advice_from(region, paired_plonk_instance, main_gate_config)
+            .map(|support_plonk_instance| {
+                SupportIncoming::assign_advice_from(
+                    region,
+                    support_plonk_instance,
+                    main_gate_config,
+                )
             })
             .collect::<Result<Vec<_>, Halo2PlonkError>>()?
             .into_boxed_slice();
+
+        iter::repeat_with(|| &original.incoming[0])
+            .take(W_COMMITMENTS_MAX_LEN - original.incoming.len())
+            .try_for_each(|support_plonk_instance| -> Result<(), Halo2PlonkError> {
+                SupportIncoming::assign_advice_from(
+                    region,
+                    support_plonk_instance,
+                    main_gate_config,
+                )?;
+                Ok(())
+            })?;
 
         Ok(Self {
             input_accumulator,
@@ -541,11 +756,12 @@ impl<F: PrimeField> PairedTrace<F> {
     }
 }
 
+#[derive(Debug)]
 pub struct Input<const ARITY: usize, F: PrimeField> {
     pub pp_digest: (AssignedValue<F>, AssignedValue<F>),
 
     pub self_trace: SelfTrace<F>,
-    pub paired_trace: PairedTrace<F>,
+    pub support_trace: SupportTrace<F>,
 
     pub step: AssignedValue<F>,
     pub z_0: [AssignedValue<F>; ARITY],
@@ -558,11 +774,15 @@ impl<const A: usize, F: PrimeField> Input<A, F> {
         original: &super::Input<A, F>,
         main_gate_config: &MainGateConfig,
     ) -> Result<Self, Halo2PlonkError> {
+        let _s = info_span!("input_assign").entered();
+
+        let start_offset = region.offset();
+
         let self_trace =
             SelfTrace::assign_advice_from(region, &original.self_trace, main_gate_config)?;
 
-        let paired_trace =
-            PairedTrace::assign_advice_from(region, &original.paired_trace, main_gate_config)?;
+        let support_trace =
+            SupportTrace::assign_advice_from(region, &original.support_trace, main_gate_config)?;
 
         let mut assigner = main_gate_config.advice_cycle_assigner();
 
@@ -580,11 +800,12 @@ impl<const A: usize, F: PrimeField> Input<A, F> {
         let z_i = assigner.assign_all_advice(region, || "z_i", original.z_i.iter().cloned())?;
 
         region.next();
+        trace!("`Input` took {} rows", region.offset() - start_offset);
 
         Ok(Self {
             pp_digest: (pp_digest_0, pp_digest_1),
             self_trace,
-            paired_trace,
+            support_trace,
             step: step_assigned,
             z_0: z_0.try_into().unwrap(),
             z_i: z_i.try_into().unwrap(),
@@ -594,7 +815,7 @@ impl<const A: usize, F: PrimeField> Input<A, F> {
     fn iter_consistency_marker_wrap_values(&self) -> impl '_ + Iterator<Item = WrapValue<F>> {
         let Self {
             self_trace,
-            paired_trace,
+            support_trace,
             pp_digest: (pp0, pp1),
             step,
             z_0,
@@ -604,13 +825,15 @@ impl<const A: usize, F: PrimeField> Input<A, F> {
         iter_consistency_marker_wrap_values(
             (pp0, pp1),
             &self_trace.input_accumulator,
-            &paired_trace.input_accumulator,
+            &support_trace.input_accumulator,
             step,
             z_0,
             z_i,
         )
     }
 
+    /// For all rounds except the zero round, check that the hash of self (input) is equal to the
+    /// hash of the previous step
     pub fn consistency_check(
         self,
         region: &mut RegionCtx<F>,
@@ -646,7 +869,8 @@ impl<const A: usize, F: PrimeField> Input<A, F> {
         Ok(self)
     }
 
-    pub fn pairing_check(
+    #[instrument(skip_all)]
+    pub fn support_circuit_consistency_check(
         &self,
         region: &mut RegionCtx<F>,
         main_gate_config: &MainGateConfig,
@@ -660,34 +884,37 @@ impl<const A: usize, F: PrimeField> Input<A, F> {
         );
 
         let mg = MainGate::new(main_gate_config.clone());
-        let is_zero_term = mg.is_zero_term(region, self.step.clone())?;
+        let is_zero_step = mg.is_zero_term(region, self.step.clone())?;
 
         let zero = region.assign_advice(|| "", main_gate_config.state[0], Value::known(F::ZERO))?;
         region.next();
 
-        let expected_l0 = mg.conditional_select(region, &zero, &poly_L_values[0], &is_zero_term)?;
-        let expected_l0 = bn_chip
+        let expected_l0 = mg.conditional_select(region, &zero, &poly_L_values[0], &is_zero_step)?;
+        let expected_l0_limbs = bn_chip
             .from_assigned_value_to_limbs(region, &expected_l0)
             .map_err(|err| {
                 error!("while make from L0 biguint form: {err:?}");
                 Halo2PlonkError::Synthesis
             })?;
 
-        let expected_l1 = mg.conditional_select(region, &zero, &poly_L_values[1], &is_zero_term)?;
-        let expected_l1 = bn_chip
+        let expected_l1 = mg.conditional_select(region, &zero, &poly_L_values[1], &is_zero_step)?;
+        let expected_l1_limbs = bn_chip
             .from_assigned_value_to_limbs(region, &expected_l1)
             .map_err(|err| {
                 error!("while make from L1 biguint form: {err:?}");
                 Halo2PlonkError::Synthesis
             })?;
 
-        for (acc_W, incoming_W, trace, new_acc_W) in itertools::multizip((
+        for (acc_W, incoming_W, trace, new_acc_W, index) in itertools::multizip((
             self.self_trace.input_accumulator.ins.W_commitments.iter(),
             self.self_trace.incoming.W_commitments.iter(),
-            self.paired_trace.incoming.iter(),
+            self.support_trace.incoming.iter(),
             new_acc.ins.W_commitments.iter_mut(),
+            0..,
         )) {
-            let [expected_x, expected_y, x0, y0, l0, x1, y1, l1] = trace.instance
+            info!("start {index} commitment check");
+
+            let [expected_x, expected_y, x0, y0, l0, x1, y1, l1]: [_; support_circuit::INSTANCES_LEN] = trace.instance
                 .instances
                 .first()
                 .expect("`SupportCircuit` always has instances.len() == 1 and it should always be used for sfc")
@@ -695,34 +922,20 @@ impl<const A: usize, F: PrimeField> Input<A, F> {
                 .try_into()
                 .unwrap();
 
-            l0.iter()
-                .zip_eq(expected_l0.iter())
+            l0.1.iter()
+                .zip_eq(expected_l0_limbs.iter())
                 .try_for_each(|(l, r)| region.constrain_equal(l.cell(), r.cell()))?;
 
-            l1.iter()
-                .zip_eq(expected_l1.iter())
+            l1.1.iter()
+                .zip_eq(expected_l1_limbs.iter())
                 .try_for_each(|(l, r)| region.constrain_equal(l.cell(), r.cell()))?;
 
-            BigUintPoint::constrain_equal(
-                region,
-                acc_W,
-                &BigUintPoint {
-                    x: x0.try_into().unwrap(),
-                    y: y0.try_into().unwrap(),
-                },
-            )?;
-            BigUintPoint::constrain_equal(
-                region,
-                incoming_W,
-                &BigUintPoint {
-                    x: x1.try_into().unwrap(),
-                    y: y1.try_into().unwrap(),
-                },
-            )?;
+            BigUintPoint::constrain_equal(region, acc_W, &BigUintPoint { x: x0.1, y: y0.1 })?;
+            BigUintPoint::constrain_equal(region, incoming_W, &BigUintPoint { x: x1.1, y: y1.1 })?;
 
             *new_acc_W = BigUintPoint {
-                x: expected_x.try_into().unwrap(),
-                y: expected_y.try_into().unwrap(),
+                x: expected_x.1,
+                y: expected_y.1,
             };
         }
 
@@ -739,6 +952,11 @@ pub fn iter_consistency_marker_wrap_values<'l, const ARITY: usize, F: PrimeField
     z_i: &'l [AssignedValue<F>; ARITY],
 ) -> impl 'l + Iterator<Item = WrapValue<F>> {
     let (pp0, pp1) = pp_digest;
+
+    trace!(
+        "oncircuit input protogalaxy accumulator: {:?}",
+        self_accumulator
+    );
 
     self_accumulator
         .iter_wrap_values()

--- a/src/ivc/cyclefold/sfc/mod.rs
+++ b/src/ivc/cyclefold/sfc/mod.rs
@@ -1,9 +1,10 @@
 use std::{marker::PhantomData, num::NonZeroUsize};
 
 use itertools::Itertools;
-use tracing::error;
+use tracing::{error, info, info_span, instrument, trace};
 
 use crate::{
+    gadgets::nonnative::bn::big_uint_mul_mod_chip::BigUintMulModChip,
     halo2_proofs::{
         arithmetic::Field,
         circuit::{Layouter, SimpleFloorPlanner},
@@ -19,6 +20,7 @@ use crate::{
         StepCircuit,
     },
     main_gate::{MainGate, MainGateConfig, RegionCtx},
+    nifs,
     poseidon::{ROCircuitTrait, ROTrait},
 };
 
@@ -27,6 +29,7 @@ pub use input::Input;
 
 pub mod sangria_adapter;
 
+use super::{support_circuit, DEFAULT_LIMBS_COUNT, DEFAULT_LIMB_WIDTH};
 use crate::halo2_proofs::halo2curves::ff::{FromUniformBytes, PrimeField, PrimeFieldBits};
 
 const MAIN_GATE_T: usize = 5;
@@ -34,11 +37,12 @@ const MAIN_GATE_T: usize = 5;
 /// 'SCC' here is 'Step Circuit Config'
 #[derive(Debug, Clone)]
 pub struct Config<SCC> {
-    consistency_marker: Column<Instance>,
-    sc: SCC,
-    mg: MainGateConfig<MAIN_GATE_T>,
+    pub consistency_marker: Column<Instance>,
+    pub sc: SCC,
+    pub mg: MainGateConfig<MAIN_GATE_T>,
 }
 
+#[derive(Debug)]
 pub struct StepFoldingCircuit<
     'sc,
     const ARITY: usize,
@@ -56,20 +60,40 @@ impl<
         CMain: CurveAffine,
         CSup: CurveAffine<Base = CMain::ScalarExt>,
         SC: StepCircuit<ARITY, CMain::ScalarExt>,
+    > Clone for StepFoldingCircuit<'_, ARITY, CMain, CSup, SC>
+{
+    fn clone(&self) -> Self {
+        let Self { sc, input, _p } = self;
+
+        Self {
+            sc,
+            input: input.clone(),
+            _p: PhantomData,
+        }
+    }
+}
+
+impl<
+        const ARITY: usize,
+        CMain: CurveAffine,
+        CSup: CurveAffine<Base = CMain::ScalarExt>,
+        SC: StepCircuit<ARITY, CMain::ScalarExt>,
     > StepFoldingCircuit<'_, ARITY, CMain, CSup, SC>
 where
     CMain::ScalarExt: PrimeFieldBits + FromUniformBytes<64>,
 {
     /// For the initial iteration, we will give the same accumulators that we take from the input
     pub fn initial_instances(&self) -> Vec<Vec<CMain::ScalarExt>> {
-        let mut input = self.input.clone();
+        let _span = info_span!("consistency_marker").entered();
+
+        let mut self_ = self.input.clone();
         assert_eq!(
-            input.step, 0,
+            self_.step, 0,
             "this method can only be called for step == 0"
         );
 
-        input.step = 1;
-        let out_marker = cyclefold::ro().absorb(&input).output(
+        self_.step = 1;
+        let out_marker = cyclefold::ro().absorb(&self_).output(
             NonZeroUsize::new(<CMain::ScalarExt as PrimeField>::NUM_BITS as usize).unwrap(),
         );
 
@@ -78,9 +102,34 @@ where
         instances
     }
 
-    pub fn instances(&self, expected_out: CMain::ScalarExt) -> Vec<Vec<CMain::ScalarExt>> {
+    pub fn instances(
+        &self,
+        self_acc: &nifs::protogalaxy::AccumulatorInstance<CMain>,
+        support_acc: &nifs::sangria::RelaxedPlonkInstance<CSup, { support_circuit::INSTANCES_LEN }>,
+        z_out: &[CMain::ScalarExt; ARITY],
+    ) -> Vec<Vec<CMain::ScalarExt>> {
+        let _span = info_span!("consistency_marker").entered();
+
+        let mut self_ = self.input.clone();
+
+        self_.step += 1;
+        self_.self_trace.input_accumulator = input::ProtoGalaxyAccumulatorInstance::new(self_acc);
+        self_.support_trace.input_accumulator = input::SangriaAccumulatorInstance::new(support_acc);
+        self_.z_i = *z_out;
+        trace!(
+            "sangria support expected acc: {:?}",
+            &self_.support_trace.input_accumulator
+        );
+
+        let out_marker = cyclefold::ro()
+            .absorb(&self_)
+            .inspect(|buf| trace!("buf before sfc_out: {buf:?}"))
+            .output(
+                NonZeroUsize::new(<CMain::ScalarExt as PrimeField>::NUM_BITS as usize).unwrap(),
+            );
+
         let mut instances = self.sc.instances();
-        instances.insert(0, vec![expected_out]);
+        instances.insert(0, vec![out_marker]);
         instances
     }
 }
@@ -116,74 +165,107 @@ where
         }
     }
 
+    #[instrument(skip_all)]
     fn synthesize(
         &self,
         config: Self::Config,
         mut layouter: impl Layouter<CMain::ScalarExt>,
     ) -> Result<(), Halo2PlonkError> {
-        let input = layouter.assign_region(
-            || "sfc input",
-            |region| {
-                let mut region = RegionCtx::new(region, 0);
+        info!("start");
 
-                input::assigned::Input::assign_advice_from(&mut region, &self.input, &config.mg)?
-                    .consistency_check(&mut region, &config.mg)
-            },
-        )?;
-
-        let z_out = self
-            .sc
-            .synthesize_step(config.sc, &mut layouter, &input.z_i)
-            .map_err(|err| {
-                error!("while synthesize_step: {err:?}");
-                Halo2PlonkError::Synthesis
-            })?;
-
-        let self_acc_out: input::assigned::ProtoGalaxyAccumulatorInstance<CMain::ScalarExt> =
-            layouter.assign_region(
-                || "sfc protogalaxy",
+        let input = layouter
+            .assign_region(
+                || "sfc_input",
                 |region| {
+                    let _span = info_span!("input").entered();
+
                     let mut region = RegionCtx::new(region, 0);
 
-                    let VerifyResult {
-                        result_acc,
-                        poly_L_values: _,
-                    } = protogalaxy::verify_chip::verify(
+                    input::assigned::Input::assign_advice_from(
                         &mut region,
-                        config.mg.clone(),
-                        ro_chip(config.mg.clone()),
-                        verify_chip::AssignedVerifierParam {
-                            pp_digest: input.pp_digest.clone(),
-                        },
-                        input.self_trace.input_accumulator.clone(),
-                        &[input.self_trace.incoming.clone()],
-                        input.self_trace.proof.clone(),
-                    )
-                    .map_err(|err| {
-                        error!("while protogalaxy::verify: {err:?}");
-                        Halo2PlonkError::Synthesis
-                    })?;
-
-                    //input.pairing_check(
-                    //    &mut region,
-                    //    &config.mg,
-                    //    &poly_L_values,
-                    //    &mut result_acc,
-                    //)?;
-
-                    Ok(result_acc)
+                        &self.input,
+                        &config.mg,
+                    )?
+                    .consistency_check(&mut region, &config.mg)
                 },
-            )?;
+            )
+            .inspect_err(|err| {
+                error!("while sfc input: {err:?}");
+            })?;
 
-        let paired_acc_out: input::assigned::SangriaAccumulatorInstance<CMain::ScalarExt> =
+        info!("sfc input done");
+
+        let z_out = {
+            let _span = info_span!("sc").entered();
+
+            self.sc
+                .synthesize_step(config.sc, &mut layouter, &input.z_i)
+                .map_err(|err| {
+                    error!("while synthesize_step: {err:?}");
+                    Halo2PlonkError::Synthesis
+                })
+        }?;
+
+        info!("step circuit synthesize done");
+
+        let self_acc_out: input::assigned::ProtoGalaxyAccumulatorInstance<CMain::ScalarExt> =
             layouter
                 .assign_region(
-                    || "sfc sangria",
+                    || "sfc protogalaxy",
                     |region| {
+                        let _span = info_span!("protogalaxy").entered();
+                        let mut region = RegionCtx::new(region, 0);
+
+                        let VerifyResult {
+                            mut result_acc,
+                            poly_L_values,
+                        } = protogalaxy::verify_chip::verify(
+                            &mut region,
+                            config.mg.clone(),
+                            ro_chip(config.mg.clone()),
+                            verify_chip::AssignedVerifierParam {
+                                pp_digest: input.pp_digest.clone(),
+                            },
+                            input.self_trace.input_accumulator.clone(),
+                            &[input.self_trace.incoming.clone()],
+                            input.self_trace.proof.clone(),
+                        )
+                        .map_err(|err| {
+                            error!("while protogalaxy::verify: {err:?}");
+                            Halo2PlonkError::Synthesis
+                        })?;
+
+                        input
+                            .support_circuit_consistency_check(
+                                &mut region,
+                                &config.mg,
+                                &poly_L_values,
+                                &mut result_acc,
+                            )
+                            .inspect_err(|err| {
+                                error!("while support circuit consistency check: {err:?}");
+                            })?;
+
+                        Ok(result_acc)
+                    },
+                )
+                .inspect_err(|err| {
+                    error!("while sfc protogalaxy: {err:?}");
+                })?;
+
+        info!("protogalaxy done");
+
+        let support_circuit_acc_out: input::assigned::SangriaAccumulatorInstance<CMain::ScalarExt> =
+            layouter
+                .assign_region(
+                    || "sfc_sangria",
+                    |region| {
+                        let _span = info_span!("sangria").entered();
                         sangria_adapter::fold::<CMain, CSup>(
                             &mut RegionCtx::new(region, 0),
                             config.mg.clone(),
-                            &input.paired_trace,
+                            &input.pp_digest,
+                            &input.support_trace,
                         )
                     },
                 )
@@ -191,65 +273,91 @@ where
                     error!("while sfc sangria: {err:?}");
                 })?;
 
-        let _consistency_marker_output = layouter.assign_region(
-            || "sfc out",
-            |region| {
-                let mut region = RegionCtx::new(region, 0);
+        info!("sangria done");
 
-                let mg = MainGate::new(config.mg.clone());
-                let is_zero_step = mg.is_zero_term(&mut region, input.step.clone())?;
+        let consistency_marker_output = layouter
+            .assign_region(
+                || "sfc out consistency marker",
+                |region| {
+                    let _span = info_span!("consistency_marker").entered();
+                    let mut region = RegionCtx::new(region, 0);
 
-                let z_out: [_; ARITY] = input
-                    .z_0
-                    .iter()
-                    .zip_eq(z_out.iter())
-                    .map(|(z_0_i, z_out_i)| {
-                        mg.conditional_select(&mut region, z_0_i, z_out_i, &is_zero_step)
-                    })
-                    .collect::<Result<Vec<_>, _>>()?
-                    .try_into()
-                    .unwrap();
+                    let mg = MainGate::new(config.mg.clone());
+                    let is_zero_step = mg.is_zero_term(&mut region, input.step.clone())?;
 
-                let self_trace_output =
-                    input::assigned::ProtoGalaxyAccumulatorInstance::conditional_select(
-                        &mut region,
-                        &mg,
-                        &input.self_trace.input_accumulator,
-                        &self_acc_out,
-                        &is_zero_step,
-                    )?;
+                    let z_out: [_; ARITY] = input
+                        .z_0
+                        .iter()
+                        .zip_eq(z_out.iter())
+                        .map(|(z_0_i, z_out_i)| {
+                            mg.conditional_select(&mut region, z_0_i, z_out_i, &is_zero_step)
+                        })
+                        .collect::<Result<Vec<_>, _>>()?
+                        .try_into()
+                        .unwrap();
 
-                let paired_trace_output =
-                    input::assigned::SangriaAccumulatorInstance::conditional_select(
-                        &mut region,
-                        &mg,
-                        &input.paired_trace.input_accumulator,
-                        &paired_acc_out,
-                        &is_zero_step,
-                    )?;
+                    let self_trace_output =
+                        input::assigned::ProtoGalaxyAccumulatorInstance::conditional_select(
+                            &mut region,
+                            &mg,
+                            &input.self_trace.input_accumulator,
+                            &self_acc_out,
+                            &is_zero_step,
+                        )?;
 
-                let next_step =
-                    mg.add_with_const(&mut region, &input.step, CMain::ScalarExt::ONE)?;
+                    let support_trace_output =
+                        input::assigned::SangriaAccumulatorInstance::conditional_select(
+                            &mut region,
+                            &mg,
+                            &input.support_trace.input_accumulator,
+                            &support_circuit_acc_out,
+                            &is_zero_step,
+                        )?;
 
-                ro_chip(config.mg.clone())
-                    .absorb_iter(input::assigned::iter_consistency_marker_wrap_values(
-                        (&input.pp_digest.0, &input.pp_digest.1),
-                        &self_trace_output,
-                        &paired_trace_output,
-                        &next_step,
-                        &input.z_0,
-                        &z_out,
-                    ))
-                    .squeeze(&mut region)
-            },
-        )?;
+                    trace!("sangria support actual acc: {:?}", &support_trace_output);
 
-        //layouter.constrain_instance(
-        //    consistency_marker_output.cell(),
-        //    config.consistency_marker,
-        //    0,
-        //)?;
+                    let next_step =
+                        mg.add_with_const(&mut region, &input.step, CMain::ScalarExt::ONE)?;
+
+                    ro_chip(config.mg.clone())
+                        .absorb_iter(input::assigned::iter_consistency_marker_wrap_values(
+                            (&input.pp_digest.0, &input.pp_digest.1),
+                            &self_trace_output,
+                            &support_trace_output,
+                            &next_step,
+                            &input.z_0,
+                            &z_out,
+                        ))
+                        .inspect(|buf| trace!("buf before marker: {buf:?}"))
+                        .squeeze(&mut region)
+                },
+            )
+            .inspect_err(|err| {
+                error!("while sfc out consistency marker: {err:?}");
+            })?;
+
+        info!("out done");
+
+        layouter
+            .constrain_instance(
+                consistency_marker_output.cell(),
+                config.consistency_marker,
+                0,
+            )
+            .inspect_err(|err| {
+                error!("while sfc out constraint instance: {err:?}");
+            })?;
 
         Ok(())
     }
+}
+
+pub fn bn_chip<F: PrimeField>(
+    main_gate_config: MainGateConfig<MAIN_GATE_T>,
+) -> BigUintMulModChip<F> {
+    BigUintMulModChip::new(
+        main_gate_config.into_smaller_size().unwrap(),
+        DEFAULT_LIMB_WIDTH,
+        DEFAULT_LIMBS_COUNT,
+    )
 }

--- a/src/ivc/cyclefold/sfc/sangria_adapter.rs
+++ b/src/ivc/cyclefold/sfc/sangria_adapter.rs
@@ -1,13 +1,13 @@
 use itertools::Itertools;
 use num_traits::Num;
-use tracing::error;
+use tracing::{debug, error, info_span};
 
 use super::{input, MAIN_GATE_T};
 use crate::{
-    constants::MAX_BITS,
+    constants::NUM_CHALLENGE_BITS,
     gadgets::{
         ecc::{AssignedPoint, EccChip},
-        nonnative::{self, bn::big_uint_mul_mod_chip::BigUintMulModChip},
+        nonnative,
     },
     halo2_proofs::{
         halo2curves::{
@@ -20,18 +20,10 @@ use crate::{
         cyclefold::{ro_chip, DEFAULT_LIMBS_COUNT, DEFAULT_LIMB_WIDTH},
         fold_relaxed_plonk_instance_chip::{self, BigUintView, FoldRelaxedPlonkInstanceChip},
     },
-    main_gate::{MainGate, MainGateConfig, RegionCtx},
+    main_gate::{AssignedValue, MainGate, MainGateConfig, RegionCtx},
     nifs::sangria,
     poseidon::ROCircuitTrait,
 };
-
-fn bn_chip<F: PrimeField>(main_gate_config: MainGateConfig<MAIN_GATE_T>) -> BigUintMulModChip<F> {
-    BigUintMulModChip::new(
-        main_gate_config.into_smaller_size().unwrap(),
-        DEFAULT_LIMB_WIDTH,
-        DEFAULT_LIMBS_COUNT,
-    )
-}
 
 fn ecc_chip<CSup: CurveAffine>(
     main_gate_config: MainGateConfig<MAIN_GATE_T>,
@@ -56,28 +48,51 @@ fn module_as_bn<F1: PrimeField, F2: PrimeField>() -> Result<BigUint<F1>, big_uin
 pub fn fold<CMain: CurveAffine, CSup: CurveAffine<Base = CMain::ScalarExt>>(
     region: &mut RegionCtx<CMain::ScalarExt>,
     config: MainGateConfig<MAIN_GATE_T>,
-    input: &input::assigned::PairedTrace<CMain::ScalarExt>,
+    pp_digest: &(
+        AssignedValue<CMain::ScalarExt>,
+        AssignedValue<CMain::ScalarExt>,
+    ),
+    input: &input::assigned::SupportTrace<CMain::ScalarExt>,
 ) -> Result<input::assigned::SangriaAccumulatorInstance<CMain::ScalarExt>, Halo2PlonkError>
 where
     CMain::ScalarExt: FromUniformBytes<64> + PrimeFieldBits,
 {
-    let bn_chip = bn_chip(config.clone());
+    let bn_chip = super::bn_chip(config.clone());
     let ecc_chip = ecc_chip::<CSup>(config.clone());
     let mg = MainGate::new(config.clone());
 
-    let r = ro_chip(config.clone())
-        .absorb_iter(input.iter_wrap_values())
-        .squeeze(region)?;
-    let r_bits = mg.le_num_to_bits(region, r.clone(), MAX_BITS)?;
-    let r_as_bn = bn_chip.from_assigned_value_to_limbs(region, &r).unwrap();
+    let sangria_cha_span = info_span!("sangria_cha").entered();
 
-    let m_bn = module_as_bn::<CMain::ScalarExt, CMain::Base>().unwrap();
+    let r_bits = ro_chip(config.clone())
+        .absorb_base(pp_digest.0.clone().into())
+        .absorb_base(pp_digest.1.clone().into())
+        .absorb_iter(input.iter_wrap_values())
+        .inspect(|buf| debug!("buf before: {buf:?}"))
+        .squeeze_n_bits(region, NUM_CHALLENGE_BITS)
+        .inspect_err(|err| error!("Error while computing 'r' in fold: {err:?}"))?;
+
+    sangria_cha_span.exit();
+
+    let r = mg
+        .le_bits_to_num(region, &r_bits)
+        .inspect_err(|err| error!("Error while converting 'r' to bits in fold: {err:?}"))?;
+
+    debug!("sangria_cha: {:?}", r.value());
+
+    let r_as_bn = bn_chip
+        .from_assigned_value_to_limbs(region, &r)
+        .inspect_err(|err| error!("Error while converting 'r' to BN limbs in fold: {err:?}"))
+        .unwrap();
+
+    let m_bn = module_as_bn::<CMain::ScalarExt, CMain::Base>()
+        .inspect_err(|err| error!("Error while creating 'm_bn' in fold: {err:?}"))
+        .unwrap();
 
     let mut acc = input.input_accumulator.clone();
 
-    for input::assigned::PairedIncoming {
+    for input::assigned::SupportIncoming {
         instance:
-            input::assigned::PairedPlonkInstance {
+            input::assigned::SupportPlonkInstance {
                 W_commitments: input_W_commitments,
                 challenges: input_challenges,
                 instances: input_instances,
@@ -87,13 +102,14 @@ where
     {
         let input::assigned::SangriaAccumulatorInstance {
             ins:
-                input::assigned::PairedPlonkInstance {
+                input::assigned::SupportPlonkInstance {
                     W_commitments: acc_W_commitments,
                     instances: acc_instances,
                     challenges: acc_challenges,
                 },
             E_commitment: acc_E_commitment,
             u: acc_u,
+            step_circuit_instances_hash_accumulator: _,
         } = &mut acc;
 
         *acc_W_commitments = FoldRelaxedPlonkInstanceChip::<
@@ -115,9 +131,7 @@ where
                 .collect::<Box<[_]>>(),
             &r_bits,
         )
-        .inspect_err(|err| {
-            error!("while fold W: {err:?}");
-        })?
+        .inspect_err(|err| error!("Error while folding W commitments in fold: {err:?}"))?
         .into_iter()
         .map(|p| (p.x, p.y))
         .collect();
@@ -131,15 +145,27 @@ where
                         .iter_mut()
                         .zip_eq(input_instance)
                         .try_for_each(|(acc_cell, input_cell)| -> Result<(), Halo2PlonkError> {
-                            *acc_cell = fold_relaxed_plonk_instance_chip::fold_via_biguint(
+                            let bn_limbs = fold_relaxed_plonk_instance_chip::fold_via_biguint(
                                 region,
                                 &bn_chip,
-                                input_cell,
-                                acc_cell.to_vec(),
+                                &input_cell.1,
+                                acc_cell.1.to_vec(),
                                 &m_bn,
                                 &r_as_bn,
                                 DEFAULT_LIMB_WIDTH,
-                            )?;
+                            )
+                            .inspect_err(|err| {
+                                error!("Error while folding instance cells in fold: {err:?}")
+                            })?;
+
+                            let value = bn_chip
+                                .from_assigned_limbs_to_value(region, &bn_limbs)
+                                .map_err(|err| {
+                                    error!("bn error: {err:?}");
+                                    Halo2PlonkError::Synthesis
+                                })?;
+
+                            *acc_cell = (value, bn_limbs.try_into().unwrap());
 
                             Ok(())
                         })?;
@@ -147,29 +173,35 @@ where
                     Ok(())
                 },
             )
-            .inspect_err(|err| {
-                error!("while fold instances: {err:?}");
-            })?;
+            .inspect_err(|err| error!("Error while folding instances in fold: {err:?}"))?;
 
         acc_challenges
             .iter_mut()
             .zip_eq(input_challenges.iter())
             .try_for_each(|(acc_cha, inp_cha)| -> Result<(), Halo2PlonkError> {
-                *acc_cha = fold_relaxed_plonk_instance_chip::fold_via_biguint(
+                let bn_limbs = fold_relaxed_plonk_instance_chip::fold_via_biguint(
                     region,
                     &bn_chip,
-                    inp_cha,
-                    acc_cha.to_vec(),
+                    &inp_cha.1,
+                    acc_cha.1.to_vec(),
                     &m_bn,
                     &r_as_bn,
                     DEFAULT_LIMB_WIDTH,
-                )?;
+                )
+                .inspect_err(|err| error!("Error while folding challenges in fold: {err:?}"))?;
+
+                let value = bn_chip
+                    .from_assigned_limbs_to_value(region, &bn_limbs)
+                    .map_err(|err| {
+                        error!("bn error: {err:?}");
+                        Halo2PlonkError::Synthesis
+                    })?;
+
+                *acc_cha = (value, bn_limbs.try_into().unwrap());
 
                 Ok(())
             })
-            .inspect_err(|err| {
-                error!("while fold challenges: {err:?}");
-            })?;
+            .inspect_err(|err| error!("Error while folding challenges in fold: {err:?}"))?;
 
         *acc_E_commitment = fold_relaxed_plonk_instance_chip::fold_E(
             region,
@@ -190,12 +222,12 @@ where
             },
             &m_bn,
         )
-        .inspect_err(|err| {
-            error!("while fold E: {err:?}");
-        })?
+        .inspect_err(|err| error!("Error while folding E commitment in fold: {err:?}"))?
         .into();
 
-        *acc_u = mg.add(region, acc_u, &r)?;
+        *acc_u = mg
+            .add(region, acc_u, &r)
+            .inspect_err(|err| error!("Error while updating accumulator 'u' in fold: {err:?}"))?;
     }
 
     Ok(acc)


### PR DESCRIPTION
**Motivation**
This PR combines all the changes for operability #373

**Overview**
- Renamed `PairedPlonkInstance` and `PairedTrace` to `SupportPlonkInstance` and `SupportTrace` for better alignment with the functionality
- Added alignment for W_commitments & challenes, since we don't know them at the "before zero step" stage, this takes 300 extra rows
- Changed `Input` absorption order for consistency from nifs::{sangria,protogalaxy} (Some fields are now converted to bn, oncircuit only)
