### PR TITLE
docs: fixed broken link in `nifs/mod.rs`

### DIFF
--- a/src/nifs/mod.rs
+++ b/src/nifs/mod.rs
@@ -7,7 +7,7 @@
 //!
 //! For more details look at:
 //! - Paragraph '3. Folding scheme' at [Nova whitepaper](https://eprint.iacr.org/2021/370)
-//! - [nifs module](https://github.com/microsoft/Nova/blob/main/src/nifs.rs) at [Nova codebase](https://github.com/microsoft/Nova)
+//! - [nifs module](https://github.com/microsoft/Nova/blob/main/src/nova/nifs.rs) at [Nova codebase](https://github.com/microsoft/Nova)
 
 pub mod protogalaxy;
 pub mod sangria;


### PR DESCRIPTION
<!-- Please read https://developers.google.com/blockly/guides/contribute/get-started/write_a_good_pr for general guidance -->
<!-- The most simplified version of Conventional Commits for PR titles. -->
<!-- allowed prefixes: `feat`, `fix`, `chore`, `ci`, `docs`, `test` -->
<!-- module names: the full name of the top-level module whose modifications were the reason for creating the PR or an accepted abbreviation, which should be specified in the rustdoc of the corresponding module -->

Hi! A broken link was found in the documentation of the `nifs/mod.rs` module, pointing to the nifs module in the Nova repository.

**Issue Link / Motivation**
<!-- Link to the related issue(s). If there's no issue, briefly explain the need for this change. -->
- This could mislead developers trying to explore the source code or documentation

**Changes Overview**
<!-- Concisely describe the changes and their impact on the project, point out anything you want reviewers to scrutinize -->
- Updated the link to the nifs module in the Nova repository

<!-- Optional Sections -->
<!-- **Implementation Details** -->
<!-- For non-trivial changes, provide context on the approach taken, focusing on the rationale behind key decisions. -->

<!-- **Testing plan** -->
<!-- Detail the testing performed to ensure reliability and performance. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated module documentation to reference the correct GitHub link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->