### PR TITLE
perf(nifs): use rayon in protogalaxy::poly::witness_eval

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,10 @@ harness = false
 name = "sangria_poseidon"
 harness = false
 
+[[bench]]
+name = "cyclefold_poseidon"
+harness = false
+
 [features]
 # Allows cli-example to check memory usage with dhat
 dhat-heap = []

--- a/benches/cyclefold_poseidon/main.rs
+++ b/benches/cyclefold_poseidon/main.rs
@@ -1,7 +1,7 @@
 use std::{array, io, marker::PhantomData, path::Path};
 
 use bn256::G1 as C1;
-use criterion::{criterion_group, Criterion};
+use criterion::{black_box, criterion_group, Criterion};
 use metadata::LevelFilter;
 use sirius::{
     commitment::CommitmentKey,
@@ -24,8 +24,8 @@ use tracing_subscriber::{fmt::format::FmtSpan, EnvFilter};
 
 const ARITY: usize = 1;
 
-const CIRCUIT_TABLE_SIZE1: usize = 17;
-const COMMITMENT_KEY_SIZE: usize = 21;
+const CIRCUIT_TABLE_SIZE1: usize = 20;
+const COMMITMENT_KEY_SIZE: usize = 24;
 
 // Spec for user defined poseidon circuit
 const T1: usize = 3;
@@ -110,7 +110,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     prepare_span.exit();
 
-    let mut group = c.benchmark_group("ivc_of_poseidon");
+    let mut group = c.benchmark_group("cyclefold_ivc_of_poseidon");
     group.significance_level(0.1).sample_size(10);
 
     group.bench_function("fold_1_step", |b| {
@@ -118,12 +118,10 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         let primary_z_0 = array::from_fn(|_| C1Scalar::random(&mut rnd));
 
         b.iter(|| {
-            IVC::new(&mut pp, &sc1, primary_z_0)
+            IVC::new(&mut pp, &sc1, black_box(primary_z_0))
                 .expect("while step=0")
                 .next(&pp, &sc1)
-                .expect("while step=1")
-                .verify(&pp)
-                .expect("while verify");
+                .expect("while step=1");
         })
     });
 

--- a/benches/sangria_poseidon/main.rs
+++ b/benches/sangria_poseidon/main.rs
@@ -153,7 +153,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
     prepare_span.exit();
 
-    let mut group = c.benchmark_group("ivc_of_poseidon");
+    let mut group = c.benchmark_group("sangria_ivc_of_poseidon");
     group.significance_level(0.1).sample_size(10);
 
     group.bench_function("fold_1_step", |b| {
@@ -169,24 +169,6 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                 &sc2,
                 black_box(secondary_z_0),
                 NonZeroUsize::new(1).unwrap(),
-            )
-            .unwrap();
-        })
-    });
-
-    group.bench_function("fold_2_step", |b| {
-        let mut rnd = rand::thread_rng();
-        let primary_z_0 = array::from_fn(|_| C1Scalar::random(&mut rnd));
-        let secondary_z_0 = array::from_fn(|_| C2Scalar::random(&mut rnd));
-
-        b.iter(|| {
-            IVC::fold(
-                &pp,
-                &sc1,
-                black_box(primary_z_0),
-                &sc2,
-                black_box(secondary_z_0),
-                NonZeroUsize::new(2).unwrap(),
             )
             .unwrap();
         })

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -26,7 +26,8 @@ use tracing::*;
 use tracing_subscriber::{filter::LevelFilter, fmt::format::FmtSpan, EnvFilter};
 
 #[allow(dead_code)]
-mod poseidon;
+mod sangria_poseidon;
+use sangria_poseidon as poseidon;
 
 #[allow(dead_code)]
 mod merkle;

--- a/examples/cyclefold_poseidon.rs
+++ b/examples/cyclefold_poseidon.rs
@@ -1,0 +1,212 @@
+/// This module represents an implementation of `StepCircuit` based on the poseidon chip
+pub mod poseidon_step_circuit {
+    use std::marker::PhantomData;
+
+    use halo2_proofs::{
+        circuit::{AssignedCell, Layouter},
+        plonk::ConstraintSystem,
+    };
+    use sirius::{
+        ff::{FromUniformBytes, PrimeFieldBits},
+        ivc::{StepCircuit, SynthesisError},
+        main_gate::{MainGate, MainGateConfig, RegionCtx, WrapValue},
+        poseidon::{poseidon_circuit::PoseidonChip, Spec},
+    };
+    use tracing::*;
+
+    /// Input and output size for `StepCircuit` within each step
+    pub const ARITY: usize = 1;
+
+    /// Spec for on-circuit poseidon circuit
+    const POSEIDON_PERMUTATION_WIDTH: usize = 3;
+    const POSEIDON_RATE: usize = POSEIDON_PERMUTATION_WIDTH - 1;
+
+    pub type CircuitPoseidonSpec<F> = Spec<F, POSEIDON_PERMUTATION_WIDTH, POSEIDON_RATE>;
+
+    const R_F1: usize = 4;
+    const R_P1: usize = 3;
+
+    #[derive(Clone, Debug)]
+    pub struct TestPoseidonCircuitConfig {
+        pconfig: MainGateConfig<POSEIDON_PERMUTATION_WIDTH>,
+    }
+
+    #[derive(Debug)]
+    pub struct TestPoseidonCircuit<F: PrimeFieldBits> {
+        repeat_count: usize,
+        _p: PhantomData<F>,
+    }
+
+    impl<F: PrimeFieldBits> Default for TestPoseidonCircuit<F> {
+        fn default() -> Self {
+            Self {
+                repeat_count: 1,
+                _p: Default::default(),
+            }
+        }
+    }
+
+    impl<F: PrimeFieldBits> TestPoseidonCircuit<F> {
+        pub fn new(repeat_count: usize) -> Self {
+            Self {
+                repeat_count,
+                _p: Default::default(),
+            }
+        }
+    }
+
+    impl<F: PrimeFieldBits + FromUniformBytes<64>> StepCircuit<ARITY, F> for TestPoseidonCircuit<F> {
+        type Config = TestPoseidonCircuitConfig;
+
+        fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+            let pconfig = MainGate::configure(meta);
+            Self::Config { pconfig }
+        }
+
+        fn synthesize_step(
+            &self,
+            config: Self::Config,
+            layouter: &mut impl Layouter<F>,
+            z_in: &[AssignedCell<F, F>; ARITY],
+        ) -> Result<[AssignedCell<F, F>; ARITY], SynthesisError> {
+            let spec = CircuitPoseidonSpec::<F>::new(R_F1, R_P1);
+
+            layouter
+                .assign_region(
+                    || "poseidon hash",
+                    move |region| {
+                        let mut z_i = z_in.clone();
+                        let ctx = &mut RegionCtx::new(region, 0);
+
+                        for step in 0..=self.repeat_count {
+                            let mut pchip = PoseidonChip::new(config.pconfig.clone(), spec.clone());
+
+                            pchip.update(
+                                &z_i.iter()
+                                    .cloned()
+                                    .map(WrapValue::Assigned)
+                                    .collect::<Vec<WrapValue<F>>>(),
+                            );
+
+                            info!(
+                                "offset for {} hash repeat count is {} (log2 = {})",
+                                step,
+                                ctx.offset(),
+                                (ctx.offset() as f64).log2()
+                            );
+
+                            z_i = [pchip.squeeze(ctx).inspect_err(|err| {
+                                error!("at step {step}: {err:?}");
+                            })?];
+                        }
+
+                        info!(
+                            "total offset for {} hash repeat count is {} (log2 = {})",
+                            self.repeat_count,
+                            ctx.offset(),
+                            (ctx.offset() as f64).log2()
+                        );
+
+                        Ok(z_i)
+                    },
+                )
+                .map_err(|err| {
+                    error!("while synth {err:?}");
+                    SynthesisError::Halo2(err)
+                })
+        }
+    }
+}
+
+use std::{array, env, io, path::Path};
+
+use bn256::G1 as C1;
+use grumpkin::G1 as C2;
+use metadata::LevelFilter;
+use sirius::{
+    commitment::CommitmentKey,
+    group::{prime::PrimeCurve, Group},
+    halo2curves::{bn256, grumpkin, CurveAffine},
+    ivc::cyclefold,
+};
+use tracing::*;
+use tracing_subscriber::{fmt::format::FmtSpan, EnvFilter};
+
+/// `K` table size for primary circuit
+const PRIMARY_CIRCUIT_TABLE_SIZE: usize = 21;
+
+/// Разрмер commitment key
+const COMMITMENT_KEY_SIZE: usize = 25;
+
+type C1Affine = <C1 as PrimeCurve>::Affine;
+type C1Scalar = <C1 as Group>::Scalar;
+
+type C2Affine = <C2 as PrimeCurve>::Affine;
+
+/// Either takes the key from [`CACHE_FOLDER`] or generates a new one and puts it in it
+#[instrument]
+pub fn get_or_create_commitment_key<C: CurveAffine>(
+    k: usize,
+    label: &'static str,
+) -> io::Result<CommitmentKey<C>> {
+    /// Relative directory where the generated `CommitmentKey` stored
+    const CACHE_FOLDER: &str = ".cache/examples";
+
+    // Safety: Safe if you have not manually modified the generated files in [`CACHE_FOLDER`]
+    unsafe { CommitmentKey::load_or_setup_cache(Path::new(CACHE_FOLDER), label, k) }
+}
+
+fn main() {
+    let builder = tracing_subscriber::fmt()
+        // Adds events to track the entry and exit of the span, which are used to build
+        // time-profiling
+        .with_span_events(FmtSpan::ENTER | FmtSpan::CLOSE)
+        // Changes the default level to INFO
+        .with_env_filter(
+            EnvFilter::builder()
+                .with_default_directive(LevelFilter::INFO.into())
+                .from_env_lossy(),
+        );
+
+    // Structured logs are needed for time-profiling, while for simple run regular logs are
+    // more convenient.
+    //
+    // So this expr keeps track of the --json argument for turn-on json-logs
+    if env::args().any(|arg| arg.eq("--json")) {
+        builder.json().init();
+    } else {
+        builder.init();
+    }
+
+    // To osterize the total execution time of the example
+    let _span = info_span!("poseidon_example").entered();
+
+    let primary = poseidon_step_circuit::TestPoseidonCircuit::default();
+
+    let primary_commitment_key =
+        get_or_create_commitment_key::<C1Affine>(COMMITMENT_KEY_SIZE, "bn256")
+            .expect("Failed to get primary key");
+    let secondary_commitment_key =
+        get_or_create_commitment_key::<C2Affine>(COMMITMENT_KEY_SIZE, "grumpkin")
+            .expect("Failed to get secondary key");
+
+    let mut pp = cyclefold::PublicParams::new(
+        &primary,
+        primary_commitment_key,
+        secondary_commitment_key,
+        PRIMARY_CIRCUIT_TABLE_SIZE as u32,
+    )
+    .unwrap();
+
+    let primary_input = array::from_fn(|i| C1Scalar::from(i as u64));
+
+    let mut ivc = cyclefold::IVC::new(&mut pp, &primary, primary_input).expect("while step=0");
+
+    for step in 1..=10 {
+        ivc = ivc
+            .next(&pp, &primary)
+            .unwrap_or_else(|err| panic!("while step={step}: {err:?}"));
+    }
+
+    ivc.verify(&pp).expect("while verify");
+}

--- a/examples/sangria_poseidon.rs
+++ b/examples/sangria_poseidon.rs
@@ -127,10 +127,7 @@ use sirius::{
     commitment::CommitmentKey,
     group::{prime::PrimeCurve, Group},
     halo2curves::{bn256, grumpkin, CurveAffine},
-    ivc::{
-        sangria::{CircuitPublicParamsInput, PublicParams, IVC},
-        step_circuit,
-    },
+    ivc::{sangria, step_circuit},
     poseidon::{self, ROPair},
 };
 use tracing::*;
@@ -216,7 +213,7 @@ fn main() {
         get_or_create_commitment_key::<C2Affine>(COMMITMENT_KEY_SIZE, "grumpkin")
             .expect("Failed to get secondary key");
 
-    let pp = PublicParams::<
+    let pp = sangria::PublicParams::<
         '_,
         ARITY,
         ARITY,
@@ -228,13 +225,13 @@ fn main() {
         RandomOracle,
         RandomOracle,
     >::new(
-        CircuitPublicParamsInput::new(
+        sangria::CircuitPublicParamsInput::new(
             PRIMARY_CIRCUIT_TABLE_SIZE as u32,
             &primary_commitment_key,
             primary_spec,
             &primary,
         ),
-        CircuitPublicParamsInput::new(
+        sangria::CircuitPublicParamsInput::new(
             SECONDARY_CIRCUIT_TABLE_SIZE as u32,
             &secondary_commitment_key,
             secondary_spec,
@@ -248,7 +245,7 @@ fn main() {
     let primary_input = array::from_fn(|i| C1Scalar::from(i as u64));
     let secondary_input = array::from_fn(|i| C2Scalar::from(i as u64));
 
-    IVC::fold_with_debug_mode(
+    sangria::IVC::fold_with_debug_mode(
         &pp,
         &primary,
         primary_input,


### PR DESCRIPTION
**Motivation**
At the moment, cyclefold::IVC is too slow
Part of #324 

**Overview**
- A little reworked examples & benches, to split sangria & cyclefold
- Made a simple acceleration via rayon, already accelerated twice cyclefold::IVC
```bash
cyclefold_ivc_of_poseidon/fold_1_step
                        time:   [38.861 s 39.079 s 39.323 s]
                        change: [-56.371% -55.922% -55.434%] (p = 0.00 < 0.10)
                        Performance has improved.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new benchmark configuration for enhanced performance testing.
  - Added a demonstration module showcasing advanced circuit integration.

- **Refactor**
  - Updated benchmark group naming and adjusted parameter constants for improved stability.
  - Reorganized module references for consistent naming across examples.
  - Optimized internal evaluation processes to boost computational efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->