### PR TITLE
chore: Remove Redundant Use of `C::ScalarExt`

### DIFF
--- a/src/nifs/protogalaxy/mod.rs
+++ b/src/nifs/protogalaxy/mod.rs
@@ -154,7 +154,7 @@ impl<C: CurveAffine, const L: usize> ProtoGalaxy<C, L> {
                 .get(),
         );
 
-        let beta = Challenges::<C::ScalarExt>::generate_one::<C::ScalarExt, _, C>(
+        let beta = Challenges::<C::ScalarExt>::generate_one::<_, _, C>(
             params,
             ro_acc,
             &accumulator,


### PR DESCRIPTION
**Issue Link / Motivation**  
The type `C::ScalarExt` is used redundantly: first as a type parameter for `Challenges`, and then as the first argument for `generate_one`.
This duplication could lead to confusion and unnecessary complexity.

**Changes Overview**  
I’ve removed the redundant usage of `C::ScalarExt`, simplifying the code without changing the logic.
This change reduces potential confusion and makes the code more concise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined internal logic for improved maintainability without affecting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->