### PR TITLE
chore: fix typo in cyclefold report

### DIFF
--- a/docs/cyclefold_report.md
+++ b/docs/cyclefold_report.md
@@ -2,7 +2,7 @@
 
 This report describes **how** we implemented the integrated **CycleFold + Protogalaxy** protocol in practice, referencing the architecture shown in the diagram above. After discussing the design decisions and code structure, we highlight off‐circuit polynomial computations, on‐circuit verifications (using the **CycleFold‐SupportCircuit**), and how we achieve data‐parallelism with **Rayon** in Rust.
 
-![Cyclefold Diagram](../img/cyclefold.png)
+![Cyclefold Diagram](img/cyclefold.png)
 
 ---
 


### PR DESCRIPTION
**Motivation**
Didn't notice earlier that the link to img was broken, without that the report is unreadable

**Overview**
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated the image reference for the Cyclefold Diagram to reflect the new structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->