### PR TITLE
perf(nifs): protogalaxy::nifs

### DIFF
--- a/src/gadgets/ecc/mod.rs
+++ b/src/gadgets/ecc/mod.rs
@@ -57,7 +57,6 @@ impl<C: CurveAffine, G: EccGate<C::Base>> EccChip<C, G> {
         self.gate.negate(ctx, p)
     }
 
-    #[instrument(skip_all)]
     pub fn add(
         &self,
         ctx: &mut RegionCtx<'_, C::Base>,

--- a/src/ivc/sangria/step_folding_circuit.rs
+++ b/src/ivc/sangria/step_folding_circuit.rs
@@ -155,12 +155,8 @@ where
 
         PairedCircuit::configure(&mut cs);
 
-        let ConstraintSystemMetainfo {
-            num_challenges,
-            round_sizes,
-            folding_degree,
-            ..
-        } = ConstraintSystemMetainfo::build(k_table_size as usize, &cs);
+        let constraint_system_metainfo =
+            ConstraintSystemMetainfo::build(k_table_size as usize, &cs);
 
         let Some((consistency_markers, step_circuit_instances)) = native_num_io.split_first()
         else {
@@ -176,21 +172,26 @@ where
             z_0: [C::Base::ZERO; ARITY],
             z_i: [C::Base::ZERO; ARITY],
             U: RelaxedPlonkInstance::new(
-                num_challenges,
-                round_sizes.len(),
+                constraint_system_metainfo.num_challenges,
+                constraint_system_metainfo.round_sizes.len(),
                 step_circuit_instances.len(),
             ),
             u: FoldablePlonkInstance::new(PlonkInstance::new(
                 paired_num_io,
-                num_challenges,
-                round_sizes.len(),
+                constraint_system_metainfo.num_challenges,
+                constraint_system_metainfo.round_sizes.len(),
             ))
             .expect("you can't use plonk instance without consistency markers"),
             step_circuit_instances: step_circuit_instances
                 .iter()
                 .map(|len| vec![C::Base::ZERO; *len])
                 .collect(),
-            cross_term_commits: vec![C::identity(); folding_degree.saturating_sub(1)],
+            cross_term_commits: vec![
+                C::identity();
+                constraint_system_metainfo
+                    .folding_degree()
+                    .saturating_sub(1)
+            ],
         }
     }
 }

--- a/src/nifs/protogalaxy/mod.rs
+++ b/src/nifs/protogalaxy/mod.rs
@@ -147,7 +147,12 @@ impl<C: CurveAffine, const L: usize> ProtoGalaxy<C, L> {
         ro_acc: &mut impl ROTrait<C::ScalarExt>,
         plonk_trace: PlonkTrace<C>,
     ) -> Result<Accumulator<C>, eval::Error> {
-        let mut accumulator = Accumulator::new(args, Self::get_count_of_valuation(&params.S));
+        let mut accumulator = Accumulator::new(
+            args,
+            get_count_of_valuation_with_padding(&params.S)
+                .unwrap()
+                .get(),
+        );
 
         let beta = Challenges::<C::ScalarExt>::generate_one::<C::ScalarExt, _, C>(
             params,

--- a/src/nifs/protogalaxy/poly/mod.rs
+++ b/src/nifs/protogalaxy/poly/mod.rs
@@ -518,7 +518,18 @@ fn get_count_of_valuation<F: PrimeField>(S: &PlonkStructure<F>) -> Option<NonZer
 pub fn get_count_of_valuation_with_padding<F: PrimeField>(
     S: &PlonkStructure<F>,
 ) -> Option<NonZeroUsize> {
-    get_count_of_valuation(S).and_then(|v| v.checked_next_power_of_two())
+    get_count_of_valuation(S).and_then(|count_of_eval| {
+        let with_padding = count_of_eval.checked_next_power_of_two();
+
+        debug!(
+            "the padding added {:?} rows.",
+            with_padding
+                .as_ref()
+                .map(|with_padding| with_padding.get() - count_of_eval.get())
+        );
+
+        with_padding
+    })
 }
 
 fn get_points_count<F: PrimeField>(S: &PlonkStructure<F>, traces_len: usize) -> usize {

--- a/src/plonk/mod.rs
+++ b/src/plonk/mod.rs
@@ -706,7 +706,7 @@ pub(crate) fn get_evaluate_witness_fn<'link, F: PrimeField>(
     // The index is pass-through, the first rows_count should go to evaluators[0], the second
     // rows_count should go to the [1], etc.
     move |index| {
-        if index > max_high_limit {
+        if index >= max_high_limit {
             return Ok(F::ZERO);
         }
 

--- a/src/table/constraint_system_metainfo.rs
+++ b/src/table/constraint_system_metainfo.rs
@@ -10,7 +10,6 @@ use crate::{
 pub(crate) struct ConstraintSystemMetainfo<F: PrimeField> {
     pub num_challenges: usize,
     pub round_sizes: Vec<usize>,
-    pub folding_degree: usize,
     pub gates: Vec<Expression<F>>,
     pub custom_gates_lookup_compressed: CompressedGates<F>,
 }
@@ -97,14 +96,15 @@ impl<F: PrimeField> ConstraintSystemMetainfo<F> {
 
         let custom_gates_lookup_compressed = CompressedGates::new(&gates, &mut ctx);
 
-        let folding_degree = custom_gates_lookup_compressed.grouped().len();
-
         ConstraintSystemMetainfo {
             num_challenges: custom_gates_lookup_compressed.compressed().num_challenges(),
             round_sizes,
-            folding_degree,
             gates,
             custom_gates_lookup_compressed,
         }
+    }
+
+    pub fn folding_degree(&self) -> usize {
+        self.custom_gates_lookup_compressed.grouped().len()
     }
 }


### PR DESCRIPTION
**Motivation**
As part of the sha256 testing, some bottle necks and bugs were discovered for a large number of gates

**Overview**
- Added alignment when creating a new gate
- Parallelized process of finding source `protogalaxy_acc.e`
- Added alignment when calculating `protogalaxy_acc.e`
- Fixed wrong boundary in witness calculation
- Counting `grouped gates`, only as required

```terminal
cyclefold_ivc_of_poseidon/fold_1_step                                                                          3
    time:   [19.804 s 19.982 s 20.140 s]
    change: [-11.874% -10.841% -9.9128%] (p = 0.00 < 0.10)
    Performance has improved.
```